### PR TITLE
Adding option for Earned Value Projections

### DIFF
--- a/src/Zametek.Common.ProjectPlan/Assessment/TrackingSeriesSetModel.cs
+++ b/src/Zametek.Common.ProjectPlan/Assessment/TrackingSeriesSetModel.cs
@@ -4,9 +4,12 @@
     public record TrackingSeriesSetModel
     {
         public List<TrackingPointModel> Plan { get; init; } = new List<TrackingPointModel>();
+        public List<TrackingPointModel> PlanProjection { get; init; } = new List<TrackingPointModel>();
 
         public List<TrackingPointModel> Progress { get; init; } = new List<TrackingPointModel>();
+        public List<TrackingPointModel> ProgressProjection { get; init; } = new List<TrackingPointModel>();
 
         public List<TrackingPointModel> Effort { get; init; } = new List<TrackingPointModel>();
+        public List<TrackingPointModel> EffortProjection { get; init; } = new List<TrackingPointModel>();
     }
 }

--- a/src/Zametek.Contract.ProjectPlan/ICoreViewModel.cs
+++ b/src/Zametek.Contract.ProjectPlan/ICoreViewModel.cs
@@ -24,6 +24,8 @@ namespace Zametek.Contract.ProjectPlan
 
         bool UseBusinessDays { get; set; }
 
+        bool ViewEarnedValueProjections { get; set; }
+
         bool AutoCompile { get; set; }
 
         ReadOnlyObservableCollection<IManagedActivityViewModel> Activities { get; }

--- a/src/Zametek.Contract.ProjectPlan/IMainViewModel.cs
+++ b/src/Zametek.Contract.ProjectPlan/IMainViewModel.cs
@@ -18,6 +18,8 @@ namespace Zametek.Contract.ProjectPlan
 
         bool UseBusinessDays { get; set; }
 
+        bool ViewEarnedValueProjections { get; set; }
+
         bool AutoCompile { get; set; }
 
         ICommand OpenProjectPlanFileCommand { get; }
@@ -35,6 +37,8 @@ namespace Zametek.Contract.ProjectPlan
         ICommand ToggleShowDatesCommand { get; }
 
         ICommand ToggleUseBusinessDaysCommand { get; }
+
+        ICommand ToggleViewEarnedValueProjectionsCommand { get; }
 
         ICommand CompileCommand { get; }
 

