### PR TITLE
Removing vertical sections of Earned Value plan line

### DIFF
--- a/src/Zametek.ViewModel.ProjectPlan/CoreViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/CoreViewModel.cs
@@ -385,11 +385,22 @@ namespace Zametek.ViewModel.ProjectPlan
                 if (orderedActivities.All(x => x.EarliestFinishTime.HasValue))
                 {
                     int runningTotalTime = 0;
-                    foreach (ActivityModel activity in orderedActivities)
+                    for (var index = 0; index < orderedActivities.Count; index++)
                     {
+                        ActivityModel activity = orderedActivities[index];
+                        
+
                         int time = activity.EarliestFinishTime.GetValueOrDefault();
                         runningTotalTime += activity.Duration;
                         double percentage = totalTime == 0 ? 0.0 : 100.0 * runningTotalTime / totalTime;
+
+                        // Don't write out the point on the graph if there's going to be a further point on the same time.
+                        // This prevents having a straight vertical segment on the graph
+                        if (index < orderedActivities.Count - 2 && activity.EarliestFinishTime == orderedActivities[index + 1].EarliestFinishTime)
+                        {
+                            continue;
+                        }
+
                         planPointSeries.Add(new TrackingPointModel
                         {
                             Time = time,


### PR DESCRIPTION
Removes vertical sections from the Earned Value Plan line when multiple activities complete at the same time. Will rebase this once #37 is addressed.

Before PR:
![image](https://user-images.githubusercontent.com/17482002/188752682-38dbf1ba-cd50-4610-800a-f3b070b159f5.png)


After PR:
![image](https://user-images.githubusercontent.com/17482002/188752578-fc3c1dc1-0bd1-421c-a224-be6fc8e717f7.png)
