### PR TITLE
Disabled deleting activities from the keyboard button

### DIFF
--- a/Zametek.Client.ProjectPlan.Wpf/Views/ActivityManagement/ActivitiesManagerView.xaml
+++ b/Zametek.Client.ProjectPlan.Wpf/Views/ActivityManagement/ActivitiesManagerView.xaml
@@ -286,7 +286,8 @@
                                   AutoGenerateColumns="False"
                                   BorderThickness="2"
                                   ItemsSource="{Binding Source={StaticResource ActivitiesView}}"
-                                  SelectionMode="Extended">
+                                  SelectionMode="Extended"
+                                  CanUserDeleteRows="False">
                             <DataGrid.Resources>
                                 <local:BindingProxy x:Key="ActivitiesGridProxy" Data="{Binding}"/>
                             </DataGrid.Resources>
@@ -295,6 +296,7 @@
                                     <zi:EventToCommand Command="{Binding Path=SetSelectedManagedActivitiesCommand, Mode=OneWay}"
                                                        PassEventArgsToCommand="True"/>
                                 </i:EventTrigger>
+                                
                             </i:Interaction.Triggers>
 
                             <DataGrid.Columns>


### PR DESCRIPTION
Added CanUserDeleteRows="False" to activities data grid so users will have to use the designated button