--- a/src/Zametek.Resource.ProjectPlan/Labels.Designer.cs
+++ b/src/Zametek.Resource.ProjectPlan/Labels.Designer.cs
@@ -385,6 +385,15 @@ namespace Zametek.Resource.ProjectPlan {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Effort Projection.
+        /// </summary>
+        public static string Label_EffortProjection {
+            get {
+                return ResourceManager.GetString("Label_EffortProjection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Fibonacci Risk:.
         /// </summary>
         public static string Label_FibonacciRisk {
@@ -620,11 +629,38 @@ namespace Zametek.Resource.ProjectPlan {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Plan Projection.
+        /// </summary>
+        public static string Label_PlanProjection {
+            get {
+                return ResourceManager.GetString("Label_PlanProjection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Progress.
         /// </summary>
         public static string Label_Progress {
             get {
                 return ResourceManager.GetString("Label_Progress", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Progress Projection.
+        /// </summary>
+        public static string Label_ProgressProjection {
+            get {
+                return ResourceManager.GetString("Label_ProgressProjection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Project Completion.
+        /// </summary>
+        public static string Label_ProjectCompletion {
+            get {
+                return ResourceManager.GetString("Label_ProjectCompletion", resourceCulture);
             }
         }
         

--- a/src/Zametek.Resource.ProjectPlan/Labels.resx
+++ b/src/Zametek.Resource.ProjectPlan/Labels.resx
@@ -225,6 +225,9 @@
   <data name="Label_Effort" xml:space="preserve">
     <value>Effort</value>
   </data>
+  <data name="Label_EffortProjection" xml:space="preserve">
+    <value>Effort Projection</value>
+  </data>
   <data name="Label_FibonacciRisk" xml:space="preserve">
     <value>Fibonacci Risk:</value>
   </data>
@@ -303,8 +306,17 @@
   <data name="Label_Plan" xml:space="preserve">
     <value>Plan</value>
   </data>
+  <data name="Label_PlanProjection" xml:space="preserve">
+    <value>Plan Projection</value>
+  </data>
   <data name="Label_Progress" xml:space="preserve">
     <value>Progress</value>
+  </data>
+  <data name="Label_ProgressProjection" xml:space="preserve">
+    <value>Progress Projection</value>
+  </data>
+  <data name="Label_ProjectCompletion" xml:space="preserve">
+    <value>Project Completion</value>
   </data>
   <data name="Label_ProjectStart" xml:space="preserve">
     <value>Project Start:</value>

--- a/src/Zametek.Resource.ProjectPlan/Menus.Designer.cs
+++ b/src/Zametek.Resource.ProjectPlan/Menus.Designer.cs
@@ -232,6 +232,15 @@ namespace Zametek.Resource.ProjectPlan {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to View _Earned Value Projections.
+        /// </summary>
+        public static string Menu_ViewEarnedValueProjections {
+            get {
+                return ResourceManager.GetString("Menu_ViewEarnedValueProjections", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to View License.
         /// </summary>
         public static string Menu_ViewLicense {

--- a/src/Zametek.Resource.ProjectPlan/Menus.resx
+++ b/src/Zametek.Resource.ProjectPlan/Menus.resx
@@ -174,6 +174,9 @@
   <data name="Menu_UseBusinessDays" xml:space="preserve">
     <value>Use _Business Days</value>
   </data>
+  <data name="Menu_ViewEarnedValueProjections" xml:space="preserve">
+    <value>View _Earned Value Projections</value>
+  </data>
   <data name="Menu_ViewLicense" xml:space="preserve">
     <value>View License</value>
   </data>

--- a/src/Zametek.View.ProjectPlan/MainView.axaml
+++ b/src/Zametek.View.ProjectPlan/MainView.axaml
@@ -22,6 +22,7 @@
 		<KeyBinding Command="{Binding Path=SaveProjectPlanFileCommand, Mode=OneWay}" Gesture="Ctrl+S" />
 		<KeyBinding Command="{Binding Path=ToggleShowDatesCommand, Mode=OneWay}" Gesture="Ctrl+D" />
 		<KeyBinding Command="{Binding Path=ToggleUseBusinessDaysCommand, Mode=OneWay}" Gesture="Ctrl+B" />
+		<KeyBinding Command="{Binding Path=ToggleViewEarnedValueProjectionsCommand, Mode=OneWay}" Gesture="Ctrl+E" />
 	</Window.KeyBindings>
 
 	<i:Interaction.Behaviors>
@@ -82,6 +83,15 @@
 						<CheckBox BorderThickness="0"
 								  IsHitTestVisible="False"
 								  IsChecked="{Binding Path=UseBusinessDays, Mode=OneWay}" />
+					</MenuItem.Icon>
+				</MenuItem>
+				<MenuItem Header="{x:Static properties:Menus.Menu_ViewEarnedValueProjections}"
+						  Command="{Binding Path=ToggleViewEarnedValueProjectionsCommand, Mode=OneWay}"
+						  InputGesture="Ctrl+E">
+					<MenuItem.Icon>
+						<CheckBox BorderThickness="0"
+								  IsHitTestVisible="False"
+								  IsChecked="{Binding Path=ViewEarnedValueProjections, Mode=OneWay}" />
 					</MenuItem.Icon>
 				</MenuItem>
 			</MenuItem>

--- a/src/Zametek.ViewModel.ProjectPlan/MainViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/MainViewModel.cs
@@ -132,6 +132,7 @@ namespace Zametek.ViewModel.ProjectPlan
 
             ToggleShowDatesCommand = ReactiveCommand.Create(ToggleShowDates);
             ToggleUseBusinessDaysCommand = ReactiveCommand.Create(ToggleUseBusinessDays);
+            ToggleViewEarnedValueProjectionsCommand = ReactiveCommand.Create(ToggleViewEarnedValueProjections);
 
             CompileCommand = ReactiveCommand.CreateFromTask(RunCompileAsync);
             ToggleAutoCompileCommand = ReactiveCommand.Create(ToggleAutoCompile);
@@ -180,6 +181,10 @@ namespace Zametek.ViewModel.ProjectPlan
                 .WhenAnyValue(main => main.m_CoreViewModel.UseBusinessDays)
                 .ToProperty(this, main => main.UseBusinessDays);
 
+            m_ViewEarnedValueProjections = this
+                .WhenAnyValue(main => main.m_CoreViewModel.ViewEarnedValueProjections)
+                .ToProperty(this, main => main.ViewEarnedValueProjections);
+
             m_AutoCompile = this
                 .WhenAnyValue(main => main.m_CoreViewModel.AutoCompile)
                 .ToProperty(this, main => main.AutoCompile);
@@ -187,6 +192,7 @@ namespace Zametek.ViewModel.ProjectPlan
             m_CoreViewModel.UseBusinessDays = true;
             m_CoreViewModel.IsProjectUpdated = false;
             m_CoreViewModel.AutoCompile = true;
+            m_CoreViewModel.ViewEarnedValueProjections = true;
 
 #if DEBUG
             DebugFactoryEvents(m_DockFactory);
@@ -332,6 +338,8 @@ namespace Zametek.ViewModel.ProjectPlan
 
         private void ToggleUseBusinessDays() => UseBusinessDays = !UseBusinessDays;
 
+        private void ToggleViewEarnedValueProjections() => ViewEarnedValueProjections = !ViewEarnedValueProjections;
+
         private void ToggleAutoCompile() => AutoCompile = !AutoCompile;
 
         private void ProcessProjectImport(ProjectImportModel importModel) => m_CoreViewModel.ProcessProjectImport(importModel);
@@ -425,6 +433,16 @@ namespace Zametek.ViewModel.ProjectPlan
             }
         }
 
+        private readonly ObservableAsPropertyHelper<bool> m_ViewEarnedValueProjections;
+        public bool ViewEarnedValueProjections
+        {
+            get => m_ViewEarnedValueProjections.Value;
+            set
+            {
+                lock (m_Lock) m_CoreViewModel.ViewEarnedValueProjections = value;
+            }
+        }
+
         private readonly ObservableAsPropertyHelper<bool> m_AutoCompile;
         public bool AutoCompile
         {
@@ -450,6 +468,8 @@ namespace Zametek.ViewModel.ProjectPlan
         public ICommand ToggleShowDatesCommand { get; }
 
         public ICommand ToggleUseBusinessDaysCommand { get; }
+
+        public ICommand ToggleViewEarnedValueProjectionsCommand { get; }
 
         public ICommand CompileCommand { get; }
 

--- a/src/Zametek.ViewModel.ProjectPlan/OutputManagement/OutputManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/OutputManagement/OutputManagerViewModel.cs
@@ -55,6 +55,10 @@ namespace Zametek.ViewModel.ProjectPlan
                 .WhenAnyValue(om => om.m_CoreViewModel.UseBusinessDays)
                 .ToProperty(this, om => om.UseBusinessDays);
 
+            m_ViewEarnedValueProjections = this
+                .WhenAnyValue(om => om.m_CoreViewModel.ViewEarnedValueProjections)
+                .ToProperty(this, om => om.ViewEarnedValueProjections);
+
             m_ProjectStart = this
                 .WhenAnyValue(om => om.m_CoreViewModel.ProjectStart)
                 .ToProperty(this, om => om.ProjectStart);
@@ -65,7 +69,8 @@ namespace Zametek.ViewModel.ProjectPlan
                     om => om.m_CoreViewModel.ResourceSeriesSet,
                     om => om.ShowDates,
                     om => om.UseBusinessDays,
-                    om => om.ProjectStart)
+                    om => om.ProjectStart,
+                    om => om.ViewEarnedValueProjections)
                 .ObserveOn(RxApp.TaskpoolScheduler)
                 .Subscribe(async result => await BuildCompilationOutputAsync(result.Item1, result.Item2));
 
@@ -82,6 +87,9 @@ namespace Zametek.ViewModel.ProjectPlan
 
         private readonly ObservableAsPropertyHelper<bool> m_UseBusinessDays;
         public bool UseBusinessDays => m_UseBusinessDays.Value;
+
+        private readonly ObservableAsPropertyHelper<bool> m_ViewEarnedValueProjections;
+        public bool ViewEarnedValueProjections => m_ViewEarnedValueProjections.Value;
 
         private readonly ObservableAsPropertyHelper<DateTimeOffset> m_ProjectStart;
         public DateTimeOffset ProjectStart => m_ProjectStart.Value;

--- a/src/Zametek.ViewModel.ProjectPlan/Zametek.ViewModel.ProjectPlan.csproj
+++ b/src/Zametek.ViewModel.ProjectPlan/Zametek.ViewModel.ProjectPlan.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Avalonia.Svg.Skia" Version="0.10.16" />
     <PackageReference Include="Dock.Model.ReactiveUI" Version="0.10.18.1" />
     <PackageReference Include="FluentDateTime" Version="2.1.0" />
+    <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="net.sf.mpxj" Version="10.9.1" />
     <PackageReference Include="NPOI" Version="2.5.6" />
     <PackageReference Include="OxyPlot.Avalonia" Version="2.1.0-Preview1" />


### PR DESCRIPTION
This adds a linear projection line for Plan, Progress, and Effort on the Earned Value chart.

MathNet.Numerics is used for the liner fit. That package is MIT licensed which should be compatible with this product.

Disabling the Earned Value Projection config produces the same chart as before this PR.