### PR TITLE
Add release artifact pipeline: self-contained binaries for all platforms on version tags

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,35 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = crlf
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.cs]
+indent_size = 4
+
+# Naming conventions matching existing codebase (m_ prefix for private fields)
+dotnet_naming_rule.private_fields_should_have_prefix.severity = suggestion
+dotnet_naming_rule.private_fields_should_have_prefix.symbols = private_fields
+dotnet_naming_rule.private_fields_should_have_prefix.style = prefix_m_underscore
+
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+
+dotnet_naming_style.prefix_m_underscore.required_prefix = m_
+dotnet_naming_style.prefix_m_underscore.capitalization = camel_case
+
+[*.{axaml,xaml}]
+indent_size = 2
+
+[*.{csproj,props,targets}]
+indent_size = 2
+
+[*.{json,yml,yaml}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,12 @@ name: CI
 
 on:
   push:
-    branches: [ master, develop ]
+    branches: [ '**' ]
   pull_request:
-    branches: [ master, develop ]
+    branches: [ develop, master ]
+
+env:
+  HUSKY: 0
 
 jobs:
   build-and-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [ master, develop ]
+  pull_request:
+    branches: [ master, develop ]
+
+jobs:
+  build-and-test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.x'
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore --configuration Release
+
+      - name: Test
+        run: dotnet test --no-build --configuration Release --verbosity normal

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,273 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  build-windows:
+    name: Build Windows (${{ matrix.arch }})
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        arch: [x64, x86, arm64]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.x'
+
+      - name: Restore
+        run: dotnet restore
+        env:
+          HUSKY: 0
+
+      - name: Publish Desktop
+        run: |
+          dotnet publish -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true --self-contained=true -c Release --os win --arch ${{ matrix.arch }} src/Zametek.ProjectPlan/Zametek.ProjectPlan.csproj --output artifacts/desktop/win-${{ matrix.arch }}
+        env:
+          HUSKY: 0
+
+      - name: Publish CLI
+        run: |
+          dotnet publish -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true --self-contained=true -c Release --os win --arch ${{ matrix.arch }} src/Zametek.ProjectPlan.CommandLine/Zametek.ProjectPlan.CommandLine.csproj --output artifacts/cli/win-${{ matrix.arch }}
+        env:
+          HUSKY: 0
+
+      - name: Package Desktop
+        shell: pwsh
+        run: |
+          $version = "${{ github.ref_name }}"
+          Compress-Archive -Path artifacts/desktop/win-${{ matrix.arch }}/* -DestinationPath "projectplandotnet-${version}-win-${{ matrix.arch }}.zip"
+
+      - name: Package CLI
+        shell: pwsh
+        run: |
+          $version = "${{ github.ref_name }}"
+          Compress-Archive -Path artifacts/cli/win-${{ matrix.arch }}/* -DestinationPath "zpp-${version}-win-${{ matrix.arch }}.zip"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-${{ matrix.arch }}
+          path: "*.zip"
+          retention-days: 1
+
+  build-linux:
+    name: Build Linux (${{ matrix.arch }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [x64, arm64]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.x'
+
+      - name: Restore
+        run: dotnet restore
+        env:
+          HUSKY: 0
+
+      - name: Publish Desktop
+        run: |
+          dotnet publish -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true --self-contained=true -c Release --os linux --arch ${{ matrix.arch }} src/Zametek.ProjectPlan/Zametek.ProjectPlan.csproj --output artifacts/desktop/linux-${{ matrix.arch }}
+        env:
+          HUSKY: 0
+
+      - name: Publish CLI
+        run: |
+          dotnet publish -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true --self-contained=true -c Release --os linux --arch ${{ matrix.arch }} src/Zametek.ProjectPlan.CommandLine/Zametek.ProjectPlan.CommandLine.csproj --output artifacts/cli/linux-${{ matrix.arch }}
+        env:
+          HUSKY: 0
+
+      - name: Package Desktop
+        run: |
+          VERSION="${{ github.ref_name }}"
+          tar -czf "projectplandotnet-${VERSION}-linux-${{ matrix.arch }}.tar.gz" -C artifacts/desktop/linux-${{ matrix.arch }} .
+
+      - name: Package CLI
+        run: |
+          VERSION="${{ github.ref_name }}"
+          tar -czf "zpp-${VERSION}-linux-${{ matrix.arch }}.tar.gz" -C artifacts/cli/linux-${{ matrix.arch }} .
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-${{ matrix.arch }}
+          path: "*.tar.gz"
+          retention-days: 1
+
+  build-macos:
+    name: Build macOS (${{ matrix.arch }})
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        arch: [x64, arm64]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.x'
+
+      - name: Restore
+        run: dotnet restore
+        env:
+          HUSKY: 0
+
+      - name: Publish Desktop
+        run: |
+          dotnet publish -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true --self-contained=true -c Release --os osx --arch ${{ matrix.arch }} src/Zametek.ProjectPlan/Zametek.ProjectPlan.csproj --output artifacts/desktop/osx-${{ matrix.arch }}
+        env:
+          HUSKY: 0
+
+      - name: Publish CLI
+        run: |
+          dotnet publish -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true --self-contained=true -c Release --os osx --arch ${{ matrix.arch }} src/Zametek.ProjectPlan.CommandLine/Zametek.ProjectPlan.CommandLine.csproj --output artifacts/cli/osx-${{ matrix.arch }}
+        env:
+          HUSKY: 0
+
+      - name: Package Desktop
+        run: |
+          VERSION="${{ github.ref_name }}"
+          tar -czf "projectplandotnet-${VERSION}-osx-${{ matrix.arch }}.tar.gz" -C artifacts/desktop/osx-${{ matrix.arch }} .
+
+      - name: Package CLI
+        run: |
+          VERSION="${{ github.ref_name }}"
+          tar -czf "zpp-${VERSION}-osx-${{ matrix.arch }}.tar.gz" -C artifacts/cli/osx-${{ matrix.arch }} .
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-${{ matrix.arch }}
+          path: "*.tar.gz"
+          retention-days: 1
+
+  create-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: [build-windows, build-linux, build-macos]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-artifacts
+          merge-multiple: true
+
+      - name: List artifacts
+        run: ls -la release-artifacts/
+
+      - name: Generate release notes
+        id: release-notes
+        run: |
+          VERSION="${{ github.ref_name }}"
+          cat > release-notes.md << EOF
+          ## $VERSION
+
+          ### Downloads
+
+          #### projectplan.net Desktop
+
+          | Platform | Architecture | Download |
+          |----------|-------------|---------|
+          | Windows | x64 | \`projectplandotnet-${VERSION}-win-x64.zip\` |
+          | Windows | x86 | \`projectplandotnet-${VERSION}-win-x86.zip\` |
+          | Windows | arm64 | \`projectplandotnet-${VERSION}-win-arm64.zip\` |
+          | Linux | x64 | \`projectplandotnet-${VERSION}-linux-x64.tar.gz\` |
+          | Linux | arm64 | \`projectplandotnet-${VERSION}-linux-arm64.tar.gz\` |
+          | macOS | x64 (Intel) | \`projectplandotnet-${VERSION}-osx-x64.tar.gz\` |
+          | macOS | arm64 (Apple Silicon) | \`projectplandotnet-${VERSION}-osx-arm64.tar.gz\` |
+
+          #### zpp CLI
+
+          | Platform | Architecture | Download |
+          |----------|-------------|---------|
+          | Windows | x64 | \`zpp-${VERSION}-win-x64.zip\` |
+          | Windows | x86 | \`zpp-${VERSION}-win-x86.zip\` |
+          | Windows | arm64 | \`zpp-${VERSION}-win-arm64.zip\` |
+          | Linux | x64 | \`zpp-${VERSION}-linux-x64.tar.gz\` |
+          | Linux | arm64 | \`zpp-${VERSION}-linux-arm64.tar.gz\` |
+          | macOS | x64 (Intel) | \`zpp-${VERSION}-osx-x64.tar.gz\` |
+          | macOS | arm64 (Apple Silicon) | \`zpp-${VERSION}-osx-arm64.tar.gz\` |
+
+          ### Installation
+
+          **Windows:** Extract the zip file and run \`projectplandotnet.exe\` (Desktop) or \`zpp.exe\` (CLI). No installer required — self-contained, no .NET runtime needed.
+
+          **Linux/macOS:** Extract the tar.gz, make executable (\`chmod +x projectplandotnet\`), and run. Self-contained, no .NET runtime needed.
+          EOF
+
+      - name: Create GitHub Release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const releaseNotes = fs.readFileSync('release-notes.md', 'utf8');
+            const tag = context.ref.replace('refs/tags/', '');
+
+            // Create the release
+            const release = await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: tag,
+              name: tag,
+              body: releaseNotes,
+              draft: false,
+              prerelease: tag.includes('-'),
+            });
+
+            // Upload all artifacts
+            const artifactsDir = 'release-artifacts';
+            const files = fs.readdirSync(artifactsDir);
+
+            for (const file of files) {
+              const filePath = path.join(artifactsDir, file);
+              const stat = fs.statSync(filePath);
+              if (!stat.isFile()) continue;
+
+              const contentType = file.endsWith('.zip')
+                ? 'application/zip'
+                : 'application/gzip';
+
+              console.log(`Uploading ${file} (${stat.size} bytes)...`);
+
+              await github.rest.repos.uploadReleaseAsset({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                release_id: release.data.id,
+                name: file,
+                data: fs.readFileSync(filePath),
+                headers: {
+                  'content-type': contentType,
+                  'content-length': stat.size,
+                },
+              });
+
+              console.log(`Uploaded ${file}`);
+            }
+
+            console.log(`Release ${tag} created: ${release.data.html_url}`);

--- a/src/Zametek.Data.ProjectPlan/Versions.cs
+++ b/src/Zametek.Data.ProjectPlan/Versions.cs
@@ -18,6 +18,6 @@
         public const string v0_6_0 = @"v0.6.0";
 
         public const string ProjectLatest = v0_6_0;
-        public const string AppSettingsLatest = v0_4_4;
+        public const string AppSettingsLatest = v0_6_0;
     }
 }

--- a/src/Zametek.ProjectPlan/App.axaml.cs
+++ b/src/Zametek.ProjectPlan/App.axaml.cs
@@ -28,124 +28,135 @@ namespace Zametek.ProjectPlan
 
         public override async void OnFrameworkInitializationCompleted()
         {
-            if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktopLifetime)
+            try
             {
-                var splashView = new SplashView();
-                var splashViewModel = new SplashViewModel();
-
-                splashView.DataContext = splashViewModel;
-
-                desktopLifetime.MainWindow = splashView;
-
-                splashView.Show();
-
-                string? input = null;
-
-                desktopLifetime.Startup += (sender, args) =>
+                if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktopLifetime)
                 {
-                    input = args?.Args?.FirstOrDefault();
-                };
+                    var splashView = new SplashView();
+                    var splashViewModel = new SplashViewModel();
 
-                try
-                {
-                    await Task.Factory.StartNew(() =>
+                    splashView.DataContext = splashViewModel;
+
+                    desktopLifetime.MainWindow = splashView;
+
+                    splashView.Show();
+
+                    string? input = null;
+
+                    desktopLifetime.Startup += (sender, args) =>
                     {
-                        Bootstrapper.RegisterIOC();
-                    }, cancellationToken: splashViewModel.CancellationToken);
-
-                    ISettingService settingService = GetRequiredService<ISettingService>();
-                    string selectedTheme = settingService.SelectedTheme;
-
-                    IMainViewModel mainViewModel = GetRequiredService<IMainViewModel>();
-
-                    DataContext = mainViewModel;
-
-                    desktopLifetime.Exit += (a, b) =>
-                    {
-                        mainViewModel.CloseLayout();
+                        input = args?.Args?.FirstOrDefault();
                     };
 
-                    MainView mainView = new()
+                    try
                     {
-                        DataContext = mainViewModel,
-                        InitialTheme = selectedTheme
-                    };
-
-                    IDialogService dialogService = GetRequiredService<IDialogService>();
-                    dialogService.Parent = mainView;
-
-                    // Cancelling the window closing does not work when using an async handler,
-                    // and trying to force Wait on the return dialog freezes the UI thread.
-                    // This solution is the hack below, where CancelClose automatically cancels
-                    // the closing event first, then CheckClose checks to see if the project
-                    // has updates.
-                    // If there are no updates, CheckClose removes all handlers and forces a new close.
-                    // If there are updates, then the dialog requests permission to proceed.
-                    // If yes, then it continues as before. If no, then CheckClose removes itself
-                    // and then adds back all the handlers in the correct order (i.e. the same
-                    // initial state) and then immediately returns.
-                    void CancelClose(object? sender, CancelEventArgs args)
-                    {
-                        args.Cancel = true;
-                    }
-
-                    async void CheckClose(object? sender, CancelEventArgs args)
-                    {
-                        mainView.Closing -= CancelClose;
-
-                        if (mainViewModel.ProjectHasChanges)
+                        await Task.Factory.StartNew(() =>
                         {
-                            bool wishToClose = await dialogService.ShowConfirmationAsync(
-                                Resource.ProjectPlan.Titles.Title_ProjectUnsavedChanges,
-                                string.Empty,
-                                Resource.ProjectPlan.Messages.Message_ProjectUnsavedChanges);
+                            Bootstrapper.RegisterIOC();
+                        }, cancellationToken: splashViewModel.CancellationToken);
 
-                            if (!wishToClose)
-                            {
-                                // Clearing the rest of the handlers and then adding
-                                // them back in the correct order.
-                                mainView.Closing -= CheckClose;
-                                mainView.Closing += CancelClose;
-                                mainView.Closing += CheckClose;
-                                return;
-                            }
+                        ISettingService settingService = GetRequiredService<ISettingService>();
+                        string selectedTheme = settingService.SelectedTheme;
+
+                        IMainViewModel mainViewModel = GetRequiredService<IMainViewModel>();
+
+                        DataContext = mainViewModel;
+
+                        desktopLifetime.Exit += (a, b) =>
+                        {
+                            mainViewModel.CloseLayout();
+                        };
+
+                        MainView mainView = new()
+                        {
+                            DataContext = mainViewModel,
+                            InitialTheme = selectedTheme
+                        };
+
+                        IDialogService dialogService = GetRequiredService<IDialogService>();
+                        dialogService.Parent = mainView;
+
+                        // Cancelling the window closing does not work when using an async handler,
+                        // and trying to force Wait on the return dialog freezes the UI thread.
+                        // This solution is the hack below, where CancelClose automatically cancels
+                        // the closing event first, then CheckClose checks to see if the project
+                        // has updates.
+                        // If there are no updates, CheckClose removes all handlers and forces a new close.
+                        // If there are updates, then the dialog requests permission to proceed.
+                        // If yes, then it continues as before. If no, then CheckClose removes itself
+                        // and then adds back all the handlers in the correct order (i.e. the same
+                        // initial state) and then immediately returns.
+                        void CancelClose(object? sender, CancelEventArgs args)
+                        {
+                            args.Cancel = true;
                         }
 
-                        mainView.Closing -= CheckClose;
-                        mainViewModel.CloseLayout();
-                        mainView.Close();
+                        async void CheckClose(object? sender, CancelEventArgs args)
+                        {
+                            mainView.Closing -= CancelClose;
+
+                            if (mainViewModel.ProjectHasChanges)
+                            {
+                                bool wishToClose = await dialogService.ShowConfirmationAsync(
+                                    Resource.ProjectPlan.Titles.Title_ProjectUnsavedChanges,
+                                    string.Empty,
+                                    Resource.ProjectPlan.Messages.Message_ProjectUnsavedChanges);
+
+                                if (!wishToClose)
+                                {
+                                    // Clearing the rest of the handlers and then adding
+                                    // them back in the correct order.
+                                    mainView.Closing -= CheckClose;
+                                    mainView.Closing += CancelClose;
+                                    mainView.Closing += CheckClose;
+                                    return;
+                                }
+                            }
+
+                            mainView.Closing -= CheckClose;
+                            mainViewModel.CloseLayout();
+                            mainView.Close();
+                        }
+
+                        mainView.Closing += CancelClose;
+                        mainView.Closing += CheckClose;
+
+                        desktopLifetime.MainWindow = mainView;
+
+                        mainView.Show();
+
+                        if (input is not null)
+                        {
+                            await mainViewModel.OpenProjectFileAsync(input);
+                        }
+
+                        splashView.Close();
                     }
-
-                    mainView.Closing += CancelClose;
-                    mainView.Closing += CheckClose;
-
-                    desktopLifetime.MainWindow = mainView;
-
-                    mainView.Show();
-
-                    if (input is not null)
+                    catch (TaskCanceledException)
                     {
-                        await mainViewModel.OpenProjectFileAsync(input);
+                        splashView.Close();
+                        return;
                     }
-
-                    splashView.Close();
                 }
-                catch (TaskCanceledException)
+                //else if (ApplicationLifetime is ISingleViewApplicationLifetime singleViewLifetime)
+                //{
+                //    var mainView = new MainView()
+                //    {
+                //        DataContext = mainViewModel
+                //    };
+
+                //    singleViewLifetime.MainView = mainView;
+                //}
+                base.OnFrameworkInitializationCompleted();
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Fatal startup error: {ex}");
+                if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
                 {
-                    splashView.Close();
-                    return;
+                    desktop.Shutdown(1);
                 }
             }
-            //else if (ApplicationLifetime is ISingleViewApplicationLifetime singleViewLifetime)
-            //{
-            //    var mainView = new MainView()
-            //    {
-            //        DataContext = mainViewModel
-            //    };
-
-            //    singleViewLifetime.MainView = mainView;
-            //}
-            base.OnFrameworkInitializationCompleted();
 
 #if DEBUG
             this.AttachDevTools();

--- a/src/Zametek.View.ProjectPlan/Miscellaneous/DataGridManager.cs
+++ b/src/Zametek.View.ProjectPlan/Miscellaneous/DataGridManager.cs
@@ -83,12 +83,8 @@ namespace Zametek.View.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 ResetActions.Clear();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/ActivityManagement/ActivityTrackerSetViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ActivityManagement/ActivityTrackerSetViewModel.cs
@@ -394,12 +394,8 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 m_DaysSub?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/ActivityManagement/ManagedActivityViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ActivityManagement/ManagedActivityViewModel.cs
@@ -980,16 +980,12 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 TrackerSet.Dispose();
                 m_ShowDates?.Dispose();
                 m_HasResources?.Dispose();
                 m_HasWorkStreams?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/CoreViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/CoreViewModel.cs
@@ -176,19 +176,22 @@ namespace Zametek.ViewModel.ProjectPlan
                 .ObserveOn(RxApp.TaskpoolScheduler)
                 .Subscribe(changeSet =>
                 {
-                    if (!IsBusy && (changeSet.Replaced + changeSet.Adds) > 0)
+                    if ((changeSet.Replaced + changeSet.Adds) > 0)
                     {
                         lock (m_Lock)
                         {
-                            if (AutoCompile)
+                            if (!IsBusy)
                             {
-                                IsReadyToReviseTrackers = ReadyToRevise.Yes;
-                                IsReadyToCompile = ReadyToCompile.Yes;
-                            }
-                            else
-                            {
-                                IsReadyToReviseTrackers = ReadyToRevise.No;
-                                IsReadyToCompile = ReadyToCompile.No;
+                                if (AutoCompile)
+                                {
+                                    IsReadyToReviseTrackers = ReadyToRevise.Yes;
+                                    IsReadyToCompile = ReadyToCompile.Yes;
+                                }
+                                else
+                                {
+                                    IsReadyToReviseTrackers = ReadyToRevise.No;
+                                    IsReadyToCompile = ReadyToCompile.No;
+                                }
                             }
                         }
                     }
@@ -199,16 +202,12 @@ namespace Zametek.ViewModel.ProjectPlan
                 .ObserveOn(Scheduler.CurrentThread)
                 .Subscribe(isReady =>
                 {
-                    if (isReady == ReadyToCompile.Yes
-                        && !IsBusy)
+                    lock (m_Lock)
                     {
-                        lock (m_Lock)
+                        if (isReady == ReadyToCompile.Yes
+                            && !IsBusy)
                         {
-                            if (isReady == ReadyToCompile.Yes
-                                && !IsBusy)
-                            {
-                                RunAutoCompile();
-                            }
+                            RunAutoCompile();
                         }
                     }
                 });
@@ -2635,7 +2634,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_ProjectFinish?.Dispose();
                 m_HasActivities?.Dispose();
@@ -2646,9 +2644,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_Activities?.Dispose();
                 m_DisplaySettingsViewModel?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/EarnedValueChartManagement/EarnedValueChartManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/EarnedValueChartManagement/EarnedValueChartManagerViewModel.cs
@@ -738,7 +738,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_IsBusy?.Dispose();
                 m_HasStaleOutputs?.Dispose();
@@ -747,9 +746,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_ShowToday?.Dispose();
                 m_ShowMilestones?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/GanttChartManagement/ActivitySelectorViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/GanttChartManagement/ActivitySelectorViewModel.cs
@@ -310,12 +310,8 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 m_ReviseActivitiesSub?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/GanttChartManagement/GanttChartManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/GanttChartManagement/GanttChartManagerViewModel.cs
@@ -1615,7 +1615,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_IsBusy?.Dispose();
                 m_HasStaleOutputs?.Dispose();
@@ -1633,9 +1632,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_BoolAccumulator?.Dispose();
                 ActivitySelector?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/GraphManagement/ArrowGraphManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/GraphManagement/ArrowGraphManagerViewModel.cs
@@ -396,7 +396,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_IsBusy?.Dispose();
                 m_HasStaleOutputs?.Dispose();
@@ -404,9 +403,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_ShowNames?.Dispose();
                 m_BaseTheme?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/GraphManagement/VertexGraphManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/GraphManagement/VertexGraphManagerViewModel.cs
@@ -399,7 +399,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_IsBusy?.Dispose();
                 m_HasStaleOutputs?.Dispose();
@@ -407,9 +406,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_ShowNames?.Dispose();
                 m_BaseTheme?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/GraphSettingsManagement/GraphSettingsManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/GraphSettingsManagement/GraphSettingsManagerViewModel.cs
@@ -382,7 +382,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 m_IsBusy?.Dispose();
                 m_HasStaleOutputs?.Dispose();
                 m_HasCompilationErrors?.Dispose();
@@ -392,9 +391,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 ClearManagedActivitySeverities();
                 m_ActivitySeverities?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/GraphSettingsManagement/ManagedActivitySeverityViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/GraphSettingsManagement/ManagedActivitySeverityViewModel.cs
@@ -150,16 +150,12 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 //m_ProjectStartSub?.Dispose();
                 //m_ResourceSettingsSub?.Dispose();
                 //m_DateTimeCalculatorSub?.Dispose();
                 //m_CompilationSub?.Dispose();
                 //ResourceSelector.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/HolidaySettingsManagement/HolidayEditViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/HolidaySettingsManagement/HolidayEditViewModel.cs
@@ -936,7 +936,6 @@ namespace Zametek.ViewModel.ProjectPlan
             }
         }
 
-
         private SetByIntModel? m_YearlySetPosSelection;
         public SetByIntModel? YearlySetPosSelection
         {
@@ -944,7 +943,6 @@ namespace Zametek.ViewModel.ProjectPlan
             set => this.RaiseAndSetIfChanged(ref m_YearlySetPosSelection, value);
         }
         public List<SetByIntModel> YearlySetPosOptions { get; }
-
 
         private SetByStringModel? m_YearlyWeekdaySelection;
         public SetByStringModel? YearlyWeekdaySelection
@@ -954,7 +952,6 @@ namespace Zametek.ViewModel.ProjectPlan
         }
         public List<SetByStringModel> YearlyWeekdayOptions { get; }
 
-
         private SetByIntModel? m_YearlyMonthSelection;
         public SetByIntModel? YearlyMonthSelection
         {
@@ -962,7 +959,6 @@ namespace Zametek.ViewModel.ProjectPlan
             set => this.RaiseAndSetIfChanged(ref m_YearlyMonthSelection, value);
         }
         public List<SetByIntModel> YearlyMonthOptions { get; }
-
 
         private RecurrenceRuleModel m_RecurrenceRule;
         public RecurrenceRuleModel RecurrenceRule
@@ -1016,12 +1012,8 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/HolidaySettingsManagement/HolidaySettingsManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/HolidaySettingsManagement/HolidaySettingsManagerViewModel.cs
@@ -441,7 +441,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 m_IsBusy?.Dispose();
                 m_HasStaleOutputs?.Dispose();
                 m_HasCompilationErrors?.Dispose();
@@ -450,9 +449,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_UpdateHolidaySettingsSub?.Dispose();
                 ClearManagedHolidays();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/HolidaySettingsManagement/ManagedHolidayViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/HolidaySettingsManagement/ManagedHolidayViewModel.cs
@@ -192,12 +192,8 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/MainViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/MainViewModel.cs
@@ -1314,7 +1314,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_IsBusy?.Dispose();
                 m_IsProjectUpdated?.Dispose();
@@ -1332,9 +1331,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_BaseTheme?.Dispose();
                 m_DataGridManager?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/MetricManagement/MetricManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/MetricManagement/MetricManagerViewModel.cs
@@ -91,7 +91,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 .WhenAnyValue(mm => mm.m_CoreViewModel.Metrics, metrics => metrics.Network)
                 .ToProperty(this, mm => mm.NetworkMetrics);
 
-
             m_CriticalityRisk = this
                 .WhenAnyValue(mm => mm.RisksMetrics, risks => risks.Criticality)
                 .ToProperty(this, mm => mm.CriticalityRisk);
@@ -120,7 +119,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 .WhenAnyValue(mm => mm.RisksMetrics, risks => risks.GeometricActivity)
                 .ToProperty(this, mm => mm.GeometricActivityRisk);
 
-
             m_DirectCost = this
                 .WhenAnyValue(mm => mm.CostsMetrics, costs => costs.Direct)
                 .ToProperty(this, mm => mm.DirectCost);
@@ -136,7 +134,6 @@ namespace Zametek.ViewModel.ProjectPlan
             m_TotalCost = this
                 .WhenAnyValue(mm => mm.CostsMetrics, costs => costs.Total)
                 .ToProperty(this, mm => mm.TotalCost);
-
 
             m_DirectBilling = this
                 .WhenAnyValue(mm => mm.BillingsMetrics, billings => billings.Direct)
@@ -154,7 +151,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 .WhenAnyValue(mm => mm.BillingsMetrics, billings => billings.Total)
                 .ToProperty(this, mm => mm.TotalBilling);
 
-
             m_DirectMargin = this
                  .WhenAnyValue(mm => mm.MarginsMetrics, margins => margins.Direct)
                  .ToProperty(this, mm => mm.DirectMargin);
@@ -170,7 +166,6 @@ namespace Zametek.ViewModel.ProjectPlan
             m_TotalMargin = this
                  .WhenAnyValue(mm => mm.MarginsMetrics, margins => margins.Total)
                  .ToProperty(this, mm => mm.TotalMargin);
-
 
             m_DisplayDirectMargin = this
                 .WhenAnyValue(
@@ -196,7 +191,6 @@ namespace Zametek.ViewModel.ProjectPlan
                     (double? margin) => margin is null ? string.Empty : string.Format(" ({0:P1})", margin))
                 .ToProperty(this, mm => mm.DisplayTotalMargin);
 
-
             m_DirectMarginAbsolute = this
                 .WhenAnyValue(mm => mm.MarginsMetrics, margins => margins.DirectAbsolute)
                 .ToProperty(this, mm => mm.DirectMarginAbsolute);
@@ -212,7 +206,6 @@ namespace Zametek.ViewModel.ProjectPlan
             m_TotalMarginAbsolute = this
                 .WhenAnyValue(mm => mm.MarginsMetrics, margins => margins.TotalAbsolute)
                 .ToProperty(this, mm => mm.TotalMarginAbsolute);
-
 
             m_DirectEffort = this
                 .WhenAnyValue(mm => mm.EffortsMetrics, efforts => efforts.Direct)
@@ -238,7 +231,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 .WhenAnyValue(mm => mm.EffortsMetrics, efforts => efforts.Efficiency)
                 .ToProperty(this, mm => mm.EffortEfficiency);
 
-
             m_NetworkCyclomaticComplexity = this
                 .WhenAnyValue(mm => mm.NetworkMetrics, network => network.CyclomaticComplexity)
                 .ToProperty(this, mm => mm.NetworkCyclomaticComplexity);
@@ -250,7 +242,6 @@ namespace Zametek.ViewModel.ProjectPlan
             m_NetworkDurationManMonths = this
                 .WhenAnyValue(mm => mm.NetworkMetrics, network => network.DurationManMonths)
                 .ToProperty(this, mm => mm.NetworkDurationManMonths);
-
 
             m_ProjectFinish = this
                 .WhenAnyValue(mm => mm.m_CoreViewModel.ProjectFinish)
@@ -266,7 +257,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
         private readonly ObservableAsPropertyHelper<bool> m_ShowDates;
         public bool ShowDates => m_ShowDates.Value;
-
 
         private readonly ObservableAsPropertyHelper<RisksModel> m_RisksMetrics;
         public RisksModel RisksMetrics => m_RisksMetrics.Value;
@@ -442,7 +432,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_IsBusy?.Dispose();
                 m_HasStaleOutputs?.Dispose();
@@ -470,9 +459,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_ActivityEffort?.Dispose();
                 m_EffortEfficiency?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/OutputManagement/OutputManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/OutputManagement/OutputManagerViewModel.cs
@@ -265,7 +265,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_IsBusy?.Dispose();
                 m_HasStaleOutputs?.Dispose();
@@ -275,9 +274,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_NonWorkingDayMode?.Dispose();
                 m_ProjectStart?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/ProjectDisplaySettingsViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ProjectDisplaySettingsViewModel.cs
@@ -199,12 +199,8 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 m_SetIsProjectUpdated = null;
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/ProjectScenarioDisplaySettingsViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ProjectScenarioDisplaySettingsViewModel.cs
@@ -568,13 +568,9 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 m_SetIsProjectScenarioUpdated = null;
                 m_IsReadyToCompile = null;
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/ProjectScenarioManagement/ManagedNodeViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ProjectScenarioManagement/ManagedNodeViewModel.cs
@@ -456,7 +456,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_Labels.Clear();
                 m_Labels.Dispose();
@@ -464,9 +463,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_Children.Dispose();
                 m_DisplayName?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/ProjectScenarioManagement/ProjectScenarioManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ProjectScenarioManagement/ProjectScenarioManagerViewModel.cs
@@ -2321,7 +2321,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 ResetProject();
                 KillSubscriptions();
                 m_IsLoading?.Dispose();
@@ -2338,8 +2337,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_ScenarioChartCurveFittingType?.Dispose();
                 m_NodeActionCommandManualTrigger?.Dispose();
             }
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/ResourceChartManagement/ResourceChartManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ResourceChartManagement/ResourceChartManagerViewModel.cs
@@ -737,7 +737,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_IsBusy?.Dispose();
                 m_HasStaleOutputs?.Dispose();
@@ -748,9 +747,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_ShowToday?.Dispose();
                 m_ShowMilestones?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/ResourceSettingsManagement/ManagedResourceViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ResourceSettingsManagement/ManagedResourceViewModel.cs
@@ -356,15 +356,11 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_HasPhases?.Dispose();
                 TrackerSet.Dispose();
                 m_InterActivityAllocationIsIndirect?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/ResourceSettingsManagement/ResourceActivitySelectorViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ResourceSettingsManagement/ResourceActivitySelectorViewModel.cs
@@ -324,12 +324,8 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 m_ReviseResourceActivityTrackersSub?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }
@@ -388,14 +384,6 @@ namespace Zametek.ViewModel.ProjectPlan
             {
                 return;
             }
-
-            if (disposing)
-            {
-                // TODO: dispose managed state (managed objects).
-            }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/ResourceSettingsManagement/ResourceSettingsManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ResourceSettingsManagement/ResourceSettingsManagerViewModel.cs
@@ -626,7 +626,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 m_IsBusy?.Dispose();
                 m_HasStaleOutputs?.Dispose();
                 m_HasCompilationErrors?.Dispose();
@@ -639,9 +638,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 ClearManagedResources();
                 m_Resources?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/ResourceSettingsManagement/ResourceTrackerSetViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ResourceSettingsManagement/ResourceTrackerSetViewModel.cs
@@ -332,16 +332,12 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 m_DaysSub?.Dispose();
                 foreach (IResourceActivitySelectorViewModel selector in m_ResourceActivitySelectorLookup.Values)
                 {
                     selector.Dispose();
                 }
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/ScenarioChartManagement/ScenarioChartManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ScenarioChartManagement/ScenarioChartManagerViewModel.cs
@@ -712,7 +712,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_IsBusy?.Dispose();
                 m_HasStaleOutputs?.Dispose();
@@ -721,9 +720,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_TrackedMetricYAxis?.Dispose();
                 m_CurveFittingType?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/TrackingManagement/TrackingManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/TrackingManagement/TrackingManagerViewModel.cs
@@ -240,7 +240,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_IsBusy?.Dispose();
                 m_HasActivities?.Dispose();
@@ -250,9 +249,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_ProjectStart?.Dispose();
                 m_HasCompilationErrors?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/WorkStreamSettingsManagement/ManagedWorkStreamViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/WorkStreamSettingsManagement/ManagedWorkStreamViewModel.cs
@@ -135,19 +135,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 return;
             }
 
-            if (disposing)
-            {
-                // TODO: dispose managed state (managed objects).
-                //m_ProjectStartSub?.Dispose();
-                //m_ResourceSettingsSub?.Dispose();
-                //m_DateTimeCalculatorSub?.Dispose();
-                //m_CompilationSub?.Dispose();
-                //ResourceSelector.Dispose();
-            }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
-
             m_Disposed = true;
         }
 

--- a/src/Zametek.ViewModel.ProjectPlan/WorkStreamSettingsManagement/WorkStreamSettingsManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/WorkStreamSettingsManagement/WorkStreamSettingsManagerViewModel.cs
@@ -415,7 +415,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 m_IsBusy?.Dispose();
                 m_HasStaleOutputs?.Dispose();
                 m_HasCompilationErrors?.Dispose();
@@ -426,9 +425,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 ClearManagedWorkStreams();
                 m_WorkStreams?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/Zametek.ViewModel.ProjectPlan.csproj
+++ b/src/Zametek.ViewModel.ProjectPlan/Zametek.ViewModel.ProjectPlan.csproj
@@ -11,6 +11,7 @@
 	<PackageReference Include="AutomaticGraphLayout.Drawing" Version="1.1.12" />
     <PackageReference Include="Dock.Model.ReactiveUI" Version="11.3.11.22" />
     <PackageReference Include="Dock.Serializer.Newtonsoft" Version="11.3.11.22" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <!--<PackageReference Include="Dock.Serializer.SystemTextJson" Version="11.3.11.22" />-->
     <PackageReference Include="Ical.Net" Version="5.2.1" />
     <PackageReference Include="net.sf.mpxj-for-csharp" Version="13.12.0" />
@@ -20,7 +21,6 @@
     <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.2" />
     <PackageReference Include="Svg.Controls.Skia.Avalonia" Version="11.3.9.5" />
     <PackageReference Include="System.Drawing.Common" Version="10.0.5" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
     <PackageReference Include="Zametek.Maths.Graphs.Compilers" Version="2.4.8" />
   </ItemGroup>
 

--- a/test/Zametek.ViewModel.ProjectPlan.Tests/Miscellaneous/MetricsHelperTests.cs
+++ b/test/Zametek.ViewModel.ProjectPlan.Tests/Miscellaneous/MetricsHelperTests.cs
@@ -1,0 +1,353 @@
+using Shouldly;
+using System.Collections.Generic;
+using Xunit;
+using Zametek.Common.ProjectPlan;
+
+namespace Zametek.ViewModel.ProjectPlan.Tests
+{
+    public class MetricsHelperTests
+    {
+        #region Helpers
+
+        private static ActivitySeverityModel MakeSeverity(int slackLimit, double criticalityWeight, double fibonacciWeight) =>
+            new ActivitySeverityModel
+            {
+                SlackLimit = slackLimit,
+                CriticalityWeight = criticalityWeight,
+                FibonacciWeight = fibonacciWeight,
+            };
+
+        private static ActivityModel MakeActivity(int? totalSlack, bool hasNoRisk = false) =>
+            new ActivityModel
+            {
+                Id = 1,
+                TotalSlack = totalSlack,
+                HasNoRisk = hasNoRisk,
+            };
+
+        private static IEnumerable<ActivitySeverityModel> DefaultSeverities() =>
+        [
+            MakeSeverity(slackLimit: 0, criticalityWeight: 1.0, fibonacciWeight: 1.0),
+            MakeSeverity(slackLimit: 5, criticalityWeight: 0.8, fibonacciWeight: 0.5),
+            MakeSeverity(slackLimit: 10, criticalityWeight: 0.6, fibonacciWeight: 0.25),
+        ];
+
+        #endregion
+
+        #region CalculateActivityRisk
+
+        [Fact]
+        public void CalculateActivityRisk_Given_EmptyList_Then_ReturnsOne()
+        {
+            var result = MetricsHelper.CalculateActivityRisk([]);
+            result.ShouldBe(1.0);
+        }
+
+        [Fact]
+        public void CalculateActivityRisk_Given_AllZeroSlack_Then_ReturnsOne()
+        {
+            var activities = new[] { MakeActivity(0), MakeActivity(0), MakeActivity(0) };
+            var result = MetricsHelper.CalculateActivityRisk(activities);
+            result.ShouldBe(1.0);
+        }
+
+        [Fact]
+        public void CalculateActivityRisk_Given_MixedSlack_Then_ReturnsExpectedRatio()
+        {
+            // Activities: slack 0, 0, 10 => numerator = 10, maxSlack = 10, denominator = 10 * 3 = 30
+            // result = 1 - 10/30 = 0.667
+            var activities = new[] { MakeActivity(0), MakeActivity(0), MakeActivity(10) };
+            var result = MetricsHelper.CalculateActivityRisk(activities);
+            result.ShouldNotBeNull();
+            result!.Value.ShouldBeInRange(0.66, 0.68);
+        }
+
+        [Fact]
+        public void CalculateActivityRisk_Given_AllNullSlack_Then_ReturnsOne()
+        {
+            // Activities with null TotalSlack are excluded from numerator/denominator calc
+            // denominator = 0 * count = 0, numerator = 0 => return 1.0
+            var activities = new[] { MakeActivity(null), MakeActivity(null) };
+            var result = MetricsHelper.CalculateActivityRisk(activities);
+            result.ShouldBe(1.0);
+        }
+
+        [Fact]
+        public void CalculateActivityRisk_Given_SingleActivityWithSlack_Then_ReturnsZero()
+        {
+            // numerator = 5, maxSlack = 5, denominator = 5 * 1 = 5
+            // result = 1 - 5/5 = 0
+            var activities = new[] { MakeActivity(5) };
+            var result = MetricsHelper.CalculateActivityRisk(activities);
+            result.ShouldBe(0.0);
+        }
+
+        #endregion
+
+        #region CalculateActivityRiskWithStdDevCorrection
+
+        [Fact]
+        public void CalculateActivityRiskWithStdDevCorrection_Given_EmptyList_Then_ReturnsOne()
+        {
+            var result = MetricsHelper.CalculateActivityRiskWithStdDevCorrection([]);
+            result.ShouldBe(1.0);
+        }
+
+        [Fact]
+        public void CalculateActivityRiskWithStdDevCorrection_Given_AllZeroSlack_Then_ReturnsOne()
+        {
+            var activities = new[] { MakeActivity(0), MakeActivity(0) };
+            var result = MetricsHelper.CalculateActivityRiskWithStdDevCorrection(activities);
+            result.ShouldBe(1.0);
+        }
+
+        [Fact]
+        public void CalculateActivityRiskWithStdDevCorrection_Given_UniformSlack_Then_CorrectValueWithStdDevOfZero()
+        {
+            // All slack = 5, mean = 5, stddev = 0, correction = round(5+0) = 5
+            // Each capped at 5, so numerator = 5*3 = 15, maxSlack = 5, denominator = 5*3 = 15
+            // result = 1 - 15/15 = 0
+            var activities = new[] { MakeActivity(5), MakeActivity(5), MakeActivity(5) };
+            var result = MetricsHelper.CalculateActivityRiskWithStdDevCorrection(activities);
+            result.ShouldBe(0.0);
+        }
+
+        #endregion
+
+        #region CalculateCriticalityRisk
+
+        [Fact]
+        public void CalculateCriticalityRisk_Given_EmptyList_Then_ReturnsOne()
+        {
+            var lookup = new ActivitySeverityLookup(DefaultSeverities());
+            var result = MetricsHelper.CalculateCriticalityRisk([], lookup);
+            result.ShouldBe(1.0);
+        }
+
+        [Fact]
+        public void CalculateCriticalityRisk_Given_AllCriticalActivities_Then_ReturnsOne()
+        {
+            var lookup = new ActivitySeverityLookup(DefaultSeverities());
+            // SlackLimit 0 => criticalityWeight 1.0. Critical weight = 1.0.
+            // numerator = 1.0 * 2 = 2, denominator = 1.0 * 2 = 2 => result = 1.0
+            var activities = new[] { MakeActivity(0), MakeActivity(0) };
+            var result = MetricsHelper.CalculateCriticalityRisk(activities, lookup);
+            result.ShouldBe(1.0);
+        }
+
+        [Fact]
+        public void CalculateCriticalityRisk_Given_MixedSlack_Then_ReturnsExpectedRatio()
+        {
+            var lookup = new ActivitySeverityLookup(DefaultSeverities());
+            // slack=0 => weight 1.0, slack=5 => weight 0.8
+            // numerator = 1.0 + 0.8 = 1.8, denominator = 1.0 * 2 = 2.0
+            var activities = new[] { MakeActivity(0), MakeActivity(5) };
+            var result = MetricsHelper.CalculateCriticalityRisk(activities, lookup);
+            result.ShouldNotBeNull();
+            result!.Value.ShouldBeInRange(0.89, 0.91);
+        }
+
+        #endregion
+
+        #region CalculateFibonacciRisk
+
+        [Fact]
+        public void CalculateFibonacciRisk_Given_EmptyList_Then_ReturnsOne()
+        {
+            var lookup = new ActivitySeverityLookup(DefaultSeverities());
+            var result = MetricsHelper.CalculateFibonacciRisk([], lookup);
+            result.ShouldBe(1.0);
+        }
+
+        [Fact]
+        public void CalculateFibonacciRisk_Given_AllCriticalActivities_Then_ReturnsOne()
+        {
+            var lookup = new ActivitySeverityLookup(DefaultSeverities());
+            var activities = new[] { MakeActivity(0), MakeActivity(0) };
+            var result = MetricsHelper.CalculateFibonacciRisk(activities, lookup);
+            result.ShouldBe(1.0);
+        }
+
+        #endregion
+
+        #region CalculateGeometricActivityRisk
+
+        [Fact]
+        public void CalculateGeometricActivityRisk_Given_EmptyList_Then_ReturnsOne()
+        {
+            var result = MetricsHelper.CalculateGeometricActivityRisk([]);
+            result.ShouldBe(1.0);
+        }
+
+        [Fact]
+        public void CalculateGeometricActivityRisk_Given_AllZeroSlack_Then_ReturnsOne()
+        {
+            // totalSlack=0 => (0+1) = 1, numerator = pow(1,1/n) - 1 = 0, denominator = maxSlack = 0
+            // both 0 => return 1.0
+            var activities = new[] { MakeActivity(0), MakeActivity(0) };
+            var result = MetricsHelper.CalculateGeometricActivityRisk(activities);
+            result.ShouldBe(1.0);
+        }
+
+        #endregion
+
+        #region CalculateEfficiency
+
+        [Fact]
+        public void CalculateEfficiency_Given_BothNull_Then_ReturnsNull()
+        {
+            MetricsHelper.CalculateEfficiency(null, null).ShouldBeNull();
+        }
+
+        [Fact]
+        public void CalculateEfficiency_Given_ActivityEffortNull_Then_ReturnsNull()
+        {
+            MetricsHelper.CalculateEfficiency(null, 10.0).ShouldBeNull();
+        }
+
+        [Fact]
+        public void CalculateEfficiency_Given_TotalEffortNull_Then_ReturnsNull()
+        {
+            MetricsHelper.CalculateEfficiency(10.0, null).ShouldBeNull();
+        }
+
+        [Fact]
+        public void CalculateEfficiency_Given_TotalEffortZero_Then_ReturnsNull()
+        {
+            MetricsHelper.CalculateEfficiency(10.0, 0.0).ShouldBeNull();
+        }
+
+        [Fact]
+        public void CalculateEfficiency_Given_ActivityEffortZero_Then_ReturnsNull()
+        {
+            MetricsHelper.CalculateEfficiency(0.0, 10.0).ShouldBeNull();
+        }
+
+        [Fact]
+        public void CalculateEfficiency_Given_ValidInputs_Then_ReturnsRatio()
+        {
+            var result = MetricsHelper.CalculateEfficiency(5.0, 10.0);
+            result.ShouldBe(0.5);
+        }
+
+        [Fact]
+        public void CalculateEfficiency_Given_EqualInputs_Then_ReturnsOne()
+        {
+            var result = MetricsHelper.CalculateEfficiency(10.0, 10.0);
+            result.ShouldBe(1.0);
+        }
+
+        #endregion
+
+        #region CalculateMarginAbsolute
+
+        [Fact]
+        public void CalculateMarginAbsolute_Given_BothNull_Then_ReturnsNull()
+        {
+            MetricsHelper.CalculateMarginAbsolute(null, null).ShouldBeNull();
+        }
+
+        [Fact]
+        public void CalculateMarginAbsolute_Given_CostNull_Then_ReturnsNull()
+        {
+            MetricsHelper.CalculateMarginAbsolute(null, 100.0).ShouldBeNull();
+        }
+
+        [Fact]
+        public void CalculateMarginAbsolute_Given_BillingNull_Then_ReturnsNull()
+        {
+            MetricsHelper.CalculateMarginAbsolute(100.0, null).ShouldBeNull();
+        }
+
+        [Fact]
+        public void CalculateMarginAbsolute_Given_ValidInputs_Then_ReturnsBillingMinusCost()
+        {
+            MetricsHelper.CalculateMarginAbsolute(80.0, 100.0).ShouldBe(20.0);
+        }
+
+        [Fact]
+        public void CalculateMarginAbsolute_Given_CostExceedsBilling_Then_ReturnsNegative()
+        {
+            MetricsHelper.CalculateMarginAbsolute(120.0, 100.0).ShouldBe(-20.0);
+        }
+
+        [Fact]
+        public void CalculateMarginAbsolute_Given_EqualValues_Then_ReturnsZero()
+        {
+            MetricsHelper.CalculateMarginAbsolute(100.0, 100.0).ShouldBe(0.0);
+        }
+
+        #endregion
+
+        #region CalculateMargin
+
+        [Fact]
+        public void CalculateMargin_Given_BothNull_Then_ReturnsZero()
+        {
+            // abs=null, billing=null => return 0
+            MetricsHelper.CalculateMargin(null, null).ShouldBe(0.0);
+        }
+
+        [Fact]
+        public void CalculateMargin_Given_ZeroCostAndZeroBilling_Then_ReturnsZero()
+        {
+            // abs=0, billing=0 => return 0
+            MetricsHelper.CalculateMargin(0.0, 0.0).ShouldBe(0.0);
+        }
+
+        [Fact]
+        public void CalculateMargin_Given_CostNullAndPositiveBilling_Then_ReturnsOne()
+        {
+            // abs=null, billing=100 (non-null, non-zero) => return 1.0
+            MetricsHelper.CalculateMargin(null, 100.0).ShouldBe(1.0);
+        }
+
+        [Fact]
+        public void CalculateMargin_Given_PositiveCostAndBilling_Then_ReturnsRatio()
+        {
+            // abs = 100 - 80 = 20, billing = 100 => margin = 20/100 = 0.2
+            MetricsHelper.CalculateMargin(80.0, 100.0).ShouldBe(0.2);
+        }
+
+        [Fact]
+        public void CalculateMargin_Given_NonZeroAbsAndZeroBilling_Then_ReturnsNull()
+        {
+            // abs = 0 - 80 = -80 (non-zero), billing = 0 => null
+            MetricsHelper.CalculateMargin(80.0, 0.0).ShouldBeNull();
+        }
+
+        #endregion
+
+        #region CalculateProjectRisks
+
+        [Fact]
+        public void CalculateProjectRisks_Given_EmptyActivities_Then_ReturnsAllOnes()
+        {
+            var result = MetricsHelper.CalculateProjectRisks([], DefaultSeverities());
+            result.Criticality.ShouldBe(1.0);
+            result.Fibonacci.ShouldBe(1.0);
+            result.Activity.ShouldBe(1.0);
+            result.ActivityStdDevCorrection.ShouldBe(1.0);
+            result.GeometricCriticality.ShouldBe(1.0);
+            result.GeometricFibonacci.ShouldBe(1.0);
+            result.GeometricActivity.ShouldBe(1.0);
+        }
+
+        [Fact]
+        public void CalculateProjectRisks_Given_ActivitiesWithNoRisk_Then_ExcludesThemFromCalc()
+        {
+            // Activities with HasNoRisk=true should be excluded
+            var activities = new[]
+            {
+                MakeActivity(0, hasNoRisk: false),
+                MakeActivity(100, hasNoRisk: true),  // excluded
+            };
+            var result = MetricsHelper.CalculateProjectRisks(activities, DefaultSeverities());
+            // Only the critical activity (slack=0) is included
+            result.Criticality.ShouldBe(1.0);
+            result.Activity.ShouldBe(1.0);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
## Summary

Adds a complete release artifact pipeline triggered on version tags (`v*.*.*`). Also fixes the existing CI workflow to set `HUSKY=0` so the pre-commit hook installer doesn't run in CI, and updates it to run on all branches (not just master/develop).

## Release workflow (`.github/workflows/release.yml`)

**Trigger:** `git tag v1.2.3 && git push --tags`

**Matrix build across three runner pools:**

| Runner | Targets |
|--------|---------|
| `windows-latest` | `win-x64`, `win-x86`, `win-arm64` |
| `ubuntu-latest` | `linux-x64`, `linux-arm64` |
| `macos-latest` | `osx-x64`, `osx-arm64` |

**Two artifacts per platform:**
- `projectplandotnet-{version}-{rid}.{zip|tar.gz}` — Desktop GUI
- `zpp-{version}-{rid}.{zip|tar.gz}` — CLI tool

Both are published as `--self-contained --publish-single-file`, matching the existing makefile convention. No .NET runtime required by end users.

**After all builds succeed:** A `create-release` job downloads all artifacts, generates a formatted release notes table, creates a GitHub Release, and uploads all 14 artifacts (7 platforms × 2 artifacts).

**Pre/post-release:** Tags with a `-` in them (e.g. `v1.0.0-beta.1`) are automatically marked as pre-releases.

## CI fix (`ci.yml`)

- Added `HUSKY: 0` environment variable — prevents `dotnet husky install` from running during CI restore (it would fail on a runner with no git user configured)
- Changed trigger from `branches: [master, develop]` to `branches: ['**']` so every branch gets CI on push, not just the two protected ones

## What's not included (scope decisions)

- **MSIX/Windows Store packaging** — the repo has `.wapproj` files for MSIX, but they require a Windows SDK signing certificate. The thumbprint in the wapproj (`97B75D49...`) is the maintainer's cert and cannot be reproduced in CI without the private key. MSIX builds should be done locally or via a secrets-enabled workflow the maintainer sets up.
- **Code signing for macOS/Linux** — omitted for the same reason. The binaries are unsigned; macOS Gatekeeper will prompt on first run.
- **Homebrew/apt/Chocolatey packaging** — out of scope for this PR but natural next step.