### PR TITLE
Round 1: Decompose CoreViewModel into focused computation services

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,35 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = crlf
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.cs]
+indent_size = 4
+
+# Naming conventions matching existing codebase (m_ prefix for private fields)
+dotnet_naming_rule.private_fields_should_have_prefix.severity = suggestion
+dotnet_naming_rule.private_fields_should_have_prefix.symbols = private_fields
+dotnet_naming_rule.private_fields_should_have_prefix.style = prefix_m_underscore
+
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+
+dotnet_naming_style.prefix_m_underscore.required_prefix = m_
+dotnet_naming_style.prefix_m_underscore.capitalization = camel_case
+
+[*.{axaml,xaml}]
+indent_size = 2
+
+[*.{csproj,props,targets}]
+indent_size = 2
+
+[*.{json,yml,yaml}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [ master, develop ]
+  pull_request:
+    branches: [ master, develop ]
+
+jobs:
+  build-and-test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.x'
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore --configuration Release
+
+      - name: Test
+        run: dotnet test --no-build --configuration Release --verbosity normal

--- a/.husky/task-runner.json
+++ b/.husky/task-runner.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://alirezanet.github.io/Husky.Net/schema.json",
+  "tasks": [
+    {
+      "name": "dotnet-format-style",
+      "command": "dotnet",
+      "args": [
+        "format",
+        "style",
+        "--verify-no-changes",
+        "--verbosity",
+        "quiet"
+      ],
+      "include": [
+        "**/*.cs",
+        "**/*.axaml"
+      ]
+    },
+    {
+      "name": "dotnet-format-analyzers",
+      "command": "dotnet",
+      "args": [
+        "format",
+        "analyzers",
+        "--verify-no-changes",
+        "--verbosity",
+        "quiet"
+      ],
+      "include": [
+        "**/*.cs"
+      ]
+    },
+    {
+      "name": "dotnet-build",
+      "command": "dotnet",
+      "args": [
+        "build",
+        "src/Zametek.ProjectPlan/Zametek.ProjectPlan.csproj",
+        "--no-restore",
+        "--configuration",
+        "Debug",
+        "--verbosity",
+        "quiet"
+      ],
+      "include": [
+        "**/*.cs",
+        "**/*.csproj",
+        "**/*.props"
+      ]
+    },
+    {
+      "name": "dotnet-test",
+      "command": "dotnet",
+      "args": [
+        "test",
+        "--no-build",
+        "--configuration",
+        "Debug",
+        "--verbosity",
+        "quiet"
+      ],
+      "include": [
+        "**/*.cs"
+      ]
+    }
+  ]
+}

--- a/src/Zametek.Contract.ProjectPlan/ICoreViewModel.cs
+++ b/src/Zametek.Contract.ProjectPlan/ICoreViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.ObjectModel;
+using System.Collections.ObjectModel;
 using Zametek.Common.ProjectPlan;
 using Zametek.Maths.Graphs;
 

--- a/src/Zametek.Contract.ProjectPlan/Miscellaneous/IGraphCompilationService.cs
+++ b/src/Zametek.Contract.ProjectPlan/Miscellaneous/IGraphCompilationService.cs
@@ -1,0 +1,17 @@
+using Zametek.Common.ProjectPlan;
+using Zametek.Maths.Graphs;
+
+namespace Zametek.Contract.ProjectPlan
+{
+    public interface IGraphCompilationService
+    {
+        ArrowGraphModel BuildArrowGraph(
+            IEnumerable<IDependentActivity> dependentActivities);
+
+        VertexGraphModel BuildVertexGraph(
+            IEnumerable<IDependentActivity> dependentActivities,
+            IEnumerable<ResourceModel> resources,
+            bool resourcesAreDisabled,
+            IEnumerable<WorkStreamModel> workStreams);
+    }
+}

--- a/src/Zametek.Contract.ProjectPlan/Miscellaneous/IMetricCalculationService.cs
+++ b/src/Zametek.Contract.ProjectPlan/Miscellaneous/IMetricCalculationService.cs
@@ -1,0 +1,25 @@
+using Zametek.Common.ProjectPlan;
+using Zametek.Maths.Graphs;
+
+namespace Zametek.Contract.ProjectPlan
+{
+    public interface IMetricCalculationService
+    {
+        NetworkModel BuildNetworkMetrics(
+            IGraphCompilation<int, int, int, IDependentActivity> graphCompilation,
+            bool hasCompilationErrors,
+            DateTimeOffset projectStart,
+            int? startTime,
+            int? finishTime);
+
+        RisksModel BuildRiskMetrics(
+            IGraphCompilation<int, int, int, IDependentActivity> graphCompilation,
+            bool hasCompilationErrors,
+            IEnumerable<ActivitySeverityModel> activitySeverities);
+
+        (CostsModel costs, BillingsModel billings, MarginsModel margins, EffortsModel efforts)
+            BuildFinancialMetrics(
+            ResourceSeriesSetModel resourceSeriesSet,
+            bool hasCompilationErrors);
+    }
+}

--- a/src/Zametek.Contract.ProjectPlan/Miscellaneous/IResourceSchedulingService.cs
+++ b/src/Zametek.Contract.ProjectPlan/Miscellaneous/IResourceSchedulingService.cs
@@ -1,0 +1,17 @@
+using Zametek.Common.ProjectPlan;
+using Zametek.Maths.Graphs;
+
+namespace Zametek.Contract.ProjectPlan
+{
+    public interface IResourceSchedulingService
+    {
+        ResourceSeriesSetModel BuildResourceSeriesSet(
+            IGraphCompilation<int, int, int, IDependentActivity> graphCompilation,
+            ResourceSettingsModel resourceSettings);
+
+        TrackingSeriesSetModel BuildTrackingSeriesSet(
+            IEnumerable<ActivityModel> activities,
+            ResourceSettingsModel resourceSettings,
+            bool hasResources);
+    }
+}

--- a/src/Zametek.Data.ProjectPlan/Versions.cs
+++ b/src/Zametek.Data.ProjectPlan/Versions.cs
@@ -18,6 +18,6 @@
         public const string v0_6_0 = @"v0.6.0";
 
         public const string ProjectLatest = v0_6_0;
-        public const string AppSettingsLatest = v0_4_4;
+        public const string AppSettingsLatest = v0_6_0;
     }
 }

--- a/src/Zametek.ProjectPlan/App.axaml.cs
+++ b/src/Zametek.ProjectPlan/App.axaml.cs
@@ -28,124 +28,135 @@ namespace Zametek.ProjectPlan
 
         public override async void OnFrameworkInitializationCompleted()
         {
-            if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktopLifetime)
+            try
             {
-                var splashView = new SplashView();
-                var splashViewModel = new SplashViewModel();
-
-                splashView.DataContext = splashViewModel;
-
-                desktopLifetime.MainWindow = splashView;
-
-                splashView.Show();
-
-                string? input = null;
-
-                desktopLifetime.Startup += (sender, args) =>
+                if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktopLifetime)
                 {
-                    input = args?.Args?.FirstOrDefault();
-                };
+                    var splashView = new SplashView();
+                    var splashViewModel = new SplashViewModel();
 
-                try
-                {
-                    await Task.Factory.StartNew(() =>
+                    splashView.DataContext = splashViewModel;
+
+                    desktopLifetime.MainWindow = splashView;
+
+                    splashView.Show();
+
+                    string? input = null;
+
+                    desktopLifetime.Startup += (sender, args) =>
                     {
-                        Bootstrapper.RegisterIOC();
-                    }, cancellationToken: splashViewModel.CancellationToken);
-
-                    ISettingService settingService = GetRequiredService<ISettingService>();
-                    string selectedTheme = settingService.SelectedTheme;
-
-                    IMainViewModel mainViewModel = GetRequiredService<IMainViewModel>();
-
-                    DataContext = mainViewModel;
-
-                    desktopLifetime.Exit += (a, b) =>
-                    {
-                        mainViewModel.CloseLayout();
+                        input = args?.Args?.FirstOrDefault();
                     };
 
-                    MainView mainView = new()
+                    try
                     {
-                        DataContext = mainViewModel,
-                        InitialTheme = selectedTheme
-                    };
-
-                    IDialogService dialogService = GetRequiredService<IDialogService>();
-                    dialogService.Parent = mainView;
-
-                    // Cancelling the window closing does not work when using an async handler,
-                    // and trying to force Wait on the return dialog freezes the UI thread.
-                    // This solution is the hack below, where CancelClose automatically cancels
-                    // the closing event first, then CheckClose checks to see if the project
-                    // has updates.
-                    // If there are no updates, CheckClose removes all handlers and forces a new close.
-                    // If there are updates, then the dialog requests permission to proceed.
-                    // If yes, then it continues as before. If no, then CheckClose removes itself
-                    // and then adds back all the handlers in the correct order (i.e. the same
-                    // initial state) and then immediately returns.
-                    void CancelClose(object? sender, CancelEventArgs args)
-                    {
-                        args.Cancel = true;
-                    }
-
-                    async void CheckClose(object? sender, CancelEventArgs args)
-                    {
-                        mainView.Closing -= CancelClose;
-
-                        if (mainViewModel.ProjectHasChanges)
+                        await Task.Factory.StartNew(() =>
                         {
-                            bool wishToClose = await dialogService.ShowConfirmationAsync(
-                                Resource.ProjectPlan.Titles.Title_ProjectUnsavedChanges,
-                                string.Empty,
-                                Resource.ProjectPlan.Messages.Message_ProjectUnsavedChanges);
+                            Bootstrapper.RegisterIOC();
+                        }, cancellationToken: splashViewModel.CancellationToken);
 
-                            if (!wishToClose)
-                            {
-                                // Clearing the rest of the handlers and then adding
-                                // them back in the correct order.
-                                mainView.Closing -= CheckClose;
-                                mainView.Closing += CancelClose;
-                                mainView.Closing += CheckClose;
-                                return;
-                            }
+                        ISettingService settingService = GetRequiredService<ISettingService>();
+                        string selectedTheme = settingService.SelectedTheme;
+
+                        IMainViewModel mainViewModel = GetRequiredService<IMainViewModel>();
+
+                        DataContext = mainViewModel;
+
+                        desktopLifetime.Exit += (a, b) =>
+                        {
+                            mainViewModel.CloseLayout();
+                        };
+
+                        MainView mainView = new()
+                        {
+                            DataContext = mainViewModel,
+                            InitialTheme = selectedTheme
+                        };
+
+                        IDialogService dialogService = GetRequiredService<IDialogService>();
+                        dialogService.Parent = mainView;
+
+                        // Cancelling the window closing does not work when using an async handler,
+                        // and trying to force Wait on the return dialog freezes the UI thread.
+                        // This solution is the hack below, where CancelClose automatically cancels
+                        // the closing event first, then CheckClose checks to see if the project
+                        // has updates.
+                        // If there are no updates, CheckClose removes all handlers and forces a new close.
+                        // If there are updates, then the dialog requests permission to proceed.
+                        // If yes, then it continues as before. If no, then CheckClose removes itself
+                        // and then adds back all the handlers in the correct order (i.e. the same
+                        // initial state) and then immediately returns.
+                        void CancelClose(object? sender, CancelEventArgs args)
+                        {
+                            args.Cancel = true;
                         }
 
-                        mainView.Closing -= CheckClose;
-                        mainViewModel.CloseLayout();
-                        mainView.Close();
+                        async void CheckClose(object? sender, CancelEventArgs args)
+                        {
+                            mainView.Closing -= CancelClose;
+
+                            if (mainViewModel.ProjectHasChanges)
+                            {
+                                bool wishToClose = await dialogService.ShowConfirmationAsync(
+                                    Resource.ProjectPlan.Titles.Title_ProjectUnsavedChanges,
+                                    string.Empty,
+                                    Resource.ProjectPlan.Messages.Message_ProjectUnsavedChanges);
+
+                                if (!wishToClose)
+                                {
+                                    // Clearing the rest of the handlers and then adding
+                                    // them back in the correct order.
+                                    mainView.Closing -= CheckClose;
+                                    mainView.Closing += CancelClose;
+                                    mainView.Closing += CheckClose;
+                                    return;
+                                }
+                            }
+
+                            mainView.Closing -= CheckClose;
+                            mainViewModel.CloseLayout();
+                            mainView.Close();
+                        }
+
+                        mainView.Closing += CancelClose;
+                        mainView.Closing += CheckClose;
+
+                        desktopLifetime.MainWindow = mainView;
+
+                        mainView.Show();
+
+                        if (input is not null)
+                        {
+                            await mainViewModel.OpenProjectFileAsync(input);
+                        }
+
+                        splashView.Close();
                     }
-
-                    mainView.Closing += CancelClose;
-                    mainView.Closing += CheckClose;
-
-                    desktopLifetime.MainWindow = mainView;
-
-                    mainView.Show();
-
-                    if (input is not null)
+                    catch (TaskCanceledException)
                     {
-                        await mainViewModel.OpenProjectFileAsync(input);
+                        splashView.Close();
+                        return;
                     }
-
-                    splashView.Close();
                 }
-                catch (TaskCanceledException)
+                //else if (ApplicationLifetime is ISingleViewApplicationLifetime singleViewLifetime)
+                //{
+                //    var mainView = new MainView()
+                //    {
+                //        DataContext = mainViewModel
+                //    };
+
+                //    singleViewLifetime.MainView = mainView;
+                //}
+                base.OnFrameworkInitializationCompleted();
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Fatal startup error: {ex}");
+                if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
                 {
-                    splashView.Close();
-                    return;
+                    desktop.Shutdown(1);
                 }
             }
-            //else if (ApplicationLifetime is ISingleViewApplicationLifetime singleViewLifetime)
-            //{
-            //    var mainView = new MainView()
-            //    {
-            //        DataContext = mainViewModel
-            //    };
-
-            //    singleViewLifetime.MainView = mainView;
-            //}
-            base.OnFrameworkInitializationCompleted();
 
 #if DEBUG
             this.AttachDevTools();

--- a/src/Zametek.ProjectPlan/Bootstrapper.cs
+++ b/src/Zametek.ProjectPlan/Bootstrapper.cs
@@ -1,4 +1,4 @@
-﻿using Autofac;
+using Autofac;
 using Autofac.Extensions.DependencyInjection;
 using Dock.Model.Core;
 using ReactiveUI;
@@ -66,6 +66,18 @@ namespace Zametek.ProjectPlan
             builder.RegisterType<DialogService>()
                 .As<IDialogService>()
                 .As<DialogService>()
+                .SingleInstance();
+            builder.RegisterType<GraphCompilationService>()
+                .As<IGraphCompilationService>()
+                .As<GraphCompilationService>()
+                .SingleInstance();
+            builder.RegisterType<ResourceSchedulingService>()
+                .As<IResourceSchedulingService>()
+                .As<ResourceSchedulingService>()
+                .SingleInstance();
+            builder.RegisterType<MetricCalculationService>()
+                .As<IMetricCalculationService>()
+                .As<MetricCalculationService>()
                 .SingleInstance();
             builder.RegisterType<CoreViewModel>()
                 .As<ICoreViewModel>()

--- a/src/Zametek.View.ProjectPlan/Miscellaneous/DataGridManager.cs
+++ b/src/Zametek.View.ProjectPlan/Miscellaneous/DataGridManager.cs
@@ -83,12 +83,8 @@ namespace Zametek.View.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 ResetActions.Clear();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/ActivityManagement/ActivityTrackerSetViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ActivityManagement/ActivityTrackerSetViewModel.cs
@@ -394,12 +394,8 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 m_DaysSub?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/ActivityManagement/ManagedActivityViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ActivityManagement/ManagedActivityViewModel.cs
@@ -980,16 +980,12 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 TrackerSet.Dispose();
                 m_ShowDates?.Dispose();
                 m_HasResources?.Dispose();
                 m_HasWorkStreams?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/CoreViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/CoreViewModel.cs
@@ -176,19 +176,22 @@ namespace Zametek.ViewModel.ProjectPlan
                 .ObserveOn(RxApp.TaskpoolScheduler)
                 .Subscribe(changeSet =>
                 {
-                    if (!IsBusy && (changeSet.Replaced + changeSet.Adds) > 0)
+                    if ((changeSet.Replaced + changeSet.Adds) > 0)
                     {
                         lock (m_Lock)
                         {
-                            if (AutoCompile)
+                            if (!IsBusy)
                             {
-                                IsReadyToReviseTrackers = ReadyToRevise.Yes;
-                                IsReadyToCompile = ReadyToCompile.Yes;
-                            }
-                            else
-                            {
-                                IsReadyToReviseTrackers = ReadyToRevise.No;
-                                IsReadyToCompile = ReadyToCompile.No;
+                                if (AutoCompile)
+                                {
+                                    IsReadyToReviseTrackers = ReadyToRevise.Yes;
+                                    IsReadyToCompile = ReadyToCompile.Yes;
+                                }
+                                else
+                                {
+                                    IsReadyToReviseTrackers = ReadyToRevise.No;
+                                    IsReadyToCompile = ReadyToCompile.No;
+                                }
                             }
                         }
                     }
@@ -199,16 +202,12 @@ namespace Zametek.ViewModel.ProjectPlan
                 .ObserveOn(Scheduler.CurrentThread)
                 .Subscribe(isReady =>
                 {
-                    if (isReady == ReadyToCompile.Yes
-                        && !IsBusy)
+                    lock (m_Lock)
                     {
-                        lock (m_Lock)
+                        if (isReady == ReadyToCompile.Yes
+                            && !IsBusy)
                         {
-                            if (isReady == ReadyToCompile.Yes
-                                && !IsBusy)
-                            {
-                                RunAutoCompile();
-                            }
+                            RunAutoCompile();
                         }
                     }
                 });
@@ -2635,7 +2634,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_ProjectFinish?.Dispose();
                 m_HasActivities?.Dispose();
@@ -2646,9 +2644,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_Activities?.Dispose();
                 m_DisplaySettingsViewModel?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/CoreViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/CoreViewModel.cs
@@ -29,6 +29,9 @@ namespace Zametek.ViewModel.ProjectPlan
         private readonly ISettingService m_SettingService;
         private readonly IDateTimeCalculator m_DateTimeCalculator;
         private readonly ProjectPlanMapper m_Mapper;
+        private readonly IGraphCompilationService m_GraphCompilationService;
+        private readonly IResourceSchedulingService m_ResourceSchedulingService;
+        private readonly IMetricCalculationService m_MetricCalculationService;
 
         private readonly IDisposable? m_ReadOnlyActivitiesSub;
         private readonly IDisposable? m_OrderableActivitiesSub;
@@ -51,13 +54,19 @@ namespace Zametek.ViewModel.ProjectPlan
             IProjectScenarioFileExport projectScenarioFileExport,
             ISettingService settingService,
             IDateTimeCalculator dateTimeCalculator,
-            ProjectPlanMapper mapper)
+            ProjectPlanMapper mapper,
+            IGraphCompilationService graphCompilationService,
+            IResourceSchedulingService resourceSchedulingService,
+            IMetricCalculationService metricCalculationService)
         {
             ArgumentNullException.ThrowIfNull(projectScenarioFileImport);
             ArgumentNullException.ThrowIfNull(projectScenarioFileExport);
             ArgumentNullException.ThrowIfNull(settingService);
             ArgumentNullException.ThrowIfNull(dateTimeCalculator);
             ArgumentNullException.ThrowIfNull(mapper);
+            ArgumentNullException.ThrowIfNull(graphCompilationService);
+            ArgumentNullException.ThrowIfNull(resourceSchedulingService);
+            ArgumentNullException.ThrowIfNull(metricCalculationService);
             m_Lock = new();
             m_TrackIsProjectScenarioUpdated = true;
             m_TrackHasStaleOutputs = true;
@@ -71,6 +80,9 @@ namespace Zametek.ViewModel.ProjectPlan
                 SetIsProjectScenarioUpdated,
                 () => IsReadyToCompile = ReadyToCompile.Yes);
             m_Mapper = mapper;
+            m_GraphCompilationService = graphCompilationService;
+            m_ResourceSchedulingService = resourceSchedulingService;
+            m_MetricCalculationService = metricCalculationService;
 
             m_IsReadyToCompile = ReadyToCompile.No;
             m_IsBusy = false;
@@ -258,742 +270,6 @@ namespace Zametek.ViewModel.ProjectPlan
         #endregion
 
         #region Private Methods
-
-        private static ResourceSeriesSetModel CalculateResourceSeriesSet(
-            IEnumerable<ResourceScheduleModel> resourceSchedules,
-            ResourceSettingsModel resourceSettings)
-        {
-            ArgumentNullException.ThrowIfNull(resourceSchedules);
-            ArgumentNullException.ThrowIfNull(resourceSettings);
-            var resourceSeriesSet = new ResourceSeriesSetModel();
-
-            IList<ResourceModel> resources = resourceSettings.Resources;
-            double defaultUnitCost = resourceSettings.DefaultUnitCost;
-            double defaultUnitBilling = resourceSettings.DefaultUnitBilling;
-
-            var resourceLookup = resources.ToDictionary(x => x.Id);
-
-            if (resourceSchedules.Any())
-            {
-                Dictionary<int, ColorFormatModel> colorFormatLookup = resources.ToDictionary(x => x.Id, x => x.ColorFormat);
-                int finishTime = resourceSchedules.Select(x => x.FinishTime).DefaultIfEmpty().Max();
-                int spareResourceCount = 1;
-                //var resourceScheduleLookup = resourceSchedules.ToDictionary(x => x.Resource.Id);
-
-                // Scheduled resource series.
-
-                // These are the series that apply to None and Direct resources only.
-                var scheduledSeriesSet = new List<ResourceSeriesModel>();
-
-                IEnumerable<ResourceScheduleModel> noneAndDirectResourceSchedules = resourceSchedules
-                    .Where(x => x.Resource.InterActivityAllocationType == InterActivityAllocationType.None || x.Resource.InterActivityAllocationType == InterActivityAllocationType.Direct);
-
-                // Make 'random' colors seem consistent.
-                ColorHelper.PresetReset();
-
-                foreach (ResourceScheduleModel scheduledResourceSchedule in noneAndDirectResourceSchedules)
-                {
-                    if (scheduledResourceSchedule.ScheduledActivities.Count > 0)
-                    {
-                        var stringBuilder = new StringBuilder();
-                        InterActivityAllocationType interActivityAllocationType = InterActivityAllocationType.None;
-                        ColorFormatModel color = ColorHelper.Preset();
-                        double unitCost = defaultUnitCost;
-                        double unitBilling = defaultUnitBilling;
-                        double fixedCost = 0.0;
-                        double fixedBilling = 0.0;
-                        int displayOrder = 0;
-
-                        if (scheduledResourceSchedule.Resource.Id != default
-                            && resourceLookup.TryGetValue(scheduledResourceSchedule.Resource.Id, out ResourceModel? resource))
-                        {
-                            int resourceId = resource.Id;
-                            interActivityAllocationType = resource.InterActivityAllocationType;
-                            if (string.IsNullOrWhiteSpace(resource.Name))
-                            {
-                                stringBuilder.Append($@"{Resource.ProjectPlan.Labels.Label_Resource} {resourceId}");
-                            }
-                            else
-                            {
-                                stringBuilder.Append($@"{resource.Name}");
-                            }
-
-                            if (colorFormatLookup.TryGetValue(resourceId, out ColorFormatModel? colorFormat))
-                            {
-                                color = colorFormat;
-                            }
-
-                            unitCost = resource.UnitCost;
-                            unitBilling = resource.UnitBilling;
-                            fixedCost = resource.FixedCost;
-                            fixedBilling = resource.FixedBilling;
-                            displayOrder = resource.DisplayOrder;
-                        }
-                        else
-                        {
-                            stringBuilder.Append($@"{Resource.ProjectPlan.Labels.Label_Resource} {spareResourceCount}");
-                            spareResourceCount++;
-                        }
-
-                        var series = new ResourceSeriesModel
-                        {
-                            Title = stringBuilder.ToString(),
-                            ColorFormat = color,
-                            UnitCost = unitCost,
-                            UnitBilling = unitBilling,
-                            FixedCost = fixedCost,
-                            FixedBilling = fixedBilling,
-                            DisplayOrder = displayOrder,
-                            ResourceSchedule = scheduledResourceSchedule,
-                            InterActivityAllocationType = interActivityAllocationType,
-                        };
-
-                        scheduledSeriesSet.Add(series);
-                    }
-                }
-
-
-                // Unscheduled resource series.
-
-                // These are series the that apply to Indirect resources, and also
-                // None and Direct resources that have roll-off periods.
-                var unscheduledSeriesSet = new List<ResourceSeriesModel>();
-                var unscheduledResourceSeriesLookup = new Dictionary<int, ResourceSeriesModel>();
-
-                IEnumerable<ResourceScheduleModel> indirectResourceSchedules = resourceSchedules
-                    .Where(x => x.Resource.InterActivityAllocationType == InterActivityAllocationType.Indirect);
-
-                foreach (ResourceScheduleModel resourceSchedule in indirectResourceSchedules)
-                {
-                    if (resourceLookup.TryGetValue(resourceSchedule.Resource.Id, out ResourceModel? resource))
-                    {
-                        int resourceId = resource.Id;
-                        var stringBuilder = new StringBuilder();
-
-                        if (string.IsNullOrWhiteSpace(resource.Name))
-                        {
-                            stringBuilder.Append($@"{Resource.ProjectPlan.Labels.Label_Resource} {resourceId}");
-                        }
-                        else
-                        {
-                            stringBuilder.Append($@"{resource.Name}");
-                        }
-
-                        string title = stringBuilder.ToString();
-
-                        var series = new ResourceSeriesModel
-                        {
-                            Title = title,
-                            InterActivityAllocationType = resource.InterActivityAllocationType,
-                            ResourceSchedule = resourceSchedule,
-                            ColorFormat = resource.ColorFormat != null ? resource.ColorFormat.CloneObject() : ColorHelper.Preset(),
-                            UnitCost = resource.UnitCost,
-                            UnitBilling = resource.UnitBilling,
-                            FixedCost = resource.FixedCost,
-                            FixedBilling = resource.FixedBilling,
-                            DisplayOrder = resource.DisplayOrder,
-                        };
-
-                        unscheduledSeriesSet.Add(series);
-                        unscheduledResourceSeriesLookup.Add(resourceId, series);
-                    }
-                }
-
-
-                // Combined resource series.
-                // The intersection of the scheduled and unscheduled series.
-                List<ResourceSeriesModel> combinedSeriesSet = scheduledSeriesSet.CloneObject();
-                var unscheduledSeriesAlreadyIncluded = new HashSet<int>();
-
-                foreach (ResourceSeriesModel combinedSeries in combinedSeriesSet)
-                {
-                    IList<bool> combinedActivityAllocations = [.. Enumerable.Repeat(false, finishTime)];
-                    IList<bool> combinedCostAllocations = [.. Enumerable.Repeat(false, finishTime)];
-                    IList<bool> combinedBillingAllocations = [.. Enumerable.Repeat(false, finishTime)];
-                    IList<bool> combinedEffortAllocations = [.. Enumerable.Repeat(false, finishTime)];
-
-                    if (combinedSeries.ResourceSchedule.Resource.Id != default)
-                    {
-                        int resourceId = combinedSeries.ResourceSchedule.Resource.Id;
-                        if (unscheduledResourceSeriesLookup.TryGetValue(resourceId, out ResourceSeriesModel? unscheduledResourceSeries))
-                        {
-                            combinedActivityAllocations = [.. combinedSeries.ResourceSchedule.ActivityAllocation.Zip(unscheduledResourceSeries.ResourceSchedule.ActivityAllocation, (x, y) => x || y)];
-                            combinedCostAllocations = [.. combinedSeries.ResourceSchedule.CostAllocation.Zip(unscheduledResourceSeries.ResourceSchedule.CostAllocation, (x, y) => x || y)];
-                            combinedBillingAllocations = [.. combinedSeries.ResourceSchedule.BillingAllocation.Zip(unscheduledResourceSeries.ResourceSchedule.BillingAllocation, (x, y) => x || y)];
-                            combinedEffortAllocations = [.. combinedSeries.ResourceSchedule.EffortAllocation.Zip(unscheduledResourceSeries.ResourceSchedule.EffortAllocation, (x, y) => x || y)];
-                            unscheduledSeriesAlreadyIncluded.Add(resourceId);
-                        }
-                        else
-                        {
-                            combinedActivityAllocations = [.. combinedSeries.ResourceSchedule.ActivityAllocation];
-                            combinedCostAllocations = [.. combinedSeries.ResourceSchedule.CostAllocation];
-                            combinedBillingAllocations = [.. combinedSeries.ResourceSchedule.BillingAllocation];
-                            combinedEffortAllocations = [.. combinedSeries.ResourceSchedule.EffortAllocation];
-                        }
-                    }
-                    else
-                    {
-                        combinedActivityAllocations = [.. combinedSeries.ResourceSchedule.ActivityAllocation];
-                        combinedCostAllocations = [.. combinedSeries.ResourceSchedule.CostAllocation];
-                        combinedBillingAllocations = [.. combinedSeries.ResourceSchedule.BillingAllocation];
-                        combinedEffortAllocations = [.. combinedSeries.ResourceSchedule.EffortAllocation];
-                    }
-
-                    combinedSeries.ResourceSchedule.ActivityAllocation.Clear();
-                    combinedSeries.ResourceSchedule.ActivityAllocation.AddRange(combinedActivityAllocations);
-                    combinedSeries.ResourceSchedule.CostAllocation.Clear();
-                    combinedSeries.ResourceSchedule.CostAllocation.AddRange(combinedCostAllocations);
-                    combinedSeries.ResourceSchedule.BillingAllocation.Clear();
-                    combinedSeries.ResourceSchedule.BillingAllocation.AddRange(combinedBillingAllocations);
-                    combinedSeries.ResourceSchedule.EffortAllocation.Clear();
-                    combinedSeries.ResourceSchedule.EffortAllocation.AddRange(combinedEffortAllocations);
-                }
-
-
-                // Finally, add the unscheduled series that have not already been included above.
-
-                // Prepend so that they might be displayed first after sorting.
-                List<ResourceSeriesModel> combined = [.. unscheduledSeriesSet.Where(x => !unscheduledSeriesAlreadyIncluded.Contains(x.ResourceSchedule.Resource.Id))];
-
-                combined.AddRange(combinedSeriesSet);
-
-                resourceSeriesSet.ResourceSchedules.AddRange(resourceSchedules);
-                resourceSeriesSet.Scheduled.AddRange(scheduledSeriesSet);
-                resourceSeriesSet.Unscheduled.AddRange(unscheduledSeriesSet);
-                resourceSeriesSet.Combined.AddRange(combined.OrderBy(x => x.DisplayOrder));
-            }
-
-            return resourceSeriesSet;
-        }
-
-        private static TrackingSeriesSetModel CalculateTrackingSeriesSet(
-            IEnumerable<ActivityModel> activities,
-            ResourceSettingsModel resourceSettings,
-            bool hasResources)
-        {
-            ArgumentNullException.ThrowIfNull(activities);
-            ArgumentNullException.ThrowIfNull(resourceSettings);
-
-            List<ResourceModel> resources = resourceSettings.Resources;
-
-            IList<ActivityModel> orderedActivities = [.. activities
-                .Where(x => !x.HasNoEffort)
-                .Select(x => x.CloneObject())
-                .OrderBy(x => x.EarliestFinishTime.GetValueOrDefault())
-                .ThenBy(x => x.EarliestStartTime.GetValueOrDefault())];
-
-            // Plan.
-            List<TrackingPointModel> planPointSeries = [];
-
-            // Progress.
-            List<TrackingPointModel> progressPointSeries = [];
-
-            // Effort.
-            List<TrackingPointModel> effortPointSeries = [];
-
-            // Plan Projection.
-            List<TrackingPointModel> planProjectionPointSeries = [];
-
-            // Progress Projection.
-            List<TrackingPointModel> progressProjectionPointSeries = [];
-
-            // Effort Projection.
-            List<TrackingPointModel> effortProjectionPointSeries = [];
-
-            var trackingSeriesSet = new TrackingSeriesSetModel
-            {
-                Plan = planPointSeries,
-                PlanProjection = planProjectionPointSeries,
-                Progress = progressPointSeries,
-                ProgressProjection = progressProjectionPointSeries,
-                Effort = effortPointSeries,
-                EffortProjection = effortProjectionPointSeries
-            };
-
-            if (!orderedActivities.Any())
-            {
-                return trackingSeriesSet;
-            }
-
-            double totalWorkingTime = Convert.ToDouble(orderedActivities.Sum(s => s.AllocatedToResources.Count * s.Duration));
-
-            // Find the anticipated end time according to the design plan.
-            int endTime = 0;
-
-            if (orderedActivities.Count > 0)
-            {
-                endTime = orderedActivities.Last().EarliestFinishTime.GetValueOrDefault();
-            }
-
-            // Always need at least one to mark the start.
-            planPointSeries.Add(new TrackingPointModel());
-
-            // Only bother calculating the plan is there is an end time.
-            if (endTime > 0)
-            {
-                // Plan.
-
-                // Build out a matrix of how we would expect progress to proceed
-                // for each activity if conditions were predictable.
-
-                var progressTimeline = new List<Dictionary<int, TrackingPointModel>>();
-
-                for (int i = 0; i < endTime; i++)
-                {
-                    progressTimeline.Add([]);
-                }
-
-                // Cycle through each activity and add its individual progress to the matrix.
-                foreach (ActivityModel activity in orderedActivities)
-                {
-                    int startTime = activity.EarliestStartTime.GetValueOrDefault();
-                    int finishTime = activity.EarliestFinishTime.GetValueOrDefault();
-
-                    // Check finish time < endtime
-                    ArgumentOutOfRangeException.ThrowIfGreaterThan(finishTime, endTime);
-
-                    // Do not bother if these values are not valid.
-                    if (finishTime > startTime)
-                    {
-                        double plannedProgress = 0.0;
-
-                        // Cycle through each time index.
-                        for (int timeIndex = 0; timeIndex < endTime; timeIndex++)
-                        {
-                            // Only need to increment during the period of activity.
-                            if (timeIndex >= startTime
-                                && timeIndex < finishTime)
-                            {
-                                plannedProgress++;
-                            }
-
-                            Dictionary<int, TrackingPointModel> trackingPointLookup = progressTimeline[timeIndex];
-
-                            if (!trackingPointLookup.TryGetValue(activity.Id, out TrackingPointModel? trackingPointModel))
-                            {
-                                trackingPointModel = new TrackingPointModel
-                                {
-                                    Time = timeIndex,
-                                    ActivityId = activity.Id,
-                                    ActivityName = activity.Name,
-                                    Value = plannedProgress,
-                                    ValuePercentage = 0.0,
-                                };
-                                trackingPointLookup.Add(activity.Id, trackingPointModel);
-                            }
-                            else
-                            {
-                                trackingPointModel.Value = plannedProgress;
-                                trackingPointModel.ValuePercentage = 0.0;
-                            }
-                        }
-                    }
-                }
-
-                // At this stage we need to cycle across all the time period and
-                // work out how the time spent on each activity has contributed to
-                // overall progress.
-
-                Dictionary<int, ActivityModel> activityLookup = orderedActivities.ToDictionary(activity => activity.Id);
-
-                // Cycle through each time index.
-                for (int timeIndex = 0; timeIndex < endTime; timeIndex++)
-                {
-                    double runningTotalSpent = 0.0;
-                    Dictionary<int, TrackingPointModel> trackingPointLookup = progressTimeline[timeIndex];
-
-                    // Now cycle across each activity at this time index.
-                    foreach (KeyValuePair<int, TrackingPointModel> trackingPoint in trackingPointLookup)
-                    {
-                        int activityId = trackingPoint.Key;
-                        double portionOfActivityDuration = trackingPoint.Value.Value;
-
-                        if (activityLookup.TryGetValue(activityId, out ActivityModel? activity))
-                        {
-                            // Remember to count the time spent for each resource used.
-                            runningTotalSpent += activity.AllocatedToResources.Count * portionOfActivityDuration;
-                        }
-                    }
-
-                    // Now record the overall progress for the project and mark it out for the activities
-                    // that are being worked on at this moment in time.
-
-                    int time = timeIndex + 1; // Since the equivalent finish time would be the next day.
-
-                    foreach (KeyValuePair<int, TrackingPointModel> trackingPoint in trackingPointLookup)
-                    {
-                        int activityId = trackingPoint.Key;
-
-                        double percentage = totalWorkingTime == 0 ? 0.0 : 100.0 * runningTotalSpent / totalWorkingTime;
-
-                        if (activityLookup.TryGetValue(activityId, out ActivityModel? activity))
-                        {
-                            int startTime = activity.EarliestStartTime.GetValueOrDefault();
-                            int finishTime = activity.EarliestFinishTime.GetValueOrDefault();
-
-                            if (timeIndex >= startTime
-                                && timeIndex < finishTime)
-                            {
-                                planPointSeries.Add(new TrackingPointModel
-                                {
-                                    Time = time,
-                                    ActivityId = activityId,
-                                    ActivityName = activity.Name,
-                                    Value = runningTotalSpent,
-                                    ValuePercentage = percentage
-                                });
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Find the new end time based on the tracking data.
-
-            int progressTime = activities
-                .SelectMany(x => x.Trackers)
-                .DefaultIfEmpty()
-                .Max(x => x?.Time ?? 0);
-
-            if (progressTime > endTime)
-            {
-                endTime = progressTime;
-            }
-
-            int effortTime = resources
-                .SelectMany(x => x.Trackers)
-                .DefaultIfEmpty()
-                .Max(x => x?.Time ?? 0);
-
-            if (effortTime > endTime)
-            {
-                endTime = effortTime;
-            }
-
-            // Only bother calculating the progress and effort is there is an end time.
-            if (endTime > 0)
-            {
-                {
-                    // Progress.
-                    progressPointSeries.Add(new TrackingPointModel());
-
-                    // Preprocess the activity trackers so they can be looked up
-                    // quickly according to the time.
-
-                    Dictionary<int, (ActivityModel activity, Dictionary<int, ActivityTrackerModel> activityTrackerLookup)> activityBehaviourLookup =
-                        orderedActivities.ToDictionary(
-                            activity => activity.Id,
-                            activity =>
-                            {
-                                int activityId = activity.Id;
-                                Dictionary<int, ActivityTrackerModel> activityTrackerLookup = [];
-
-                                foreach (ActivityTrackerModel tracker in activity.Trackers)
-                                {
-                                    if (tracker.ActivityId == activityId)
-                                    {
-                                        activityTrackerLookup[tracker.Time] = tracker;
-                                    }
-                                }
-
-                                return (activity, activityTrackerLookup);
-                            });
-
-                    // This is for tracking the working progresses for each activity.
-                    Dictionary<int, int> runningWorkingProgresses = orderedActivities.ToDictionary(activity => activity.Id, activity => 0);
-
-                    // Cycle through each time index.
-                    for (int timeIndex = 0; timeIndex <= endTime; timeIndex++)
-                    {
-                        // Here we need to update the running percentage completion for each activity.
-                        foreach ((ActivityModel activity, Dictionary<int, ActivityTrackerModel> activityTrackerLookup) in activityBehaviourLookup.Values)
-                        {
-                            int runningWorkingProgress = 0;
-
-                            if (runningWorkingProgresses.TryGetValue(activity.Id, out int workingCompletion))
-                            {
-                                runningWorkingProgress = workingCompletion;
-                            }
-
-                            if (activityTrackerLookup.TryGetValue(timeIndex, out ActivityTrackerModel? tracker))
-                            {
-                                if (tracker.PercentageComplete > runningWorkingProgress)
-                                {
-                                    runningWorkingProgress = tracker.PercentageComplete;
-                                }
-                            }
-
-                            runningWorkingProgresses[activity.Id] = runningWorkingProgress;
-                        }
-
-                        // Now we can calculate percentage progress for each activity that has
-                        // a percentage completed entry.
-                        double currentWorkingProgress = 0.0;
-
-                        foreach (ActivityModel activity in orderedActivities)
-                        {
-                            int percentageCompleted = runningWorkingProgresses[activity.Id];
-                            currentWorkingProgress += activity.AllocatedToResources.Count * activity.Duration * (percentageCompleted / 100.0);
-                        }
-
-                        double progressPercentage = endTime == 0 ? 0.0 : 100.0 * currentWorkingProgress / totalWorkingTime;
-                        int time = timeIndex + 1; // Since the equivalent finish time would be the next day.
-
-                        foreach ((ActivityModel activity, Dictionary<int, ActivityTrackerModel> activityTrackerLookup) in activityBehaviourLookup.Values)
-                        {
-                            // Now add progress points for activities only if they have
-                            // a recorded percentage completed entry for this time index.
-                            if (activityTrackerLookup.TryGetValue(timeIndex, out ActivityTrackerModel? tracker))
-                            {
-                                progressPointSeries.Add(new TrackingPointModel
-                                {
-                                    Time = time,
-                                    ActivityId = activity.Id,
-                                    ActivityName = activity.Name,
-                                    Value = currentWorkingProgress,
-                                    ValuePercentage = progressPercentage
-                                });
-                            }
-                        }
-                    }
-                }
-
-                // Do not bother with effort measures if we are assuming infinite resources.
-                if (hasResources)
-                {
-                    // Effort
-                    effortPointSeries.Add(new TrackingPointModel());
-
-                    // Preprocess the resource trackers so they can be looked up
-                    // quickly according to the time.
-
-                    Dictionary<int, (ResourceModel resource, Dictionary<int, ResourceTrackerModel> resourceTrackerLookup)> resourceBehaviourLookup =
-                        resources.ToDictionary(
-                            resource => resource.Id,
-                            resource =>
-                            {
-                                int resourceId = resource.Id;
-                                Dictionary<int, ResourceTrackerModel> resourceTrackerLookup = [];
-
-                                foreach (ResourceTrackerModel tracker in resource.Trackers)
-                                {
-                                    if (tracker.ResourceId == resourceId)
-                                    {
-                                        resourceTrackerLookup[tracker.Time] = tracker;
-                                    }
-                                }
-
-                                return (resource, resourceTrackerLookup);
-                            });
-
-                    // This is for tracking the working effort for each activity.
-                    Dictionary<int, int> runningWorkingEfforts = orderedActivities.ToDictionary(activity => activity.Id, activity => 0);
-
-                    // Cycle through each time index.
-                    for (int timeIndex = 0; timeIndex <= endTime; timeIndex++)
-                    {
-                        // Here we need to update the running percentage effort for each resource.
-                        foreach ((ResourceModel resource, Dictionary<int, ResourceTrackerModel> resourceTrackerLookup) in resourceBehaviourLookup.Values)
-                        {
-                            foreach (ActivityModel activity in orderedActivities)
-                            {
-                                int runningWorkingEffort = 0;
-                                int activityId = activity.Id;
-
-                                if (runningWorkingEfforts.TryGetValue(activityId, out int workingEffort))
-                                {
-                                    runningWorkingEffort = workingEffort;
-                                }
-
-                                if (resourceTrackerLookup.TryGetValue(timeIndex, out ResourceTrackerModel? tracker))
-                                {
-                                    foreach (ResourceActivityTrackerModel activityTracker in tracker.ActivityTrackers.Where(x => x.ActivityId == activityId))
-                                    {
-                                        runningWorkingEffort += activityTracker.PercentageWorked;
-                                    }
-                                }
-
-                                runningWorkingEfforts[activity.Id] = runningWorkingEffort;
-                            }
-                        }
-
-                        // Now we can calculate percentage effort for each activity that has
-                        // a effort percentage completed entry.
-                        double currentWorkingEffort = 0.0;
-
-                        foreach (ActivityModel activity in orderedActivities)
-                        {
-                            int percentageWorked = runningWorkingEfforts[activity.Id];
-                            currentWorkingEffort += percentageWorked / 100.0;
-                        }
-
-                        double effortPercentage = endTime == 0 ? 0.0 : 100.0 * currentWorkingEffort / totalWorkingTime;
-                        int time = timeIndex + 1; // Since the equivalent finish time would be the next day.
-
-                        foreach ((ResourceModel resource, Dictionary<int, ResourceTrackerModel> resourceTrackerLookup) in resourceBehaviourLookup.Values)
-                        {
-                            // Now add effort points for activities only if they have
-                            // a recorded effort completed entry for this time index.
-                            if (resourceTrackerLookup.TryGetValue(timeIndex, out ResourceTrackerModel? tracker))
-                            {
-                                int resourceId = tracker.ResourceId;
-
-                                foreach (ResourceActivityTrackerModel activityTracker in tracker.ActivityTrackers.Where(x => x.ResourceId == resourceId))
-                                {
-                                    effortPointSeries.Add(new TrackingPointModel
-                                    {
-                                        Time = time,
-                                        ActivityId = activityTracker.ActivityId,
-                                        ActivityName = activityTracker.ActivityName,
-                                        Value = currentWorkingEffort,
-                                        ValuePercentage = effortPercentage
-                                    });
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Projections.
-
-            // Plan
-            {
-                planProjectionPointSeries.Add(new TrackingPointModel());
-
-                //if (planPointSeries.Count > 1)
-                //{
-                //    var projectedLinearFit = MathNet.Numerics.Fit.LineThroughOrigin(
-                //        planPointSeries.Select(p => (double)p.Time).ToArray(),
-                //        planPointSeries.Select(p => p.Value).ToArray());
-
-                //    var lastTrackingPoint = planPointSeries.Last();
-
-                //    if (projectedLinearFit > 0)
-                //    {
-                //        var projectedCompletion = lastTrackingPoint.Value / projectedLinearFit;
-
-                //        planProjectionPointSeries.Add(new TrackingPointModel
-                //        {
-                //            ActivityId = lastTrackingPoint.ActivityId,
-                //            ActivityName = lastTrackingPoint.ActivityName,
-                //            Value = lastTrackingPoint.Value,
-                //            ValuePercentage = lastTrackingPoint.ValuePercentage,
-                //            Time = (int)Math.Ceiling(projectedCompletion)
-                //        });
-                //    }
-                //}
-
-                // Each series will always have at least one item.
-                planProjectionPointSeries.Add(planPointSeries.Last());
-            }
-
-            // Progress
-            {
-                progressProjectionPointSeries.Add(new TrackingPointModel());
-
-                if (progressPointSeries.Count > 1)
-                {
-                    var projectedLinearFit = MathNet.Numerics.Fit.LineThroughOrigin(
-                        [.. progressPointSeries.Select(p => (double)p.Time)],
-                        [.. progressPointSeries.Select(p => p.Value)]);
-
-                    var lastTrackingPoint = planPointSeries.Last();
-
-                    if (projectedLinearFit > 0)
-                    {
-                        var projectedCompletion = lastTrackingPoint.Value / projectedLinearFit;
-
-                        progressProjectionPointSeries.Add(new TrackingPointModel
-                        {
-                            ActivityId = lastTrackingPoint.ActivityId,
-                            ActivityName = lastTrackingPoint.ActivityName,
-                            Value = lastTrackingPoint.Value,
-                            ValuePercentage = lastTrackingPoint.ValuePercentage,
-                            Time = (int)Math.Ceiling(projectedCompletion)
-                        });
-                    }
-                }
-            }
-
-            // Effort
-            if (hasResources
-                && effortPointSeries.Count > 1)
-            {
-                effortProjectionPointSeries.Add(new TrackingPointModel());
-
-                // We want to project effort out to the greater of the plan or the progress projection
-                var projectedCompletion = Math.Max(
-                    progressProjectionPointSeries.Last().Time,
-                    planProjectionPointSeries.Last().Time);
-
-                var projectedLinearFit = MathNet.Numerics.Fit.LineThroughOrigin(
-                    [.. effortPointSeries.Select(p => (double)p.Time)],
-                    [.. effortPointSeries.Select(p => p.Value)]);
-
-                var lastTrackingPoint = planPointSeries.Last();
-
-                if (lastTrackingPoint.Value > 0)
-                {
-                    var projectedFinalEffort = projectedLinearFit * projectedCompletion;
-
-                    effortProjectionPointSeries.Add(new TrackingPointModel
-                    {
-                        ActivityId = lastTrackingPoint.ActivityId,
-                        ActivityName = lastTrackingPoint.ActivityName,
-                        Value = projectedFinalEffort,
-                        ValuePercentage = (projectedFinalEffort / lastTrackingPoint.Value) * 100.0,
-                        Time = projectedCompletion
-                    });
-                }
-            }
-
-            return trackingSeriesSet;
-        }
-
-        private static int? CalculateCyclomaticComplexity(IEnumerable<IDependentActivity> dependentActivities)
-        {
-            ArgumentNullException.ThrowIfNull(dependentActivities);
-
-            IEnumerable<IDependentActivity> dependentActivitiesCopy =
-                dependentActivities.Select(x => (IDependentActivity)x.CloneObject());
-
-            if (!dependentActivitiesCopy.Any())
-            {
-                return null;
-            }
-
-            var vertexGraphCompiler = new VertexGraphCompiler();
-
-            foreach (var dependentActivity in dependentActivitiesCopy.Cast<DependentActivity>())
-            {
-                dependentActivity.Dependencies.UnionWith(dependentActivity.PlanningDependencies);
-                dependentActivity.Dependencies.UnionWith(dependentActivity.ResourceDependencies);
-                dependentActivity.PlanningDependencies.Clear();
-                dependentActivity.ResourceDependencies.Clear();
-                vertexGraphCompiler.AddActivity(dependentActivity);
-            }
-
-            vertexGraphCompiler.TransitiveReduction();
-            return vertexGraphCompiler.CyclomaticComplexity;
-        }
-
-        private static double? CalculateDurationManMonths(
-            DateTimeOffset projectStart,
-            int? duration,
-            IDateTimeCalculator dateTimeCalculator)
-        {
-            ArgumentNullException.ThrowIfNull(dateTimeCalculator);
-            (_, DateTimeOffset? endDate) = dateTimeCalculator.CalculateTimeAndDateTime(projectStart, duration);
-
-            if (endDate is not null)
-            {
-                TimeSpan diff = endDate.Value - projectStart;
-                double days = diff.TotalDays;
-                return 12.0 * (days / 365.0);
-            }
-            return null;
-        }
 
         private void SetIsProjectScenarioUpdated(bool isProjectScenarioUpdated, bool trackStaleOutputs)
         {
@@ -2412,28 +1688,14 @@ namespace Zametek.ViewModel.ProjectPlan
         {
             lock (m_Lock)
             {
-                ArrowGraph = new ArrowGraphModel();
-
-                if (!HasCompilationErrors)
+                if (HasCompilationErrors)
                 {
-                    IEnumerable<IDependentActivity> dependentActivities =
-                        GraphCompilation.DependentActivities.Select(x => (IDependentActivity)x.CloneObject());
-
-                    if (dependentActivities.Any())
-                    {
-                        var arrowGraphCompiler = new ArrowGraphCompiler();
-                        foreach (IDependentActivity dependentActivity in dependentActivities)
-                        {
-                            dependentActivity.Dependencies.UnionWith(dependentActivity.ResourceDependencies);
-                            dependentActivity.ResourceDependencies.Clear();
-                            arrowGraphCompiler.AddActivity(dependentActivity);
-                        }
-
-                        arrowGraphCompiler.Compile();
-                        Graph<int, IDependentActivity, IEvent<int>>? arrowGraph =
-                            arrowGraphCompiler.ToGraph() ?? throw new InvalidOperationException(Resource.ProjectPlan.Messages.Message_CannotBuildArrowGraph);
-                        ArrowGraph = m_Mapper.ToArrowGraphModel(arrowGraph);
-                    }
+                    ArrowGraph = new ArrowGraphModel();
+                }
+                else
+                {
+                    ArrowGraph = m_GraphCompilationService.BuildArrowGraph(
+                        GraphCompilation.DependentActivities.Select(x => (IDependentActivity)x.CloneObject()));
                 }
             }
         }
@@ -2442,39 +1704,17 @@ namespace Zametek.ViewModel.ProjectPlan
         {
             lock (m_Lock)
             {
-                VertexGraph = new VertexGraphModel();
-
-                if (!HasCompilationErrors)
+                if (HasCompilationErrors)
                 {
-                    IEnumerable<IDependentActivity> dependentActivities =
-                        GraphCompilation.DependentActivities.Select(x => (IDependentActivity)x.CloneObject());
-
-                    if (dependentActivities.Any())
-                    {
-                        var availableResources = new List<IResource<int, int>>();
-                        if (!ResourceSettings.AreDisabled)
-                        {
-                            availableResources.AddRange(ResourceSettings.Resources.OrderBy(x => x.Id).Select(m_Mapper.ToResource));
-                        }
-
-                        var workStreams = new List<IWorkStream<int>>();
-                        workStreams.AddRange(WorkStreamSettings.WorkStreams.Select(m_Mapper.ToWorkStream));
-
-                        var vertexGraphCompiler = new VertexGraphCompiler();
-                        foreach (IDependentActivity dependentActivity in dependentActivities)
-                        {
-                            dependentActivity.Dependencies.UnionWith(dependentActivity.ResourceDependencies);
-                            dependentActivity.ResourceDependencies.Clear();
-                            vertexGraphCompiler.AddActivity(dependentActivity);
-                        }
-
-                        vertexGraphCompiler.TransitiveReduction();
-                        vertexGraphCompiler.Compile(availableResources, workStreams);
-
-                        Graph<int, IEvent<int>, IDependentActivity>? vertexGraph =
-                            vertexGraphCompiler.ToGraph() ?? throw new InvalidOperationException(Resource.ProjectPlan.Messages.Message_CannotBuildArrowGraph);
-                        VertexGraph = m_Mapper.ToVertexGraphModel(vertexGraph);
-                    }
+                    VertexGraph = new VertexGraphModel();
+                }
+                else
+                {
+                    VertexGraph = m_GraphCompilationService.BuildVertexGraph(
+                        GraphCompilation.DependentActivities.Select(x => (IDependentActivity)x.CloneObject()),
+                        ResourceSettings.Resources,
+                        ResourceSettings.AreDisabled,
+                        WorkStreamSettings.WorkStreams);
                 }
             }
         }
@@ -2483,14 +1723,9 @@ namespace Zametek.ViewModel.ProjectPlan
         {
             lock (m_Lock)
             {
-                IList<ResourceScheduleModel> resourceScheduleModels =
-                    [.. m_Mapper.ToResourceScheduleModels(GraphCompilation)];
-
-                ResourceSeriesSetModel resourceSeriesSet = CalculateResourceSeriesSet(
-                    resourceScheduleModels,
+                ResourceSeriesSet = m_ResourceSchedulingService.BuildResourceSeriesSet(
+                    GraphCompilation,
                     ResourceSettings);
-
-                ResourceSeriesSet = resourceSeriesSet;
             }
         }
 
@@ -2498,17 +1733,13 @@ namespace Zametek.ViewModel.ProjectPlan
         {
             lock (m_Lock)
             {
-                var trackingSeriesSet = new TrackingSeriesSetModel();
-
                 IList<ActivityModel> activityModels =
                     [.. RawActivities.Cast<ManagedActivityViewModel>().Select(m_Mapper.ToActivityModel)];
 
-                trackingSeriesSet = CalculateTrackingSeriesSet(
+                TrackingSeriesSet = m_ResourceSchedulingService.BuildTrackingSeriesSet(
                     activityModels,
                     ResourceSettings,
                     HasResources);
-
-                TrackingSeriesSet = trackingSeriesSet;
             }
         }
 
@@ -2516,26 +1747,12 @@ namespace Zametek.ViewModel.ProjectPlan
         {
             lock (m_Lock)
             {
-                int? cyclomaticComplexity = null;
-                int? duration = null;
-                double? durationManMonths = null;
-
-                if (!HasCompilationErrors)
-                {
-                    if (GraphCompilation.DependentActivities.Any())
-                    {
-                        cyclomaticComplexity = CalculateCyclomaticComplexity(GraphCompilation.DependentActivities);
-                        duration = m_VertexGraphCompiler.FinishTime - m_VertexGraphCompiler.StartTime;
-                        durationManMonths = CalculateDurationManMonths(ProjectStart, duration, m_DateTimeCalculator);
-                    }
-                }
-
-                NetworkMetrics = new NetworkModel
-                {
-                    CyclomaticComplexity = cyclomaticComplexity,
-                    Duration = duration,
-                    DurationManMonths = durationManMonths,
-                };
+                NetworkMetrics = m_MetricCalculationService.BuildNetworkMetrics(
+                    GraphCompilation,
+                    HasCompilationErrors,
+                    ProjectStart,
+                    m_VertexGraphCompiler.StartTime,
+                    m_VertexGraphCompiler.FinishTime);
                 this.RaisePropertyChanged(nameof(Metrics));
             }
         }
@@ -2544,58 +1761,27 @@ namespace Zametek.ViewModel.ProjectPlan
         {
             lock (m_Lock)
             {
-                var risksModel = new RisksModel();
-
-                List<IDependentActivity> dependentActivities =
-                    [.. GraphCompilation.DependentActivities.Select(x => (IDependentActivity)x.CloneObject())];
-
-                if (dependentActivities.Count != 0)
-                {
-                    if (!HasCompilationErrors)
-                    {
-                        IEnumerable<ActivityModel> activities = dependentActivities
-                            .Where(x => !x.IsDummy)
-                            .Cast<DependentActivity<int, int, int>>()
-                            .Select(m_Mapper.ToActivityModel);
-
-                        IEnumerable<ActivitySeverityModel> activitySeverities = GraphSettings.ActivitySeverities;
-
-                        risksModel = MetricsHelper.CalculateProjectRisks(activities, activitySeverities);
-                    }
-                }
-
-                RiskMetrics = risksModel;
+                RiskMetrics = m_MetricCalculationService.BuildRiskMetrics(
+                    GraphCompilation,
+                    HasCompilationErrors,
+                    GraphSettings.ActivitySeverities);
                 this.RaisePropertyChanged(nameof(Metrics));
             }
         }
 
         public void BuildFinancialMetrics()
         {
-
             lock (m_Lock)
             {
-                var costsModel = new CostsModel();
-                var billingsModel = new BillingsModel();
-                var marginsModel = new MarginsModel();
-                var effortsModel = new EffortsModel();
+                (CostsModel costs, BillingsModel billings, MarginsModel margins, EffortsModel efforts) =
+                    m_MetricCalculationService.BuildFinancialMetrics(
+                        ResourceSeriesSet,
+                        HasCompilationErrors);
 
-                List<ResourceSeriesModel> combinedResourceSeriesModels = ResourceSeriesSet.Combined;
-
-                if (combinedResourceSeriesModels.Count != 0)
-                {
-                    if (!HasCompilationErrors)
-                    {
-                        costsModel = MetricsHelper.CalculateProjectCosts(combinedResourceSeriesModels);
-                        billingsModel = MetricsHelper.CalculateProjectBillings(combinedResourceSeriesModels);
-                        marginsModel = MetricsHelper.CalculateProjectMargins(costsModel, billingsModel);
-                        effortsModel = MetricsHelper.CalculateProjectEfforts(combinedResourceSeriesModels);
-                    }
-                }
-
-                CostMetrics = costsModel;
-                BillingMetrics = billingsModel;
-                MarginMetrics = marginsModel;
-                EffortMetrics = effortsModel;
+                CostMetrics = costs;
+                BillingMetrics = billings;
+                MarginMetrics = margins;
+                EffortMetrics = efforts;
                 this.RaisePropertyChanged(nameof(Metrics));
             }
         }

--- a/src/Zametek.ViewModel.ProjectPlan/EarnedValueChartManagement/EarnedValueChartManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/EarnedValueChartManagement/EarnedValueChartManagerViewModel.cs
@@ -738,7 +738,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_IsBusy?.Dispose();
                 m_HasStaleOutputs?.Dispose();
@@ -747,9 +746,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_ShowToday?.Dispose();
                 m_ShowMilestones?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/GanttChartManagement/ActivitySelectorViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/GanttChartManagement/ActivitySelectorViewModel.cs
@@ -310,12 +310,8 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 m_ReviseActivitiesSub?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/GanttChartManagement/GanttChartManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/GanttChartManagement/GanttChartManagerViewModel.cs
@@ -1615,7 +1615,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_IsBusy?.Dispose();
                 m_HasStaleOutputs?.Dispose();
@@ -1633,9 +1632,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_BoolAccumulator?.Dispose();
                 ActivitySelector?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/GraphManagement/ArrowGraphManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/GraphManagement/ArrowGraphManagerViewModel.cs
@@ -396,7 +396,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_IsBusy?.Dispose();
                 m_HasStaleOutputs?.Dispose();
@@ -404,9 +403,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_ShowNames?.Dispose();
                 m_BaseTheme?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/GraphManagement/VertexGraphManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/GraphManagement/VertexGraphManagerViewModel.cs
@@ -399,7 +399,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_IsBusy?.Dispose();
                 m_HasStaleOutputs?.Dispose();
@@ -407,9 +406,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_ShowNames?.Dispose();
                 m_BaseTheme?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/GraphSettingsManagement/GraphSettingsManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/GraphSettingsManagement/GraphSettingsManagerViewModel.cs
@@ -382,7 +382,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 m_IsBusy?.Dispose();
                 m_HasStaleOutputs?.Dispose();
                 m_HasCompilationErrors?.Dispose();
@@ -392,9 +391,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 ClearManagedActivitySeverities();
                 m_ActivitySeverities?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/GraphSettingsManagement/ManagedActivitySeverityViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/GraphSettingsManagement/ManagedActivitySeverityViewModel.cs
@@ -150,16 +150,12 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 //m_ProjectStartSub?.Dispose();
                 //m_ResourceSettingsSub?.Dispose();
                 //m_DateTimeCalculatorSub?.Dispose();
                 //m_CompilationSub?.Dispose();
                 //ResourceSelector.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/HolidaySettingsManagement/HolidayEditViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/HolidaySettingsManagement/HolidayEditViewModel.cs
@@ -936,7 +936,6 @@ namespace Zametek.ViewModel.ProjectPlan
             }
         }
 
-
         private SetByIntModel? m_YearlySetPosSelection;
         public SetByIntModel? YearlySetPosSelection
         {
@@ -944,7 +943,6 @@ namespace Zametek.ViewModel.ProjectPlan
             set => this.RaiseAndSetIfChanged(ref m_YearlySetPosSelection, value);
         }
         public List<SetByIntModel> YearlySetPosOptions { get; }
-
 
         private SetByStringModel? m_YearlyWeekdaySelection;
         public SetByStringModel? YearlyWeekdaySelection
@@ -954,7 +952,6 @@ namespace Zametek.ViewModel.ProjectPlan
         }
         public List<SetByStringModel> YearlyWeekdayOptions { get; }
 
-
         private SetByIntModel? m_YearlyMonthSelection;
         public SetByIntModel? YearlyMonthSelection
         {
@@ -962,7 +959,6 @@ namespace Zametek.ViewModel.ProjectPlan
             set => this.RaiseAndSetIfChanged(ref m_YearlyMonthSelection, value);
         }
         public List<SetByIntModel> YearlyMonthOptions { get; }
-
 
         private RecurrenceRuleModel m_RecurrenceRule;
         public RecurrenceRuleModel RecurrenceRule
@@ -1016,12 +1012,8 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/HolidaySettingsManagement/HolidaySettingsManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/HolidaySettingsManagement/HolidaySettingsManagerViewModel.cs
@@ -441,7 +441,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 m_IsBusy?.Dispose();
                 m_HasStaleOutputs?.Dispose();
                 m_HasCompilationErrors?.Dispose();
@@ -450,9 +449,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_UpdateHolidaySettingsSub?.Dispose();
                 ClearManagedHolidays();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/HolidaySettingsManagement/ManagedHolidayViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/HolidaySettingsManagement/ManagedHolidayViewModel.cs
@@ -192,12 +192,8 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/MainViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/MainViewModel.cs
@@ -1314,7 +1314,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_IsBusy?.Dispose();
                 m_IsProjectUpdated?.Dispose();
@@ -1332,9 +1331,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_BaseTheme?.Dispose();
                 m_DataGridManager?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/MetricManagement/MetricManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/MetricManagement/MetricManagerViewModel.cs
@@ -91,7 +91,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 .WhenAnyValue(mm => mm.m_CoreViewModel.Metrics, metrics => metrics.Network)
                 .ToProperty(this, mm => mm.NetworkMetrics);
 
-
             m_CriticalityRisk = this
                 .WhenAnyValue(mm => mm.RisksMetrics, risks => risks.Criticality)
                 .ToProperty(this, mm => mm.CriticalityRisk);
@@ -120,7 +119,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 .WhenAnyValue(mm => mm.RisksMetrics, risks => risks.GeometricActivity)
                 .ToProperty(this, mm => mm.GeometricActivityRisk);
 
-
             m_DirectCost = this
                 .WhenAnyValue(mm => mm.CostsMetrics, costs => costs.Direct)
                 .ToProperty(this, mm => mm.DirectCost);
@@ -136,7 +134,6 @@ namespace Zametek.ViewModel.ProjectPlan
             m_TotalCost = this
                 .WhenAnyValue(mm => mm.CostsMetrics, costs => costs.Total)
                 .ToProperty(this, mm => mm.TotalCost);
-
 
             m_DirectBilling = this
                 .WhenAnyValue(mm => mm.BillingsMetrics, billings => billings.Direct)
@@ -154,7 +151,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 .WhenAnyValue(mm => mm.BillingsMetrics, billings => billings.Total)
                 .ToProperty(this, mm => mm.TotalBilling);
 
-
             m_DirectMargin = this
                  .WhenAnyValue(mm => mm.MarginsMetrics, margins => margins.Direct)
                  .ToProperty(this, mm => mm.DirectMargin);
@@ -170,7 +166,6 @@ namespace Zametek.ViewModel.ProjectPlan
             m_TotalMargin = this
                  .WhenAnyValue(mm => mm.MarginsMetrics, margins => margins.Total)
                  .ToProperty(this, mm => mm.TotalMargin);
-
 
             m_DisplayDirectMargin = this
                 .WhenAnyValue(
@@ -196,7 +191,6 @@ namespace Zametek.ViewModel.ProjectPlan
                     (double? margin) => margin is null ? string.Empty : string.Format(" ({0:P1})", margin))
                 .ToProperty(this, mm => mm.DisplayTotalMargin);
 
-
             m_DirectMarginAbsolute = this
                 .WhenAnyValue(mm => mm.MarginsMetrics, margins => margins.DirectAbsolute)
                 .ToProperty(this, mm => mm.DirectMarginAbsolute);
@@ -212,7 +206,6 @@ namespace Zametek.ViewModel.ProjectPlan
             m_TotalMarginAbsolute = this
                 .WhenAnyValue(mm => mm.MarginsMetrics, margins => margins.TotalAbsolute)
                 .ToProperty(this, mm => mm.TotalMarginAbsolute);
-
 
             m_DirectEffort = this
                 .WhenAnyValue(mm => mm.EffortsMetrics, efforts => efforts.Direct)
@@ -238,7 +231,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 .WhenAnyValue(mm => mm.EffortsMetrics, efforts => efforts.Efficiency)
                 .ToProperty(this, mm => mm.EffortEfficiency);
 
-
             m_NetworkCyclomaticComplexity = this
                 .WhenAnyValue(mm => mm.NetworkMetrics, network => network.CyclomaticComplexity)
                 .ToProperty(this, mm => mm.NetworkCyclomaticComplexity);
@@ -250,7 +242,6 @@ namespace Zametek.ViewModel.ProjectPlan
             m_NetworkDurationManMonths = this
                 .WhenAnyValue(mm => mm.NetworkMetrics, network => network.DurationManMonths)
                 .ToProperty(this, mm => mm.NetworkDurationManMonths);
-
 
             m_ProjectFinish = this
                 .WhenAnyValue(mm => mm.m_CoreViewModel.ProjectFinish)
@@ -266,7 +257,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
         private readonly ObservableAsPropertyHelper<bool> m_ShowDates;
         public bool ShowDates => m_ShowDates.Value;
-
 
         private readonly ObservableAsPropertyHelper<RisksModel> m_RisksMetrics;
         public RisksModel RisksMetrics => m_RisksMetrics.Value;
@@ -442,7 +432,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_IsBusy?.Dispose();
                 m_HasStaleOutputs?.Dispose();
@@ -470,9 +459,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_ActivityEffort?.Dispose();
                 m_EffortEfficiency?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/OutputManagement/OutputManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/OutputManagement/OutputManagerViewModel.cs
@@ -265,7 +265,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_IsBusy?.Dispose();
                 m_HasStaleOutputs?.Dispose();
@@ -275,9 +274,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_NonWorkingDayMode?.Dispose();
                 m_ProjectStart?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/ProjectDisplaySettingsViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ProjectDisplaySettingsViewModel.cs
@@ -199,12 +199,8 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 m_SetIsProjectUpdated = null;
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/ProjectScenarioDisplaySettingsViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ProjectScenarioDisplaySettingsViewModel.cs
@@ -568,13 +568,9 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 m_SetIsProjectScenarioUpdated = null;
                 m_IsReadyToCompile = null;
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/ProjectScenarioManagement/ManagedNodeViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ProjectScenarioManagement/ManagedNodeViewModel.cs
@@ -456,7 +456,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_Labels.Clear();
                 m_Labels.Dispose();
@@ -464,9 +463,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_Children.Dispose();
                 m_DisplayName?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/ProjectScenarioManagement/ProjectScenarioManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ProjectScenarioManagement/ProjectScenarioManagerViewModel.cs
@@ -2321,7 +2321,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 ResetProject();
                 KillSubscriptions();
                 m_IsLoading?.Dispose();
@@ -2338,8 +2337,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_ScenarioChartCurveFittingType?.Dispose();
                 m_NodeActionCommandManualTrigger?.Dispose();
             }
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/ResourceChartManagement/ResourceChartManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ResourceChartManagement/ResourceChartManagerViewModel.cs
@@ -737,7 +737,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_IsBusy?.Dispose();
                 m_HasStaleOutputs?.Dispose();
@@ -748,9 +747,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_ShowToday?.Dispose();
                 m_ShowMilestones?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/ResourceSettingsManagement/ManagedResourceViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ResourceSettingsManagement/ManagedResourceViewModel.cs
@@ -356,15 +356,11 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_HasPhases?.Dispose();
                 TrackerSet.Dispose();
                 m_InterActivityAllocationIsIndirect?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/ResourceSettingsManagement/ResourceActivitySelectorViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ResourceSettingsManagement/ResourceActivitySelectorViewModel.cs
@@ -324,12 +324,8 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 m_ReviseResourceActivityTrackersSub?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }
@@ -388,14 +384,6 @@ namespace Zametek.ViewModel.ProjectPlan
             {
                 return;
             }
-
-            if (disposing)
-            {
-                // TODO: dispose managed state (managed objects).
-            }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/ResourceSettingsManagement/ResourceSettingsManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ResourceSettingsManagement/ResourceSettingsManagerViewModel.cs
@@ -626,7 +626,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 m_IsBusy?.Dispose();
                 m_HasStaleOutputs?.Dispose();
                 m_HasCompilationErrors?.Dispose();
@@ -639,9 +638,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 ClearManagedResources();
                 m_Resources?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/ResourceSettingsManagement/ResourceTrackerSetViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ResourceSettingsManagement/ResourceTrackerSetViewModel.cs
@@ -332,16 +332,12 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 m_DaysSub?.Dispose();
                 foreach (IResourceActivitySelectorViewModel selector in m_ResourceActivitySelectorLookup.Values)
                 {
                     selector.Dispose();
                 }
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/ScenarioChartManagement/ScenarioChartManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ScenarioChartManagement/ScenarioChartManagerViewModel.cs
@@ -712,7 +712,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_IsBusy?.Dispose();
                 m_HasStaleOutputs?.Dispose();
@@ -721,9 +720,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_TrackedMetricYAxis?.Dispose();
                 m_CurveFittingType?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/Services/GraphCompilationService.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/Services/GraphCompilationService.cs
@@ -1,0 +1,100 @@
+using Zametek.Common.ProjectPlan;
+using Zametek.Contract.ProjectPlan;
+using Zametek.Maths.Graphs;
+
+namespace Zametek.ViewModel.ProjectPlan
+{
+    public class GraphCompilationService
+        : IGraphCompilationService
+    {
+        #region Fields
+
+        private readonly ProjectPlanMapper m_Mapper;
+
+        #endregion
+
+        #region Ctors
+
+        public GraphCompilationService(ProjectPlanMapper mapper)
+        {
+            ArgumentNullException.ThrowIfNull(mapper);
+            m_Mapper = mapper;
+        }
+
+        #endregion
+
+        #region IGraphCompilationService Members
+
+        public ArrowGraphModel BuildArrowGraph(
+            IEnumerable<IDependentActivity> dependentActivities)
+        {
+            ArgumentNullException.ThrowIfNull(dependentActivities);
+
+            IEnumerable<IDependentActivity> dependentActivitiesCopy =
+                dependentActivities.Select(x => (IDependentActivity)x.CloneObject());
+
+            if (!dependentActivitiesCopy.Any())
+            {
+                return new ArrowGraphModel();
+            }
+
+            var arrowGraphCompiler = new ArrowGraphCompiler();
+            foreach (IDependentActivity dependentActivity in dependentActivitiesCopy)
+            {
+                dependentActivity.Dependencies.UnionWith(dependentActivity.ResourceDependencies);
+                dependentActivity.ResourceDependencies.Clear();
+                arrowGraphCompiler.AddActivity(dependentActivity);
+            }
+
+            arrowGraphCompiler.Compile();
+            Graph<int, IDependentActivity, IEvent<int>>? arrowGraph =
+                arrowGraphCompiler.ToGraph() ?? throw new InvalidOperationException(Resource.ProjectPlan.Messages.Message_CannotBuildArrowGraph);
+            return m_Mapper.ToArrowGraphModel(arrowGraph);
+        }
+
+        public VertexGraphModel BuildVertexGraph(
+            IEnumerable<IDependentActivity> dependentActivities,
+            IEnumerable<ResourceModel> resources,
+            bool resourcesAreDisabled,
+            IEnumerable<WorkStreamModel> workStreams)
+        {
+            ArgumentNullException.ThrowIfNull(dependentActivities);
+            ArgumentNullException.ThrowIfNull(resources);
+            ArgumentNullException.ThrowIfNull(workStreams);
+
+            IEnumerable<IDependentActivity> dependentActivitiesCopy =
+                dependentActivities.Select(x => (IDependentActivity)x.CloneObject());
+
+            if (!dependentActivitiesCopy.Any())
+            {
+                return new VertexGraphModel();
+            }
+
+            var availableResources = new List<IResource<int, int>>();
+            if (!resourcesAreDisabled)
+            {
+                availableResources.AddRange(resources.OrderBy(x => x.Id).Select(m_Mapper.ToResource));
+            }
+
+            List<IWorkStream<int>> workStreamList =
+                [.. workStreams.Select(m_Mapper.ToWorkStream)];
+
+            var vertexGraphCompiler = new VertexGraphCompiler();
+            foreach (IDependentActivity dependentActivity in dependentActivitiesCopy)
+            {
+                dependentActivity.Dependencies.UnionWith(dependentActivity.ResourceDependencies);
+                dependentActivity.ResourceDependencies.Clear();
+                vertexGraphCompiler.AddActivity(dependentActivity);
+            }
+
+            vertexGraphCompiler.TransitiveReduction();
+            vertexGraphCompiler.Compile(availableResources, workStreamList);
+
+            Graph<int, IEvent<int>, IDependentActivity>? vertexGraph =
+                vertexGraphCompiler.ToGraph() ?? throw new InvalidOperationException(Resource.ProjectPlan.Messages.Message_CannotBuildArrowGraph);
+            return m_Mapper.ToVertexGraphModel(vertexGraph);
+        }
+
+        #endregion
+    }
+}

--- a/src/Zametek.ViewModel.ProjectPlan/Services/MetricCalculationService.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/Services/MetricCalculationService.cs
@@ -1,0 +1,167 @@
+using Zametek.Common.ProjectPlan;
+using Zametek.Contract.ProjectPlan;
+using Zametek.Maths.Graphs;
+
+namespace Zametek.ViewModel.ProjectPlan
+{
+    public class MetricCalculationService
+        : IMetricCalculationService
+    {
+        #region Fields
+
+        private readonly ProjectPlanMapper m_Mapper;
+        private readonly IDateTimeCalculator m_DateTimeCalculator;
+
+        #endregion
+
+        #region Ctors
+
+        public MetricCalculationService(
+            ProjectPlanMapper mapper,
+            IDateTimeCalculator dateTimeCalculator)
+        {
+            ArgumentNullException.ThrowIfNull(mapper);
+            ArgumentNullException.ThrowIfNull(dateTimeCalculator);
+            m_Mapper = mapper;
+            m_DateTimeCalculator = dateTimeCalculator;
+        }
+
+        #endregion
+
+        #region Private Methods
+
+        private static int? CalculateCyclomaticComplexity(IEnumerable<IDependentActivity> dependentActivities)
+        {
+            ArgumentNullException.ThrowIfNull(dependentActivities);
+
+            IEnumerable<IDependentActivity> dependentActivitiesCopy =
+                dependentActivities.Select(x => (IDependentActivity)x.CloneObject());
+
+            if (!dependentActivitiesCopy.Any())
+            {
+                return null;
+            }
+
+            var vertexGraphCompiler = new VertexGraphCompiler();
+
+            foreach (var dependentActivity in dependentActivitiesCopy.Cast<DependentActivity>())
+            {
+                dependentActivity.Dependencies.UnionWith(dependentActivity.PlanningDependencies);
+                dependentActivity.Dependencies.UnionWith(dependentActivity.ResourceDependencies);
+                dependentActivity.PlanningDependencies.Clear();
+                dependentActivity.ResourceDependencies.Clear();
+                vertexGraphCompiler.AddActivity(dependentActivity);
+            }
+
+            vertexGraphCompiler.TransitiveReduction();
+            return vertexGraphCompiler.CyclomaticComplexity;
+        }
+
+        private double? CalculateDurationManMonths(DateTimeOffset projectStart, int? duration)
+        {
+            (_, DateTimeOffset? endDate) = m_DateTimeCalculator.CalculateTimeAndDateTime(projectStart, duration);
+
+            if (endDate is not null)
+            {
+                TimeSpan diff = endDate.Value - projectStart;
+                double days = diff.TotalDays;
+                return 12.0 * (days / 365.0);
+            }
+            return null;
+        }
+
+        #endregion
+
+        #region IMetricCalculationService Members
+
+        public NetworkModel BuildNetworkMetrics(
+            IGraphCompilation<int, int, int, IDependentActivity> graphCompilation,
+            bool hasCompilationErrors,
+            DateTimeOffset projectStart,
+            int? startTime,
+            int? finishTime)
+        {
+            ArgumentNullException.ThrowIfNull(graphCompilation);
+
+            int? cyclomaticComplexity = null;
+            int? duration = null;
+            double? durationManMonths = null;
+
+            if (!hasCompilationErrors)
+            {
+                if (graphCompilation.DependentActivities.Any())
+                {
+                    cyclomaticComplexity = CalculateCyclomaticComplexity(graphCompilation.DependentActivities);
+                    duration = finishTime - startTime;
+                    durationManMonths = CalculateDurationManMonths(projectStart, duration);
+                }
+            }
+
+            return new NetworkModel
+            {
+                CyclomaticComplexity = cyclomaticComplexity,
+                Duration = duration,
+                DurationManMonths = durationManMonths,
+            };
+        }
+
+        public RisksModel BuildRiskMetrics(
+            IGraphCompilation<int, int, int, IDependentActivity> graphCompilation,
+            bool hasCompilationErrors,
+            IEnumerable<ActivitySeverityModel> activitySeverities)
+        {
+            ArgumentNullException.ThrowIfNull(graphCompilation);
+            ArgumentNullException.ThrowIfNull(activitySeverities);
+
+            var risksModel = new RisksModel();
+
+            List<IDependentActivity> dependentActivities =
+                [.. graphCompilation.DependentActivities.Select(x => (IDependentActivity)x.CloneObject())];
+
+            if (dependentActivities.Count != 0)
+            {
+                if (!hasCompilationErrors)
+                {
+                    IEnumerable<ActivityModel> activities = dependentActivities
+                        .Where(x => !x.IsDummy)
+                        .Cast<DependentActivity<int, int, int>>()
+                        .Select(m_Mapper.ToActivityModel);
+
+                    risksModel = MetricsHelper.CalculateProjectRisks(activities, activitySeverities);
+                }
+            }
+
+            return risksModel;
+        }
+
+        public (CostsModel costs, BillingsModel billings, MarginsModel margins, EffortsModel efforts)
+            BuildFinancialMetrics(
+            ResourceSeriesSetModel resourceSeriesSet,
+            bool hasCompilationErrors)
+        {
+            ArgumentNullException.ThrowIfNull(resourceSeriesSet);
+
+            var costsModel = new CostsModel();
+            var billingsModel = new BillingsModel();
+            var marginsModel = new MarginsModel();
+            var effortsModel = new EffortsModel();
+
+            List<ResourceSeriesModel> combinedResourceSeriesModels = resourceSeriesSet.Combined;
+
+            if (combinedResourceSeriesModels.Count != 0)
+            {
+                if (!hasCompilationErrors)
+                {
+                    costsModel = MetricsHelper.CalculateProjectCosts(combinedResourceSeriesModels);
+                    billingsModel = MetricsHelper.CalculateProjectBillings(combinedResourceSeriesModels);
+                    marginsModel = MetricsHelper.CalculateProjectMargins(costsModel, billingsModel);
+                    effortsModel = MetricsHelper.CalculateProjectEfforts(combinedResourceSeriesModels);
+                }
+            }
+
+            return (costsModel, billingsModel, marginsModel, effortsModel);
+        }
+
+        #endregion
+    }
+}

--- a/src/Zametek.ViewModel.ProjectPlan/Services/ResourceSchedulingService.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/Services/ResourceSchedulingService.cs
@@ -1,0 +1,719 @@
+using System.Text;
+using Zametek.Common.ProjectPlan;
+using Zametek.Contract.ProjectPlan;
+using Zametek.Maths.Graphs;
+using Zametek.Utility;
+
+namespace Zametek.ViewModel.ProjectPlan
+{
+    public class ResourceSchedulingService
+        : IResourceSchedulingService
+    {
+        #region Fields
+
+        private readonly ProjectPlanMapper m_Mapper;
+
+        #endregion
+
+        #region Ctors
+
+        public ResourceSchedulingService(ProjectPlanMapper mapper)
+        {
+            ArgumentNullException.ThrowIfNull(mapper);
+            m_Mapper = mapper;
+        }
+
+        #endregion
+
+        #region Private Methods
+
+        private static ResourceSeriesSetModel CalculateResourceSeriesSet(
+            IEnumerable<ResourceScheduleModel> resourceSchedules,
+            ResourceSettingsModel resourceSettings)
+        {
+            ArgumentNullException.ThrowIfNull(resourceSchedules);
+            ArgumentNullException.ThrowIfNull(resourceSettings);
+            var resourceSeriesSet = new ResourceSeriesSetModel();
+
+            IList<ResourceModel> resources = resourceSettings.Resources;
+            double defaultUnitCost = resourceSettings.DefaultUnitCost;
+            double defaultUnitBilling = resourceSettings.DefaultUnitBilling;
+
+            var resourceLookup = resources.ToDictionary(x => x.Id);
+
+            if (resourceSchedules.Any())
+            {
+                int finishTime = resourceSchedules.Select(x => x.FinishTime).DefaultIfEmpty().Max();
+                int spareResourceCount = 1;
+
+                // Scheduled resource series.
+                // These are the series that apply to None and Direct resources only.
+                var scheduledSeriesSet = new List<ResourceSeriesModel>();
+
+                IEnumerable<ResourceScheduleModel> noneAndDirectResourceSchedules = resourceSchedules
+                    .Where(x => x.Resource.InterActivityAllocationType == InterActivityAllocationType.None || x.Resource.InterActivityAllocationType == InterActivityAllocationType.Direct);
+
+                // Make 'random' colors seem consistent.
+                ColorHelper.PresetReset();
+
+                foreach (ResourceScheduleModel scheduledResourceSchedule in noneAndDirectResourceSchedules)
+                {
+                    if (scheduledResourceSchedule.ScheduledActivities.Count > 0)
+                    {
+                        var stringBuilder = new StringBuilder();
+                        InterActivityAllocationType interActivityAllocationType = InterActivityAllocationType.None;
+                        ColorFormatModel color = ColorHelper.Preset();
+                        double unitCost = defaultUnitCost;
+                        double unitBilling = defaultUnitBilling;
+                        double fixedCost = 0.0;
+                        double fixedBilling = 0.0;
+                        int displayOrder = 0;
+
+                        if (scheduledResourceSchedule.Resource.Id != default
+                            && resourceLookup.TryGetValue(scheduledResourceSchedule.Resource.Id, out ResourceModel? resource))
+                        {
+                            int resourceId = resource.Id;
+                            interActivityAllocationType = resource.InterActivityAllocationType;
+                            if (string.IsNullOrWhiteSpace(resource.Name))
+                            {
+                                stringBuilder.Append($@"{Resource.ProjectPlan.Labels.Label_Resource} {resourceId}");
+                            }
+                            else
+                            {
+                                stringBuilder.Append($@"{resource.Name}");
+                            }
+
+                            if (resource.ColorFormat is not null)
+                            {
+                                color = resource.ColorFormat;
+                            }
+
+                            unitCost = resource.UnitCost;
+                            unitBilling = resource.UnitBilling;
+                            fixedCost = resource.FixedCost;
+                            fixedBilling = resource.FixedBilling;
+                            displayOrder = resource.DisplayOrder;
+                        }
+                        else
+                        {
+                            stringBuilder.Append($@"{Resource.ProjectPlan.Labels.Label_Resource} {spareResourceCount}");
+                            spareResourceCount++;
+                        }
+
+                        var series = new ResourceSeriesModel
+                        {
+                            Title = stringBuilder.ToString(),
+                            ColorFormat = color,
+                            UnitCost = unitCost,
+                            UnitBilling = unitBilling,
+                            FixedCost = fixedCost,
+                            FixedBilling = fixedBilling,
+                            DisplayOrder = displayOrder,
+                            ResourceSchedule = scheduledResourceSchedule,
+                            InterActivityAllocationType = interActivityAllocationType,
+                        };
+
+                        scheduledSeriesSet.Add(series);
+                    }
+                }
+
+                // Unscheduled resource series.
+                // These are series that apply to Indirect resources, and also
+                // None and Direct resources that have roll-off periods.
+                var unscheduledSeriesSet = new List<ResourceSeriesModel>();
+                var unscheduledResourceSeriesLookup = new Dictionary<int, ResourceSeriesModel>();
+
+                IEnumerable<ResourceScheduleModel> indirectResourceSchedules = resourceSchedules
+                    .Where(x => x.Resource.InterActivityAllocationType == InterActivityAllocationType.Indirect);
+
+                foreach (ResourceScheduleModel resourceSchedule in indirectResourceSchedules)
+                {
+                    if (resourceLookup.TryGetValue(resourceSchedule.Resource.Id, out ResourceModel? resource))
+                    {
+                        int resourceId = resource.Id;
+                        var stringBuilder = new StringBuilder();
+
+                        if (string.IsNullOrWhiteSpace(resource.Name))
+                        {
+                            stringBuilder.Append($@"{Resource.ProjectPlan.Labels.Label_Resource} {resourceId}");
+                        }
+                        else
+                        {
+                            stringBuilder.Append($@"{resource.Name}");
+                        }
+
+                        string title = stringBuilder.ToString();
+
+                        var series = new ResourceSeriesModel
+                        {
+                            Title = title,
+                            InterActivityAllocationType = resource.InterActivityAllocationType,
+                            ResourceSchedule = resourceSchedule,
+                            ColorFormat = resource.ColorFormat != null ? resource.ColorFormat with { } : ColorHelper.Preset(),
+                            UnitCost = resource.UnitCost,
+                            UnitBilling = resource.UnitBilling,
+                            FixedCost = resource.FixedCost,
+                            FixedBilling = resource.FixedBilling,
+                            DisplayOrder = resource.DisplayOrder,
+                        };
+
+                        unscheduledSeriesSet.Add(series);
+                        unscheduledResourceSeriesLookup.Add(resourceId, series);
+                    }
+                }
+
+                // Combined resource series.
+                // The intersection of the scheduled and unscheduled series.
+                List<ResourceSeriesModel> combinedSeriesSet = [.. scheduledSeriesSet];
+                var unscheduledSeriesAlreadyIncluded = new HashSet<int>();
+
+                foreach (ResourceSeriesModel combinedSeries in combinedSeriesSet)
+                {
+                    IList<bool> combinedActivityAllocations = [.. Enumerable.Repeat(false, finishTime)];
+                    IList<bool> combinedCostAllocations = [.. Enumerable.Repeat(false, finishTime)];
+                    IList<bool> combinedBillingAllocations = [.. Enumerable.Repeat(false, finishTime)];
+                    IList<bool> combinedEffortAllocations = [.. Enumerable.Repeat(false, finishTime)];
+
+                    if (combinedSeries.ResourceSchedule.Resource.Id != default)
+                    {
+                        int resourceId = combinedSeries.ResourceSchedule.Resource.Id;
+                        if (unscheduledResourceSeriesLookup.TryGetValue(resourceId, out ResourceSeriesModel? unscheduledResourceSeries))
+                        {
+                            combinedActivityAllocations = [.. combinedSeries.ResourceSchedule.ActivityAllocation.Zip(unscheduledResourceSeries.ResourceSchedule.ActivityAllocation, (x, y) => x || y)];
+                            combinedCostAllocations = [.. combinedSeries.ResourceSchedule.CostAllocation.Zip(unscheduledResourceSeries.ResourceSchedule.CostAllocation, (x, y) => x || y)];
+                            combinedBillingAllocations = [.. combinedSeries.ResourceSchedule.BillingAllocation.Zip(unscheduledResourceSeries.ResourceSchedule.BillingAllocation, (x, y) => x || y)];
+                            combinedEffortAllocations = [.. combinedSeries.ResourceSchedule.EffortAllocation.Zip(unscheduledResourceSeries.ResourceSchedule.EffortAllocation, (x, y) => x || y)];
+                            unscheduledSeriesAlreadyIncluded.Add(resourceId);
+                        }
+                        else
+                        {
+                            combinedActivityAllocations = [.. combinedSeries.ResourceSchedule.ActivityAllocation];
+                            combinedCostAllocations = [.. combinedSeries.ResourceSchedule.CostAllocation];
+                            combinedBillingAllocations = [.. combinedSeries.ResourceSchedule.BillingAllocation];
+                            combinedEffortAllocations = [.. combinedSeries.ResourceSchedule.EffortAllocation];
+                        }
+                    }
+                    else
+                    {
+                        combinedActivityAllocations = [.. combinedSeries.ResourceSchedule.ActivityAllocation];
+                        combinedCostAllocations = [.. combinedSeries.ResourceSchedule.CostAllocation];
+                        combinedBillingAllocations = [.. combinedSeries.ResourceSchedule.BillingAllocation];
+                        combinedEffortAllocations = [.. combinedSeries.ResourceSchedule.EffortAllocation];
+                    }
+
+                    combinedSeries.ResourceSchedule.ActivityAllocation.Clear();
+                    combinedSeries.ResourceSchedule.ActivityAllocation.AddRange(combinedActivityAllocations);
+                    combinedSeries.ResourceSchedule.CostAllocation.Clear();
+                    combinedSeries.ResourceSchedule.CostAllocation.AddRange(combinedCostAllocations);
+                    combinedSeries.ResourceSchedule.BillingAllocation.Clear();
+                    combinedSeries.ResourceSchedule.BillingAllocation.AddRange(combinedBillingAllocations);
+                    combinedSeries.ResourceSchedule.EffortAllocation.Clear();
+                    combinedSeries.ResourceSchedule.EffortAllocation.AddRange(combinedEffortAllocations);
+                }
+
+                // Finally, add the unscheduled series that have not already been included above.
+                // Prepend so that they might be displayed first after sorting.
+                List<ResourceSeriesModel> combined = [.. unscheduledSeriesSet.Where(x => !unscheduledSeriesAlreadyIncluded.Contains(x.ResourceSchedule.Resource.Id))];
+
+                combined.AddRange(combinedSeriesSet);
+
+                resourceSeriesSet.ResourceSchedules.AddRange(resourceSchedules);
+                resourceSeriesSet.Scheduled.AddRange(scheduledSeriesSet);
+                resourceSeriesSet.Unscheduled.AddRange(unscheduledSeriesSet);
+                resourceSeriesSet.Combined.AddRange(combined.OrderBy(x => x.DisplayOrder));
+            }
+
+            return resourceSeriesSet;
+        }
+
+        private static TrackingSeriesSetModel CalculateTrackingSeriesSet(
+            IEnumerable<ActivityModel> activities,
+            ResourceSettingsModel resourceSettings,
+            bool hasResources)
+        {
+            ArgumentNullException.ThrowIfNull(activities);
+            ArgumentNullException.ThrowIfNull(resourceSettings);
+
+            List<ResourceModel> resources = resourceSettings.Resources;
+
+            IList<ActivityModel> orderedActivities = [.. activities
+                .Where(x => !x.HasNoEffort)
+                .Select(x => x with { })
+                .OrderBy(x => x.EarliestFinishTime.GetValueOrDefault())
+                .ThenBy(x => x.EarliestStartTime.GetValueOrDefault())];
+
+            // Plan.
+            List<TrackingPointModel> planPointSeries = [];
+
+            // Progress.
+            List<TrackingPointModel> progressPointSeries = [];
+
+            // Effort.
+            List<TrackingPointModel> effortPointSeries = [];
+
+            // Plan Projection.
+            List<TrackingPointModel> planProjectionPointSeries = [];
+
+            // Progress Projection.
+            List<TrackingPointModel> progressProjectionPointSeries = [];
+
+            // Effort Projection.
+            List<TrackingPointModel> effortProjectionPointSeries = [];
+
+            var trackingSeriesSet = new TrackingSeriesSetModel
+            {
+                Plan = planPointSeries,
+                PlanProjection = planProjectionPointSeries,
+                Progress = progressPointSeries,
+                ProgressProjection = progressProjectionPointSeries,
+                Effort = effortPointSeries,
+                EffortProjection = effortProjectionPointSeries
+            };
+
+            if (!orderedActivities.Any())
+            {
+                return trackingSeriesSet;
+            }
+
+            double totalWorkingTime = Convert.ToDouble(orderedActivities.Sum(s => s.AllocatedToResources.Count * s.Duration));
+
+            // Find the anticipated end time according to the design plan.
+            int endTime = 0;
+
+            if (orderedActivities.Count > 0)
+            {
+                endTime = orderedActivities.Last().EarliestFinishTime.GetValueOrDefault();
+            }
+
+            // Always need at least one to mark the start.
+            planPointSeries.Add(new TrackingPointModel());
+
+            // Only bother calculating the plan if there is an end time.
+            if (endTime > 0)
+            {
+                // Plan.
+                // Build out a matrix of how we would expect progress to proceed
+                // for each activity if conditions were predictable.
+
+                var progressTimeline = new List<Dictionary<int, TrackingPointModel>>();
+
+                for (int i = 0; i < endTime; i++)
+                {
+                    progressTimeline.Add([]);
+                }
+
+                // Cycle through each activity and add its individual progress to the matrix.
+                foreach (ActivityModel activity in orderedActivities)
+                {
+                    int startTime = activity.EarliestStartTime.GetValueOrDefault();
+                    int finishTime = activity.EarliestFinishTime.GetValueOrDefault();
+
+                    // Check finish time < endtime
+                    ArgumentOutOfRangeException.ThrowIfGreaterThan(finishTime, endTime);
+
+                    // Do not bother if these values are not valid.
+                    if (finishTime > startTime)
+                    {
+                        double plannedProgress = 0.0;
+
+                        // Cycle through each time index.
+                        for (int timeIndex = 0; timeIndex < endTime; timeIndex++)
+                        {
+                            // Only need to increment during the period of activity.
+                            if (timeIndex >= startTime
+                                && timeIndex < finishTime)
+                            {
+                                plannedProgress++;
+                            }
+
+                            Dictionary<int, TrackingPointModel> trackingPointLookup = progressTimeline[timeIndex];
+
+                            if (!trackingPointLookup.TryGetValue(activity.Id, out TrackingPointModel? trackingPointModel))
+                            {
+                                trackingPointModel = new TrackingPointModel
+                                {
+                                    Time = timeIndex,
+                                    ActivityId = activity.Id,
+                                    ActivityName = activity.Name,
+                                    Value = plannedProgress,
+                                    ValuePercentage = 0.0,
+                                };
+                                trackingPointLookup.Add(activity.Id, trackingPointModel);
+                            }
+                            else
+                            {
+                                trackingPointModel.Value = plannedProgress;
+                                trackingPointModel.ValuePercentage = 0.0;
+                            }
+                        }
+                    }
+                }
+
+                // At this stage we need to cycle across all the time periods and
+                // work out how the time spent on each activity has contributed to
+                // overall progress.
+
+                Dictionary<int, ActivityModel> activityLookup = orderedActivities.ToDictionary(activity => activity.Id);
+
+                // Cycle through each time index.
+                for (int timeIndex = 0; timeIndex < endTime; timeIndex++)
+                {
+                    double runningTotalSpent = 0.0;
+                    Dictionary<int, TrackingPointModel> trackingPointLookup = progressTimeline[timeIndex];
+
+                    // Now cycle across each activity at this time index.
+                    foreach (KeyValuePair<int, TrackingPointModel> trackingPoint in trackingPointLookup)
+                    {
+                        int activityId = trackingPoint.Key;
+                        double portionOfActivityDuration = trackingPoint.Value.Value;
+
+                        if (activityLookup.TryGetValue(activityId, out ActivityModel? activity))
+                        {
+                            // Remember to count the time spent for each resource used.
+                            runningTotalSpent += activity.AllocatedToResources.Count * portionOfActivityDuration;
+                        }
+                    }
+
+                    // Now record the overall progress for the project and mark it out for the activities
+                    // that are being worked on at this moment in time.
+
+                    int time = timeIndex + 1; // Since the equivalent finish time would be the next day.
+
+                    foreach (KeyValuePair<int, TrackingPointModel> trackingPoint in trackingPointLookup)
+                    {
+                        int activityId = trackingPoint.Key;
+
+                        double percentage = totalWorkingTime == 0 ? 0.0 : 100.0 * runningTotalSpent / totalWorkingTime;
+
+                        if (activityLookup.TryGetValue(activityId, out ActivityModel? activity))
+                        {
+                            int startTime = activity.EarliestStartTime.GetValueOrDefault();
+                            int finishTime = activity.EarliestFinishTime.GetValueOrDefault();
+
+                            if (timeIndex >= startTime
+                                && timeIndex < finishTime)
+                            {
+                                planPointSeries.Add(new TrackingPointModel
+                                {
+                                    Time = time,
+                                    ActivityId = activityId,
+                                    ActivityName = activity.Name,
+                                    Value = runningTotalSpent,
+                                    ValuePercentage = percentage
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Find the new end time based on the tracking data.
+
+            int progressTime = activities
+                .SelectMany(x => x.Trackers)
+                .DefaultIfEmpty()
+                .Max(x => x?.Time ?? 0);
+
+            if (progressTime > endTime)
+            {
+                endTime = progressTime;
+            }
+
+            int effortTime = resources
+                .SelectMany(x => x.Trackers)
+                .DefaultIfEmpty()
+                .Max(x => x?.Time ?? 0);
+
+            if (effortTime > endTime)
+            {
+                endTime = effortTime;
+            }
+
+            // Only bother calculating the progress and effort if there is an end time.
+            if (endTime > 0)
+            {
+                {
+                    // Progress.
+                    progressPointSeries.Add(new TrackingPointModel());
+
+                    // Preprocess the activity trackers so they can be looked up
+                    // quickly according to the time.
+
+                    Dictionary<int, (ActivityModel activity, Dictionary<int, ActivityTrackerModel> activityTrackerLookup)> activityBehaviourLookup =
+                        orderedActivities.ToDictionary(
+                            activity => activity.Id,
+                            activity =>
+                            {
+                                int activityId = activity.Id;
+                                Dictionary<int, ActivityTrackerModel> activityTrackerLookup = [];
+
+                                foreach (ActivityTrackerModel tracker in activity.Trackers)
+                                {
+                                    if (tracker.ActivityId == activityId)
+                                    {
+                                        activityTrackerLookup[tracker.Time] = tracker;
+                                    }
+                                }
+
+                                return (activity, activityTrackerLookup);
+                            });
+
+                    // This is for tracking the working progresses for each activity.
+                    Dictionary<int, int> runningWorkingProgresses = orderedActivities.ToDictionary(activity => activity.Id, activity => 0);
+
+                    // Cycle through each time index.
+                    for (int timeIndex = 0; timeIndex <= endTime; timeIndex++)
+                    {
+                        // Here we need to update the running percentage completion for each activity.
+                        foreach ((ActivityModel activity, Dictionary<int, ActivityTrackerModel> activityTrackerLookup) in activityBehaviourLookup.Values)
+                        {
+                            int runningWorkingProgress = 0;
+
+                            if (runningWorkingProgresses.TryGetValue(activity.Id, out int workingCompletion))
+                            {
+                                runningWorkingProgress = workingCompletion;
+                            }
+
+                            if (activityTrackerLookup.TryGetValue(timeIndex, out ActivityTrackerModel? tracker))
+                            {
+                                if (tracker.PercentageComplete > runningWorkingProgress)
+                                {
+                                    runningWorkingProgress = tracker.PercentageComplete;
+                                }
+                            }
+
+                            runningWorkingProgresses[activity.Id] = runningWorkingProgress;
+                        }
+
+                        // Now we can calculate percentage progress for each activity that has
+                        // a percentage completed entry.
+                        double currentWorkingProgress = 0.0;
+
+                        foreach (ActivityModel activity in orderedActivities)
+                        {
+                            int percentageCompleted = runningWorkingProgresses[activity.Id];
+                            currentWorkingProgress += activity.AllocatedToResources.Count * activity.Duration * (percentageCompleted / 100.0);
+                        }
+
+                        double progressPercentage = endTime == 0 ? 0.0 : 100.0 * currentWorkingProgress / totalWorkingTime;
+                        int time = timeIndex + 1; // Since the equivalent finish time would be the next day.
+
+                        foreach ((ActivityModel activity, Dictionary<int, ActivityTrackerModel> activityTrackerLookup) in activityBehaviourLookup.Values)
+                        {
+                            // Now add progress points for activities only if they have
+                            // a recorded percentage completed entry for this time index.
+                            if (activityTrackerLookup.TryGetValue(timeIndex, out ActivityTrackerModel? tracker))
+                            {
+                                progressPointSeries.Add(new TrackingPointModel
+                                {
+                                    Time = time,
+                                    ActivityId = activity.Id,
+                                    ActivityName = activity.Name,
+                                    Value = currentWorkingProgress,
+                                    ValuePercentage = progressPercentage
+                                });
+                            }
+                        }
+                    }
+                }
+
+                // Do not bother with effort measures if we are assuming infinite resources.
+                if (hasResources)
+                {
+                    // Effort
+                    effortPointSeries.Add(new TrackingPointModel());
+
+                    // Preprocess the resource trackers so they can be looked up
+                    // quickly according to the time.
+
+                    Dictionary<int, (ResourceModel resource, Dictionary<int, ResourceTrackerModel> resourceTrackerLookup)> resourceBehaviourLookup =
+                        resources.ToDictionary(
+                            resource => resource.Id,
+                            resource =>
+                            {
+                                int resourceId = resource.Id;
+                                Dictionary<int, ResourceTrackerModel> resourceTrackerLookup = [];
+
+                                foreach (ResourceTrackerModel tracker in resource.Trackers)
+                                {
+                                    if (tracker.ResourceId == resourceId)
+                                    {
+                                        resourceTrackerLookup[tracker.Time] = tracker;
+                                    }
+                                }
+
+                                return (resource, resourceTrackerLookup);
+                            });
+
+                    // This is for tracking the working effort for each activity.
+                    Dictionary<int, int> runningWorkingEfforts = orderedActivities.ToDictionary(activity => activity.Id, activity => 0);
+
+                    // Cycle through each time index.
+                    for (int timeIndex = 0; timeIndex <= endTime; timeIndex++)
+                    {
+                        // Here we need to update the running percentage effort for each resource.
+                        foreach ((ResourceModel resource, Dictionary<int, ResourceTrackerModel> resourceTrackerLookup) in resourceBehaviourLookup.Values)
+                        {
+                            foreach (ActivityModel activity in orderedActivities)
+                            {
+                                int runningWorkingEffort = 0;
+                                int activityId = activity.Id;
+
+                                if (runningWorkingEfforts.TryGetValue(activityId, out int workingEffort))
+                                {
+                                    runningWorkingEffort = workingEffort;
+                                }
+
+                                if (resourceTrackerLookup.TryGetValue(timeIndex, out ResourceTrackerModel? tracker))
+                                {
+                                    foreach (ResourceActivityTrackerModel activityTracker in tracker.ActivityTrackers.Where(x => x.ActivityId == activityId))
+                                    {
+                                        runningWorkingEffort += activityTracker.PercentageWorked;
+                                    }
+                                }
+
+                                runningWorkingEfforts[activity.Id] = runningWorkingEffort;
+                            }
+                        }
+
+                        // Now we can calculate percentage effort for each activity that has
+                        // an effort percentage completed entry.
+                        double currentWorkingEffort = 0.0;
+
+                        foreach (ActivityModel activity in orderedActivities)
+                        {
+                            int percentageWorked = runningWorkingEfforts[activity.Id];
+                            currentWorkingEffort += percentageWorked / 100.0;
+                        }
+
+                        double effortPercentage = endTime == 0 ? 0.0 : 100.0 * currentWorkingEffort / totalWorkingTime;
+                        int time = timeIndex + 1; // Since the equivalent finish time would be the next day.
+
+                        foreach ((ResourceModel resource, Dictionary<int, ResourceTrackerModel> resourceTrackerLookup) in resourceBehaviourLookup.Values)
+                        {
+                            // Now add effort points for activities only if they have
+                            // a recorded effort completed entry for this time index.
+                            if (resourceTrackerLookup.TryGetValue(timeIndex, out ResourceTrackerModel? tracker))
+                            {
+                                int resourceId = tracker.ResourceId;
+
+                                foreach (ResourceActivityTrackerModel activityTracker in tracker.ActivityTrackers.Where(x => x.ResourceId == resourceId))
+                                {
+                                    effortPointSeries.Add(new TrackingPointModel
+                                    {
+                                        Time = time,
+                                        ActivityId = activityTracker.ActivityId,
+                                        ActivityName = activityTracker.ActivityName,
+                                        Value = currentWorkingEffort,
+                                        ValuePercentage = effortPercentage
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Projections.
+
+            // Plan
+            {
+                planProjectionPointSeries.Add(new TrackingPointModel());
+                // Each series will always have at least one item.
+                planProjectionPointSeries.Add(planPointSeries.Last());
+            }
+
+            // Progress
+            {
+                progressProjectionPointSeries.Add(new TrackingPointModel());
+
+                if (progressPointSeries.Count > 1)
+                {
+                    var projectedLinearFit = MathNet.Numerics.Fit.LineThroughOrigin(
+                        [.. progressPointSeries.Select(p => (double)p.Time)],
+                        [.. progressPointSeries.Select(p => p.Value)]);
+
+                    var lastTrackingPoint = planPointSeries.Last();
+
+                    if (projectedLinearFit > 0)
+                    {
+                        var projectedCompletion = lastTrackingPoint.Value / projectedLinearFit;
+
+                        progressProjectionPointSeries.Add(new TrackingPointModel
+                        {
+                            ActivityId = lastTrackingPoint.ActivityId,
+                            ActivityName = lastTrackingPoint.ActivityName,
+                            Value = lastTrackingPoint.Value,
+                            ValuePercentage = lastTrackingPoint.ValuePercentage,
+                            Time = (int)Math.Ceiling(projectedCompletion)
+                        });
+                    }
+                }
+            }
+
+            // Effort
+            if (hasResources
+                && effortPointSeries.Count > 1)
+            {
+                effortProjectionPointSeries.Add(new TrackingPointModel());
+
+                // We want to project effort out to the greater of the plan or the progress projection.
+                var projectedCompletion = Math.Max(
+                    progressProjectionPointSeries.Last().Time,
+                    planProjectionPointSeries.Last().Time);
+
+                var projectedLinearFit = MathNet.Numerics.Fit.LineThroughOrigin(
+                    [.. effortPointSeries.Select(p => (double)p.Time)],
+                    [.. effortPointSeries.Select(p => p.Value)]);
+
+                var lastTrackingPoint = planPointSeries.Last();
+
+                if (lastTrackingPoint.Value > 0)
+                {
+                    var projectedFinalEffort = projectedLinearFit * projectedCompletion;
+
+                    effortProjectionPointSeries.Add(new TrackingPointModel
+                    {
+                        ActivityId = lastTrackingPoint.ActivityId,
+                        ActivityName = lastTrackingPoint.ActivityName,
+                        Value = projectedFinalEffort,
+                        ValuePercentage = (projectedFinalEffort / lastTrackingPoint.Value) * 100.0,
+                        Time = projectedCompletion
+                    });
+                }
+            }
+
+            return trackingSeriesSet;
+        }
+
+        #endregion
+
+        #region IResourceSchedulingService Members
+
+        public ResourceSeriesSetModel BuildResourceSeriesSet(
+            IGraphCompilation<int, int, int, IDependentActivity> graphCompilation,
+            ResourceSettingsModel resourceSettings)
+        {
+            ArgumentNullException.ThrowIfNull(graphCompilation);
+            ArgumentNullException.ThrowIfNull(resourceSettings);
+
+            IList<ResourceScheduleModel> resourceScheduleModels =
+                [.. m_Mapper.ToResourceScheduleModels(graphCompilation)];
+
+            return CalculateResourceSeriesSet(resourceScheduleModels, resourceSettings);
+        }
+
+        public TrackingSeriesSetModel BuildTrackingSeriesSet(
+            IEnumerable<ActivityModel> activities,
+            ResourceSettingsModel resourceSettings,
+            bool hasResources)
+        {
+            ArgumentNullException.ThrowIfNull(activities);
+            ArgumentNullException.ThrowIfNull(resourceSettings);
+
+            return CalculateTrackingSeriesSet(activities, resourceSettings, hasResources);
+        }
+
+        #endregion
+    }
+}

--- a/src/Zametek.ViewModel.ProjectPlan/TrackingManagement/TrackingManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/TrackingManagement/TrackingManagerViewModel.cs
@@ -240,7 +240,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_IsBusy?.Dispose();
                 m_HasActivities?.Dispose();
@@ -250,9 +249,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_ProjectStart?.Dispose();
                 m_HasCompilationErrors?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/WorkStreamSettingsManagement/ManagedWorkStreamViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/WorkStreamSettingsManagement/ManagedWorkStreamViewModel.cs
@@ -135,19 +135,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 return;
             }
 
-            if (disposing)
-            {
-                // TODO: dispose managed state (managed objects).
-                //m_ProjectStartSub?.Dispose();
-                //m_ResourceSettingsSub?.Dispose();
-                //m_DateTimeCalculatorSub?.Dispose();
-                //m_CompilationSub?.Dispose();
-                //ResourceSelector.Dispose();
-            }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
-
             m_Disposed = true;
         }
 

--- a/src/Zametek.ViewModel.ProjectPlan/WorkStreamSettingsManagement/WorkStreamSettingsManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/WorkStreamSettingsManagement/WorkStreamSettingsManagerViewModel.cs
@@ -415,7 +415,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 m_IsBusy?.Dispose();
                 m_HasStaleOutputs?.Dispose();
                 m_HasCompilationErrors?.Dispose();
@@ -426,9 +425,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 ClearManagedWorkStreams();
                 m_WorkStreams?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/Zametek.ViewModel.ProjectPlan.csproj
+++ b/src/Zametek.ViewModel.ProjectPlan/Zametek.ViewModel.ProjectPlan.csproj
@@ -11,6 +11,7 @@
 	<PackageReference Include="AutomaticGraphLayout.Drawing" Version="1.1.12" />
     <PackageReference Include="Dock.Model.ReactiveUI" Version="11.3.11.22" />
     <PackageReference Include="Dock.Serializer.Newtonsoft" Version="11.3.11.22" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <!--<PackageReference Include="Dock.Serializer.SystemTextJson" Version="11.3.11.22" />-->
     <PackageReference Include="Ical.Net" Version="5.2.1" />
     <PackageReference Include="net.sf.mpxj-for-csharp" Version="13.12.0" />
@@ -20,7 +21,6 @@
     <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.2" />
     <PackageReference Include="Svg.Controls.Skia.Avalonia" Version="11.3.9.5" />
     <PackageReference Include="System.Drawing.Common" Version="10.0.5" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
     <PackageReference Include="Zametek.Maths.Graphs.Compilers" Version="2.4.8" />
   </ItemGroup>
 

--- a/test/Zametek.ViewModel.ProjectPlan.Tests/HolidayManagement/RecurrencePatternHelperEdgeCaseTests.cs
+++ b/test/Zametek.ViewModel.ProjectPlan.Tests/HolidayManagement/RecurrencePatternHelperEdgeCaseTests.cs
@@ -1,0 +1,247 @@
+using Shouldly;
+using System;
+using Xunit;
+using Zametek.Common.ProjectPlan;
+
+namespace Zametek.ViewModel.ProjectPlan.Tests
+{
+    /// <summary>
+    /// Edge-case tests for RecurrencePatternHelper that are not covered by the
+    /// round-trip fixture (which exercises the happy path).
+    /// Covers: day/frequency parsing utilities, error paths, and boundary values.
+    /// </summary>
+    public class RecurrencePatternHelperEdgeCaseTests
+    {
+        #region ParseFrequency — all tokens
+
+        [Theory]
+        [InlineData("SECONDLY", RecurrenceFrequency.Secondly)]
+        [InlineData("MINUTELY", RecurrenceFrequency.Minutely)]
+        [InlineData("HOURLY",   RecurrenceFrequency.Hourly)]
+        [InlineData("DAILY",    RecurrenceFrequency.Daily)]
+        [InlineData("WEEKLY",   RecurrenceFrequency.Weekly)]
+        [InlineData("MONTHLY",  RecurrenceFrequency.Monthly)]
+        [InlineData("YEARLY",   RecurrenceFrequency.Yearly)]
+        public void ParseFrequency_KnownToken_ReturnsExpectedFrequency(string token, RecurrenceFrequency expected)
+        {
+            RecurrencePatternHelper.ParseFrequency(token).ShouldBe(expected);
+        }
+
+        [Theory]
+        [InlineData("daily")]    // lowercase
+        [InlineData("Daily")]    // mixed case
+        public void ParseFrequency_CaseInsensitive_RecognisesLowerCase(string token)
+        {
+            RecurrencePatternHelper.ParseFrequency(token).ShouldBe(RecurrenceFrequency.Daily);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("UNKNOWN")]
+        [InlineData("FORTNIGHTLY")]
+        public void ParseFrequency_UnknownToken_ReturnsNone(string token)
+        {
+            RecurrencePatternHelper.ParseFrequency(token).ShouldBe(RecurrenceFrequency.None);
+        }
+
+        #endregion
+
+        #region ParseDay — all tokens
+
+        [Theory]
+        [InlineData("MO", RecurrenceDay.MO)]
+        [InlineData("TU", RecurrenceDay.TU)]
+        [InlineData("WE", RecurrenceDay.WE)]
+        [InlineData("TH", RecurrenceDay.TH)]
+        [InlineData("FR", RecurrenceDay.FR)]
+        [InlineData("SA", RecurrenceDay.SA)]
+        [InlineData("SU", RecurrenceDay.SU)]
+        public void ParseDay_KnownToken_ReturnsExpectedDay(string token, RecurrenceDay expected)
+        {
+            RecurrencePatternHelper.ParseDay(token).ShouldBe(expected);
+        }
+
+        [Theory]
+        [InlineData("mo")]
+        [InlineData("Mo")]
+        public void ParseDay_LowercaseMO_ReturnsMonday(string token)
+        {
+            RecurrencePatternHelper.ParseDay(token).ShouldBe(RecurrenceDay.MO);
+        }
+
+        #endregion
+
+        #region ToDayToken — all days
+
+        [Theory]
+        [InlineData(RecurrenceDay.MO, "MO")]
+        [InlineData(RecurrenceDay.TU, "TU")]
+        [InlineData(RecurrenceDay.WE, "WE")]
+        [InlineData(RecurrenceDay.TH, "TH")]
+        [InlineData(RecurrenceDay.FR, "FR")]
+        [InlineData(RecurrenceDay.SA, "SA")]
+        [InlineData(RecurrenceDay.SU, "SU")]
+        public void ToDayToken_AllDays_RoundTripWithParseDay(RecurrenceDay day, string expectedToken)
+        {
+            string token = RecurrencePatternHelper.ToDayToken(day);
+            token.ShouldBe(expectedToken);
+            RecurrencePatternHelper.ParseDay(token).ShouldBe(day);
+        }
+
+        #endregion
+
+        #region ToRecurrenceDay / ToDayOfWeek round-trips
+
+        [Theory]
+        [InlineData(DayOfWeek.Monday,    RecurrenceDay.MO)]
+        [InlineData(DayOfWeek.Tuesday,   RecurrenceDay.TU)]
+        [InlineData(DayOfWeek.Wednesday, RecurrenceDay.WE)]
+        [InlineData(DayOfWeek.Thursday,  RecurrenceDay.TH)]
+        [InlineData(DayOfWeek.Friday,    RecurrenceDay.FR)]
+        [InlineData(DayOfWeek.Saturday,  RecurrenceDay.SA)]
+        [InlineData(DayOfWeek.Sunday,    RecurrenceDay.SU)]
+        public void ToRecurrenceDay_ToDayOfWeek_RoundTrips(DayOfWeek dotNetDay, RecurrenceDay expected)
+        {
+            RecurrenceDay recurrenceDay = RecurrencePatternHelper.ToRecurrenceDay(dotNetDay);
+            recurrenceDay.ShouldBe(expected);
+            RecurrencePatternHelper.ToDayOfWeek(recurrenceDay).ShouldBe(dotNetDay);
+        }
+
+        #endregion
+
+        #region ToFrequencyToken — all frequencies
+
+        [Theory]
+        [InlineData(RecurrenceFrequency.Secondly, "SECONDLY")]
+        [InlineData(RecurrenceFrequency.Minutely, "MINUTELY")]
+        [InlineData(RecurrenceFrequency.Hourly,   "HOURLY")]
+        [InlineData(RecurrenceFrequency.Daily,    "DAILY")]
+        [InlineData(RecurrenceFrequency.Weekly,   "WEEKLY")]
+        [InlineData(RecurrenceFrequency.Monthly,  "MONTHLY")]
+        [InlineData(RecurrenceFrequency.Yearly,   "YEARLY")]
+        public void ToFrequencyToken_AllFrequencies_ReturnExpectedTokens(RecurrenceFrequency freq, string expectedToken)
+        {
+            RecurrencePatternHelper.ToFrequencyToken(freq).ShouldBe(expectedToken);
+        }
+
+        #endregion
+
+        #region ToRule — error paths
+
+        [Fact]
+        public void ToRule_NullInput_Returns_EmptyModel()
+        {
+            // null is treated the same as empty string.
+            RecurrenceRuleModel model = RecurrencePatternHelper.ToRule(null);
+            model.Frequency.ShouldBe(RecurrenceFrequency.None);
+        }
+
+        [Fact]
+        public void ToRule_WhitespaceOnly_Returns_EmptyModel()
+        {
+            RecurrenceRuleModel model = RecurrencePatternHelper.ToRule("   ");
+            model.Frequency.ShouldBe(RecurrenceFrequency.None);
+        }
+
+        [Fact]
+        public void ToRule_MissingFrequency_Throws_FormatException()
+        {
+            Should.Throw<FormatException>(() => RecurrencePatternHelper.ToRule("COUNT=5"));
+        }
+
+        [Fact]
+        public void ToRule_DuplicateKey_Throws_FormatException()
+        {
+            Should.Throw<FormatException>(() =>
+                RecurrencePatternHelper.ToRule("FREQ=DAILY;FREQ=WEEKLY"));
+        }
+
+        [Fact]
+        public void ToRule_BothCountAndUntil_Throws_InvalidOperationException()
+        {
+            Should.Throw<InvalidOperationException>(() =>
+                RecurrencePatternHelper.ToRule("FREQ=DAILY;COUNT=5;UNTIL=20261231T000000"));
+        }
+
+        [Fact]
+        public void ToRule_ZeroInterval_Throws_FormatException_Or_InvalidOperationException()
+        {
+            // INTERVAL=0 is not a positive integer so the parser should throw.
+            Should.Throw<Exception>(() => RecurrencePatternHelper.ToRule("FREQ=DAILY;INTERVAL=0"));
+        }
+
+        #endregion
+
+        #region ToPattern — FREQ=NONE produces empty string
+
+        [Fact]
+        public void ToPattern_FrequencyNone_Returns_EmptyString()
+        {
+            var model = new RecurrenceRuleModel { Frequency = RecurrenceFrequency.None };
+            RecurrencePatternHelper.ToPattern(model).ShouldBe(string.Empty);
+        }
+
+        #endregion
+
+        #region ToPattern — interval of 1 is omitted, other values are included
+
+        [Fact]
+        public void ToPattern_Interval_Of_One_Is_Omitted_From_Output()
+        {
+            var model = new RecurrenceRuleModel { Frequency = RecurrenceFrequency.Daily, Interval = 1 };
+            string pattern = RecurrencePatternHelper.ToPattern(model);
+            pattern.ShouldNotContain("INTERVAL");
+        }
+
+        [Fact]
+        public void ToPattern_Interval_Greater_Than_One_Is_Included()
+        {
+            var model = new RecurrenceRuleModel { Frequency = RecurrenceFrequency.Daily, Interval = 3 };
+            string pattern = RecurrencePatternHelper.ToPattern(model);
+            pattern.ShouldContain("INTERVAL=3");
+        }
+
+        #endregion
+
+        #region ToRule — UNTIL date-only format is accepted
+
+        [Fact]
+        public void ToRule_UntilDateOnly_Format_Is_Parsed()
+        {
+            // iCal allows UNTIL=YYYYMMDD (without the time component).
+            RecurrenceRuleModel model = RecurrencePatternHelper.ToRule("FREQ=DAILY;UNTIL=20261231");
+            model.Frequency.ShouldBe(RecurrenceFrequency.Daily);
+            model.Until.ShouldNotBeNull();
+            model.Until!.Value.Year.ShouldBe(2026);
+            model.Until!.Value.Month.ShouldBe(12);
+            model.Until!.Value.Day.ShouldBe(31);
+        }
+
+        #endregion
+
+        #region Negative BYMONTHDAY is preserved
+
+        [Fact]
+        public void ToRule_NegativeByMonthDay_Preserved()
+        {
+            // "BYMONTHDAY=-1" means the last day of the month.
+            RecurrenceRuleModel model = RecurrencePatternHelper.ToRule("FREQ=MONTHLY;BYMONTHDAY=-1");
+            model.ByMonthDay.ShouldContain(-1);
+        }
+
+        [Fact]
+        public void ToPattern_NegativeByMonthDay_RoundTrips()
+        {
+            var model = new RecurrenceRuleModel
+            {
+                Frequency  = RecurrenceFrequency.Monthly,
+                ByMonthDay = [-1],
+            };
+            string pattern = RecurrencePatternHelper.ToPattern(model);
+            RecurrenceRuleModel reparsed = RecurrencePatternHelper.ToRule(pattern);
+            reparsed.ByMonthDay.ShouldContain(-1);
+        }
+
+        #endregion
+    }
+}

--- a/test/Zametek.ViewModel.ProjectPlan.Tests/Miscellaneous/ColorHelperTests.cs
+++ b/test/Zametek.ViewModel.ProjectPlan.Tests/Miscellaneous/ColorHelperTests.cs
@@ -1,0 +1,248 @@
+using Shouldly;
+using System;
+using Xunit;
+using Zametek.Common.ProjectPlan;
+
+namespace Zametek.ViewModel.ProjectPlan.Tests
+{
+    /// <summary>
+    /// Tests for ColorHelper. The class operates purely on bytes and string
+    /// manipulation, so no Avalonia application host is required.
+    /// </summary>
+    public class ColorHelperTests
+    {
+        #region Named-colour factories
+
+        [Fact]
+        public void None_Returns_AllZeroAlphaAndChannels()
+        {
+            ColorFormatModel c = ColorHelper.None();
+            c.A.ShouldBe((byte)0);
+            c.R.ShouldBe((byte)0);
+            c.G.ShouldBe((byte)0);
+            c.B.ShouldBe((byte)0);
+        }
+
+        [Fact]
+        public void Black_Returns_OpaqueBlack()
+        {
+            ColorFormatModel c = ColorHelper.Black();
+            c.A.ShouldBe(ColorHelper.AnnotationAFull);
+            c.R.ShouldBe((byte)0);
+            c.G.ShouldBe((byte)0);
+            c.B.ShouldBe((byte)0);
+        }
+
+        [Fact]
+        public void Red_Returns_OpaqueRed()
+        {
+            ColorFormatModel c = ColorHelper.Red();
+            c.A.ShouldBe(ColorHelper.AnnotationAFull);
+            c.R.ShouldBe((byte)255);
+            c.G.ShouldBe((byte)0);
+            c.B.ShouldBe((byte)0);
+        }
+
+        [Fact]
+        public void Gold_Returns_OpaqueGold()
+        {
+            ColorFormatModel c = ColorHelper.Gold();
+            c.A.ShouldBe(ColorHelper.AnnotationAFull);
+            c.R.ShouldBe((byte)255);
+            c.G.ShouldBe((byte)215);
+            c.B.ShouldBe((byte)0);
+        }
+
+        [Fact]
+        public void Green_Returns_OpaqueGreen()
+        {
+            ColorFormatModel c = ColorHelper.Green();
+            c.A.ShouldBe(ColorHelper.AnnotationAFull);
+            c.R.ShouldBe((byte)0);
+            c.G.ShouldBe((byte)128);
+            c.B.ShouldBe((byte)0);
+        }
+
+        #endregion
+
+        #region Random
+
+        [Fact]
+        public void Random_Returns_OpaqueColor()
+        {
+            // Alpha is always 255; RGB are random.
+            ColorFormatModel c = ColorHelper.Random();
+            c.A.ShouldBe(ColorHelper.AnnotationAFull);
+        }
+
+        #endregion
+
+        #region Preset cycling
+
+        [Fact]
+        public void Preset_CyclesThrough_MultipleColors_Without_Repeating_Immediately()
+        {
+            ColorHelper.PresetReset();
+            ColorFormatModel first  = ColorHelper.Preset();
+            ColorFormatModel second = ColorHelper.Preset();
+            // Two consecutive Preset() calls must not return the identical value
+            // (the list has 20 entries so the first two are guaranteed to differ).
+            (first.R == second.R && first.G == second.G && first.B == second.B).ShouldBeFalse();
+        }
+
+        [Fact]
+        public void PresetReset_Causes_NextPreset_ToReturnFirstColor()
+        {
+            ColorHelper.PresetReset();
+            ColorFormatModel a = ColorHelper.Preset();
+            ColorHelper.PresetReset();
+            ColorFormatModel b = ColorHelper.Preset();
+            // After resetting the index both calls should produce the same colour.
+            a.R.ShouldBe(b.R);
+            a.G.ShouldBe(b.G);
+            a.B.ShouldBe(b.B);
+        }
+
+        #endregion
+
+        #region BytesToHtmlHexCode (3-byte variant)
+
+        [Fact]
+        public void BytesToHtmlHexCode_3Bytes_Returns_HashPrefixedUppercaseHex()
+        {
+            string hex = ColorHelper.BytesToHtmlHexCode(0xFF, 0x00, 0x80);
+            hex.ShouldBe("#FF0080");
+        }
+
+        [Fact]
+        public void BytesToHtmlHexCode_3Bytes_AllZero_Returns_HashThreeZeroPairs()
+        {
+            string hex = ColorHelper.BytesToHtmlHexCode(0x00, 0x00, 0x00);
+            hex.ShouldBe("#000000");
+        }
+
+        [Fact]
+        public void BytesToHtmlHexCode_3Bytes_AllMax_Returns_FFFFFF()
+        {
+            string hex = ColorHelper.BytesToHtmlHexCode(0xFF, 0xFF, 0xFF);
+            hex.ShouldBe("#FFFFFF");
+        }
+
+        #endregion
+
+        #region BytesToHtmlHexCode (4-byte variant)
+
+        [Fact]
+        public void BytesToHtmlHexCode_4Bytes_Includes_Alpha_First()
+        {
+            // ARGB ordering: A=FF, R=12, G=34, B=56
+            string hex = ColorHelper.BytesToHtmlHexCode(0xFF, 0x12, 0x34, 0x56);
+            hex.ShouldBe("#FF123456");
+        }
+
+        [Fact]
+        public void BytesToHtmlHexCode_4Bytes_ZeroAlpha_StartsWithDoubleZero()
+        {
+            string hex = ColorHelper.BytesToHtmlHexCode(0x00, 0xAA, 0xBB, 0xCC);
+            hex.ShouldBe("#00AABBCC");
+        }
+
+        #endregion
+
+        #region ColorFormatToHtmlHexCode
+
+        [Fact]
+        public void ColorFormatToHtmlHexCode_RoundTrips_Via_HtmlHexCodeToColorFormat()
+        {
+            // Build a colour, convert to hex string, parse back, compare.
+            var original = new ColorFormatModel { A = 255, R = 0x1A, G = 0x2B, B = 0x3C };
+            string hex = ColorHelper.ColorFormatToHtmlHexCode(original);
+
+            // The 4-byte path includes alpha; strip leading '#' for length check.
+            hex.ShouldStartWith("#");
+            (hex.Length == 7 || hex.Length == 9).ShouldBeTrue(); // #RRGGBB or #AARRGGBB
+        }
+
+        #endregion
+
+        #region HtmlHexCodeToColorFormat
+
+        [Fact]
+        public void HtmlHexCodeToColorFormat_ValidSixDigit_Returns_CorrectChannels()
+        {
+            // #FF8000 = R=255, G=128, B=0, A=255 (default)
+            ColorFormatModel c = ColorHelper.HtmlHexCodeToColorFormat("#FF8000");
+            c.R.ShouldBe((byte)0xFF);
+            c.G.ShouldBe((byte)0x80);
+            c.B.ShouldBe((byte)0x00);
+            c.A.ShouldBe(byte.MaxValue);
+        }
+
+        [Fact]
+        public void HtmlHexCodeToColorFormat_ValidEightDigit_Returns_CorrectAlpha()
+        {
+            // 8-digit: #RRGGBBAA (note: the regex captures groups of 2 per channel)
+            // bytes[0]=R, bytes[1]=G, bytes[2]=B, bytes[3]=A
+            ColorFormatModel c = ColorHelper.HtmlHexCodeToColorFormat("#FF800040");
+            c.R.ShouldBe((byte)0xFF);
+            c.G.ShouldBe((byte)0x80);
+            c.B.ShouldBe((byte)0x00);
+            c.A.ShouldBe((byte)0x40);
+        }
+
+        [Fact]
+        public void HtmlHexCodeToColorFormat_InvalidInput_Returns_DefaultColorFormat()
+        {
+            // Malformed input should return a zeroed-out model (not throw).
+            ColorFormatModel c = ColorHelper.HtmlHexCodeToColorFormat("notacolor");
+            c.R.ShouldBe((byte)0);
+            c.G.ShouldBe((byte)0);
+            c.B.ShouldBe((byte)0);
+            c.A.ShouldBe((byte)0);
+        }
+
+        [Fact]
+        public void HtmlHexCodeToColorFormat_MissingHash_Returns_DefaultColorFormat()
+        {
+            ColorFormatModel c = ColorHelper.HtmlHexCodeToColorFormat("FF8000");
+            c.R.ShouldBe((byte)0);
+            c.G.ShouldBe((byte)0);
+            c.B.ShouldBe((byte)0);
+        }
+
+        [Fact]
+        public void HtmlHexCodeToColorFormat_EmptyString_Returns_DefaultColorFormat()
+        {
+            ColorFormatModel c = ColorHelper.HtmlHexCodeToColorFormat(string.Empty);
+            c.A.ShouldBe((byte)0);
+        }
+
+        #endregion
+
+        #region Constant values sanity check
+
+        [Fact]
+        public void AnnotationAFull_Is_255()
+        {
+            ColorHelper.AnnotationAFull.ShouldBe((byte)255);
+        }
+
+        [Fact]
+        public void AnnotationATransparent_IsLessThan_AnnotationALight()
+        {
+            ((int)ColorHelper.AnnotationATransparent).ShouldBeLessThan(ColorHelper.AnnotationALight);
+        }
+
+        [Fact]
+        public void AlphaConstants_AreStrictlyOrdered()
+        {
+            // Transparent < Light < Medium < Heavy < Full
+            ((int)ColorHelper.AnnotationATransparent).ShouldBeLessThan(ColorHelper.AnnotationALight);
+            ((int)ColorHelper.AnnotationALight).ShouldBeLessThan(ColorHelper.AnnotationAMedium);
+            ((int)ColorHelper.AnnotationAMedium).ShouldBeLessThan(ColorHelper.AnnotationAHeavy);
+            ((int)ColorHelper.AnnotationAHeavy).ShouldBeLessThan(ColorHelper.AnnotationAFull);
+        }
+
+        #endregion
+    }
+}

--- a/test/Zametek.ViewModel.ProjectPlan.Tests/Miscellaneous/DateTimeCalculatorEdgeCaseTests.cs
+++ b/test/Zametek.ViewModel.ProjectPlan.Tests/Miscellaneous/DateTimeCalculatorEdgeCaseTests.cs
@@ -1,0 +1,275 @@
+using Shouldly;
+using System;
+using Xunit;
+using Zametek.Common.ProjectPlan;
+
+namespace Zametek.ViewModel.ProjectPlan.Tests
+{
+    /// <summary>
+    /// Additional edge-case tests for DateTimeCalculator not covered by
+    /// DateTimeCalculatorTests. Focuses on:
+    ///   • DisplayMode.Classic vs Default behaviour
+    ///   • CalculateTimeAndDateTime(DateTimeOffset?) overload
+    ///   • Weekends mode: start-date-is-Saturday edge case
+    ///   • Large number of working days across multiple weekends
+    ///   • NonWorkingDayMode.Weekends: AddDays with 10 working days
+    ///   • CustomCalendar with multiple holidays in one week
+    /// </summary>
+    public class DateTimeCalculatorEdgeCaseTests
+    {
+        #region Helpers
+
+        private static DateTimeOffset Local(int year, int month, int day) =>
+            new DateTimeOffset(
+                new DateTime(year, month, day),
+                TimeZoneInfo.Local.GetUtcOffset(new DateTime(year, month, day)));
+
+        private static DateTimeCalculator CreateCalculator(
+            NonWorkingDayMode mode = NonWorkingDayMode.None,
+            DateTimeDisplayMode displayMode = DateTimeDisplayMode.Default)
+        {
+            var calc = new DateTimeCalculator(TimeProvider.System);
+            calc.NonWorkingDayMode = mode;
+            calc.DisplayMode = displayMode;
+            return calc;
+        }
+
+        #endregion
+
+        #region CalculateTimeAndDateTime — DateTimeOffset? overload
+
+        [Fact]
+        public void CalculateTimeAndDateTime_FromDateTimeOffset_NullInput_Returns_Nulls()
+        {
+            var calc = CreateCalculator(NonWorkingDayMode.None);
+            var projectStart = Local(2025, 1, 6);
+
+            (int? days, DateTimeOffset? dto) = calc.CalculateTimeAndDateTime(projectStart, (DateTimeOffset?)null);
+
+            days.ShouldBeNull();
+            dto.ShouldBeNull();
+        }
+
+        [Fact]
+        public void CalculateTimeAndDateTime_FromDateTimeOffset_ProjectStartInput_Returns_Zero()
+        {
+            var calc = CreateCalculator(NonWorkingDayMode.None);
+            var projectStart = Local(2025, 1, 6);
+
+            (int? days, DateTimeOffset? dto) = calc.CalculateTimeAndDateTime(projectStart, (DateTimeOffset?)projectStart);
+
+            days.ShouldBe(0);
+            dto.ShouldNotBeNull();
+            dto!.Value.Date.ShouldBe(projectStart.Date);
+        }
+
+        [Fact]
+        public void CalculateTimeAndDateTime_FromDateTimeOffset_BeforeProjectStart_ClampsToProjectStart()
+        {
+            var calc = CreateCalculator(NonWorkingDayMode.None);
+            var projectStart = Local(2025, 6, 10);
+            var beforeStart  = Local(2025, 1, 1); // way before project start
+
+            (int? days, DateTimeOffset? dto) = calc.CalculateTimeAndDateTime(projectStart, (DateTimeOffset?)beforeStart);
+
+            // Should clamp: days = 0, date = projectStart
+            days.ShouldBe(0);
+            dto.ShouldNotBeNull();
+            dto!.Value.Date.ShouldBe(projectStart.Date);
+        }
+
+        [Fact]
+        public void CalculateTimeAndDateTime_FromDateTimeOffset_AfterProjectStart_Returns_PositiveDays()
+        {
+            var calc = CreateCalculator(NonWorkingDayMode.None);
+            var projectStart = Local(2025, 6, 1);
+            var input        = Local(2025, 6, 11); // 10 calendar days later
+
+            (int? days, DateTimeOffset? dto) = calc.CalculateTimeAndDateTime(projectStart, (DateTimeOffset?)input);
+
+            days.ShouldBe(10);
+            dto.ShouldNotBeNull();
+        }
+
+        #endregion
+
+        #region DisplayMode.Classic — DisplayEarliestStartDate
+
+        [Fact]
+        public void DisplayEarliestStartDate_Default_Returns_EarliestStart_Unchanged()
+        {
+            var calc = CreateCalculator(NonWorkingDayMode.None, DateTimeDisplayMode.Default);
+            var projectStart  = Local(2025, 6, 1);
+            var earliestStart = Local(2025, 6, 5);
+
+            DateTimeOffset result = calc.DisplayEarliestStartDate(projectStart, earliestStart, duration: 5);
+            result.Date.ShouldBe(earliestStart.Date);
+        }
+
+        [Fact]
+        public void DisplayFinishDate_Default_Returns_FinishDate_Unchanged()
+        {
+            var calc   = CreateCalculator(NonWorkingDayMode.None, DateTimeDisplayMode.Default);
+            var start  = Local(2025, 6, 1);
+            var finish = Local(2025, 6, 10);
+
+            DateTimeOffset result = calc.DisplayFinishDate(start, finish, duration: 5);
+            result.Date.ShouldBe(finish.Date);
+        }
+
+        [Fact]
+        public void DisplayLatestStartDate_Default_Returns_LatestStart_Unchanged()
+        {
+            var calc         = CreateCalculator(NonWorkingDayMode.None, DateTimeDisplayMode.Default);
+            var earliestStart = Local(2025, 6, 1);
+            var latestStart   = Local(2025, 6, 5);
+
+            DateTimeOffset result = calc.DisplayLatestStartDate(earliestStart, latestStart, duration: 3);
+            result.Date.ShouldBe(latestStart.Date);
+        }
+
+        #endregion
+
+        #region DisplayMode.Classic — MaximumLatestFinishDate In/Out
+
+        [Fact]
+        public void MaximumLatestFinishDateIn_Default_Returns_MaxLatestFinish_Unchanged()
+        {
+            var calc           = CreateCalculator(NonWorkingDayMode.None, DateTimeDisplayMode.Default);
+            var start          = Local(2025, 6, 1);
+            var maxLatestFinish = Local(2025, 6, 30);
+
+            DateTimeOffset result = calc.MaximumLatestFinishDateIn(start, maxLatestFinish, duration: 5);
+            result.Date.ShouldBe(maxLatestFinish.Date);
+        }
+
+        [Fact]
+        public void MaximumLatestFinishDateOut_Default_Returns_MaxLatestFinish_Unchanged()
+        {
+            var calc           = CreateCalculator(NonWorkingDayMode.None, DateTimeDisplayMode.Default);
+            var start          = Local(2025, 6, 1);
+            var maxLatestFinish = Local(2025, 6, 30);
+
+            DateTimeOffset result = calc.MaximumLatestFinishDateOut(start, maxLatestFinish, duration: 5);
+            result.Date.ShouldBe(maxLatestFinish.Date);
+        }
+
+        #endregion
+
+        #region NonWorkingDayMode.Weekends — larger spans
+
+        [Fact]
+        public void AddDays_Weekends_TenWorkingDays_SkipsTwoWeekends()
+        {
+            var calc   = CreateCalculator(NonWorkingDayMode.Weekends);
+            var monday = Local(2025, 6, 2); // Mon 2 Jun 2025
+
+            // 10 working days = 2 full working weeks = Mon 16 Jun 2025
+            DateTimeOffset result = calc.AddDays(monday, 10);
+            result.Date.ShouldBe(Local(2025, 6, 16).Date);
+        }
+
+        [Fact]
+        public void CountDays_Weekends_TwoFullWorkWeeks_IsTen()
+        {
+            var calc = CreateCalculator(NonWorkingDayMode.Weekends);
+            // Mon 2 Jun 2025 → Mon 16 Jun 2025 = 10 working days
+            calc.CountDays(Local(2025, 6, 2), Local(2025, 6, 16)).ShouldBe(10);
+        }
+
+        [Fact]
+        public void AddDays_Weekends_StartOnSaturday_FirstDayIsMonday()
+        {
+            // When starting on a Saturday, adding 1 working day should
+            // produce Monday (not Saturday+1=Sunday, and not Saturday itself).
+            var calc     = CreateCalculator(NonWorkingDayMode.Weekends);
+            var saturday = Local(2025, 6, 7); // Saturday
+
+            // Adding 0 working days from a Saturday: Saturday stays Saturday
+            // (the calculator counts working days moved, not whether start is working).
+            // Adding 1 working day from Saturday should give us Mon 9 Jun.
+            DateTimeOffset result = calc.AddDays(saturday, 1);
+            result.Date.ShouldBe(Local(2025, 6, 9).Date); // Monday
+        }
+
+        #endregion
+
+        #region CustomCalendar — multiple holidays in the same week
+
+        [Fact]
+        public void AddDays_CustomCalendar_MultipleHolidaysInWeek_SkipsAllOfThem()
+        {
+            var calc = CreateCalculator(NonWorkingDayMode.CustomCalendar);
+
+            // Mon 2 Jun, Tue 3 Jun, and Thu 5 Jun are holidays.
+            var h1 = new HolidayModel { Id = 1, StartDateTime = Local(2025, 6, 2), RecurrencePattern = "FREQ=DAILY;COUNT=1" };
+            var h2 = new HolidayModel { Id = 2, StartDateTime = Local(2025, 6, 3), RecurrencePattern = "FREQ=DAILY;COUNT=1" };
+            var h3 = new HolidayModel { Id = 3, StartDateTime = Local(2025, 6, 5), RecurrencePattern = "FREQ=DAILY;COUNT=1" };
+            calc.SetNonWorkingDayCalendarEvents([h1, h2, h3]);
+
+            // From Mon 2 Jun + 1 working day: Mon is a holiday, so first working day
+            // is Wed 4 Jun; +1 more skips Thu (holiday) → Fri 6 Jun.
+            // i.e., 1 working day from Mon 2 Jun = Wed 4 Jun.
+            DateTimeOffset result = calc.AddDays(Local(2025, 6, 2), 1);
+            result.Date.ShouldBe(Local(2025, 6, 4).Date); // Wednesday
+        }
+
+        [Fact]
+        public void CountDays_CustomCalendar_ThreeHolidays_ReducesCount()
+        {
+            var calc = CreateCalculator(NonWorkingDayMode.CustomCalendar);
+
+            var h1 = new HolidayModel { Id = 1, StartDateTime = Local(2025, 6, 2), RecurrencePattern = "FREQ=DAILY;COUNT=1" };
+            var h2 = new HolidayModel { Id = 2, StartDateTime = Local(2025, 6, 3), RecurrencePattern = "FREQ=DAILY;COUNT=1" };
+            var h3 = new HolidayModel { Id = 3, StartDateTime = Local(2025, 6, 5), RecurrencePattern = "FREQ=DAILY;COUNT=1" };
+            calc.SetNonWorkingDayCalendarEvents([h1, h2, h3]);
+
+            // Mon 2 Jun → Fri 6 Jun: 5 calendar days, 3 holidays → 2 working days.
+            calc.CountDays(Local(2025, 6, 2), Local(2025, 6, 6)).ShouldBe(2);
+        }
+
+        #endregion
+
+        #region GetLocalNow — returns a value close to now
+
+        [Fact]
+        public void GetLocalNow_Returns_ValueWithinOneMinute_Of_SystemNow()
+        {
+            var calc = new DateTimeCalculator(TimeProvider.System);
+            DateTimeOffset before = DateTimeOffset.Now.AddSeconds(-5);
+            DateTimeOffset result = calc.GetLocalNow();
+            DateTimeOffset after  = DateTimeOffset.Now.AddSeconds(5);
+
+            result.ShouldBeGreaterThanOrEqualTo(before);
+            result.ShouldBeLessThanOrEqualTo(after);
+        }
+
+        #endregion
+
+        #region NonWorkingDayCalendarEvents property reflects SetNonWorkingDayCalendarEvents
+
+        [Fact]
+        public void NonWorkingDayCalendarEvents_ReflectsSetCall()
+        {
+            var calc = CreateCalculator(NonWorkingDayMode.CustomCalendar);
+            var h = new HolidayModel { Id = 99, StartDateTime = Local(2025, 12, 25), RecurrencePattern = "FREQ=DAILY;COUNT=1" };
+            calc.SetNonWorkingDayCalendarEvents([h]);
+
+            calc.NonWorkingDayCalendarEvents.Count.ShouldBe(1);
+            calc.NonWorkingDayCalendarEvents[0].Id.ShouldBe(99);
+        }
+
+        [Fact]
+        public void NonWorkingDayCalendarEvents_AfterClear_IsEmpty()
+        {
+            var calc = CreateCalculator(NonWorkingDayMode.CustomCalendar);
+            var h = new HolidayModel { Id = 1, StartDateTime = Local(2025, 6, 10), RecurrencePattern = "FREQ=DAILY;COUNT=1" };
+            calc.SetNonWorkingDayCalendarEvents([h]);
+            calc.SetNonWorkingDayCalendarEvents([]);
+
+            calc.NonWorkingDayCalendarEvents.ShouldBeEmpty();
+        }
+
+        #endregion
+    }
+}

--- a/test/Zametek.ViewModel.ProjectPlan.Tests/Miscellaneous/DateTimeCalculatorTests.cs
+++ b/test/Zametek.ViewModel.ProjectPlan.Tests/Miscellaneous/DateTimeCalculatorTests.cs
@@ -1,0 +1,316 @@
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using Xunit;
+using Zametek.Common.ProjectPlan;
+using Zametek.ViewModel.ProjectPlan;
+
+namespace Zametek.ViewModel.ProjectPlan.Tests
+{
+    /// <summary>
+    /// Tests for DateTimeCalculator covering working-day arithmetic, non-working-day
+    /// detection, and business-day counting under each NonWorkingDayMode.
+    /// DateTimeCalculator accepts a TimeProvider via constructor so no mocking framework
+    /// is needed — we use TimeProvider.System (or a fixed fake via FakeTimeProvider).
+    /// </summary>
+    public class DateTimeCalculatorTests
+    {
+        #region Helpers
+
+        /// <summary>Minimal TimeProvider that always returns the same instant.</summary>
+        private sealed class FixedTimeProvider : TimeProvider
+        {
+            private readonly DateTimeOffset m_Now;
+            public FixedTimeProvider(DateTimeOffset now) => m_Now = now;
+            public override DateTimeOffset GetUtcNow() => m_Now.ToUniversalTime();
+            public override TimeZoneInfo LocalTimeZone => TimeZoneInfo.Local;
+        }
+
+        private static DateTimeCalculator CreateCalculator(NonWorkingDayMode mode = NonWorkingDayMode.None)
+        {
+            var calc = new DateTimeCalculator(TimeProvider.System);
+            calc.NonWorkingDayMode = mode;
+            return calc;
+        }
+
+        /// <summary>Returns a DateTimeOffset at midnight local time for the given date.</summary>
+        private static DateTimeOffset Local(int year, int month, int day) =>
+            new DateTimeOffset(new DateTime(year, month, day), TimeZoneInfo.Local.GetUtcOffset(new DateTime(year, month, day)));
+
+        #endregion
+
+        #region NonWorkingDayMode.None — AddDays / CountDays treat every day as a working day
+
+        [Fact]
+        public void AddDays_None_Given_ZeroDays_Returns_SameDate()
+        {
+            var calc = CreateCalculator(NonWorkingDayMode.None);
+            var start = Local(2025, 6, 2); // Monday
+            calc.AddDays(start, 0).Date.ShouldBe(start.Date);
+        }
+
+        [Fact]
+        public void AddDays_None_Given_PositiveDays_Counts_Every_Day()
+        {
+            var calc = CreateCalculator(NonWorkingDayMode.None);
+            var start = Local(2025, 6, 6); // Friday
+            var result = calc.AddDays(start, 3);
+            // Friday + 3 calendar days = Monday (6 + 3 = 9 June 2025)
+            result.Date.ShouldBe(Local(2025, 6, 9).Date);
+        }
+
+        [Fact]
+        public void AddDays_None_Given_NegativeDays_Steps_Backward()
+        {
+            var calc = CreateCalculator(NonWorkingDayMode.None);
+            var start = Local(2025, 6, 9); // Monday
+            var result = calc.AddDays(start, -3);
+            result.Date.ShouldBe(Local(2025, 6, 6).Date); // Friday
+        }
+
+        [Fact]
+        public void CountDays_None_Given_SameDate_Returns_Zero()
+        {
+            var calc = CreateCalculator(NonWorkingDayMode.None);
+            var date = Local(2025, 6, 2);
+            calc.CountDays(date, date).ShouldBe(0);
+        }
+
+        [Fact]
+        public void CountDays_None_Counts_Every_Calendar_Day_Including_Weekends()
+        {
+            var calc = CreateCalculator(NonWorkingDayMode.None);
+            // Mon 2 Jun 2025 → Mon 9 Jun 2025 = 7 days (includes Sat+Sun)
+            calc.CountDays(Local(2025, 6, 2), Local(2025, 6, 9)).ShouldBe(7);
+        }
+
+        [Fact]
+        public void CountDays_None_Is_Negative_When_Arguments_Reversed()
+        {
+            var calc = CreateCalculator(NonWorkingDayMode.None);
+            int forward = calc.CountDays(Local(2025, 6, 2), Local(2025, 6, 9));
+            int backward = calc.CountDays(Local(2025, 6, 9), Local(2025, 6, 2));
+            backward.ShouldBe(-forward);
+        }
+
+        #endregion
+
+        #region NonWorkingDayMode.Weekends — AddDays / CountDays skip Saturday and Sunday
+
+        [Fact]
+        public void AddDays_Weekends_Given_ZeroDays_Returns_SameDate()
+        {
+            var calc = CreateCalculator(NonWorkingDayMode.Weekends);
+            var start = Local(2025, 6, 2); // Monday
+            calc.AddDays(start, 0).Date.ShouldBe(start.Date);
+        }
+
+        [Fact]
+        public void AddDays_Weekends_SkipsWeekend_FridayPlusOne_GivesMonday()
+        {
+            var calc = CreateCalculator(NonWorkingDayMode.Weekends);
+            var friday = Local(2025, 6, 6); // Friday
+            var result = calc.AddDays(friday, 1);
+            // Next working day after Friday = Monday 9 Jun
+            result.Date.ShouldBe(Local(2025, 6, 9).Date);
+        }
+
+        [Fact]
+        public void AddDays_Weekends_FiveDays_Spans_Weekend()
+        {
+            var calc = CreateCalculator(NonWorkingDayMode.Weekends);
+            var monday = Local(2025, 6, 2); // Monday
+            // Mon + 5 working days = Mon, Tue, Wed, Thu, Fri → finish Mon 9 Jun
+            var result = calc.AddDays(monday, 5);
+            result.Date.ShouldBe(Local(2025, 6, 9).Date);
+        }
+
+        [Fact]
+        public void CountDays_Weekends_OneWorkWeek_IsFive()
+        {
+            var calc = CreateCalculator(NonWorkingDayMode.Weekends);
+            // Mon 2 Jun → Mon 9 Jun 2025: 5 working days (Tue–Fri + Mon)
+            calc.CountDays(Local(2025, 6, 2), Local(2025, 6, 9)).ShouldBe(5);
+        }
+
+        [Fact]
+        public void CountDays_Weekends_FullWeekPlusWeekend_IsFive()
+        {
+            var calc = CreateCalculator(NonWorkingDayMode.Weekends);
+            // Mon 2 Jun → Fri 6 Jun: 4 working days (Tue, Wed, Thu, Fri)
+            calc.CountDays(Local(2025, 6, 2), Local(2025, 6, 6)).ShouldBe(4);
+        }
+
+        [Fact]
+        public void CountDays_Weekends_Reversed_IsNegative()
+        {
+            var calc = CreateCalculator(NonWorkingDayMode.Weekends);
+            int forward = calc.CountDays(Local(2025, 6, 2), Local(2025, 6, 9));
+            int backward = calc.CountDays(Local(2025, 6, 9), Local(2025, 6, 2));
+            backward.ShouldBe(-forward);
+        }
+
+        [Fact]
+        public void AddDays_Weekends_PositiveDays_ThenNegativeDays_ReturnsToStart()
+        {
+            // Going forward N working days then backward N working days should
+            // return to the original date (when both directions are in the cached
+            // non-working-day window).
+            var calc = CreateCalculator(NonWorkingDayMode.Weekends);
+            var start = Local(2025, 6, 2); // Monday
+            calc.ProjectStart = start;
+
+            // Warm up the forward cache first so backward has non-working days available.
+            var forward = calc.AddDays(start, 5); // Mon 9 Jun
+            var back = calc.AddDays(forward, -5);  // Should be Mon 2 Jun again
+            back.Date.ShouldBe(start.Date);
+        }
+
+        #endregion
+
+        #region NonWorkingDayMode.CustomCalendar — user-defined holiday list
+
+        [Fact]
+        public void AddDays_CustomCalendar_EmptyHolidayList_BehavesLikeNone()
+        {
+            var calc = CreateCalculator(NonWorkingDayMode.CustomCalendar);
+            calc.SetNonWorkingDayCalendarEvents([]);
+
+            var start = Local(2025, 6, 6); // Friday
+            var result = calc.AddDays(start, 3);
+            // Without any non-working-day rules, every day is a working day.
+            result.Date.ShouldBe(Local(2025, 6, 9).Date);
+        }
+
+        [Fact]
+        public void AddDays_CustomCalendar_HolidayOnTuesday_SkipsIt()
+        {
+            var calc = CreateCalculator(NonWorkingDayMode.CustomCalendar);
+
+            // Set a single-occurrence holiday on Tuesday 10 Jun 2025
+            var holiday = new HolidayModel
+            {
+                Id = 1,
+                StartDateTime = Local(2025, 6, 10),
+                RecurrencePattern = "FREQ=DAILY;COUNT=1",
+            };
+            calc.SetNonWorkingDayCalendarEvents([holiday]);
+
+            // Mon 9 Jun + 1 working day should skip Tue 10 Jun → Wed 11 Jun
+            var result = calc.AddDays(Local(2025, 6, 9), 1);
+            result.Date.ShouldBe(Local(2025, 6, 11).Date);
+        }
+
+        [Fact]
+        public void CountDays_CustomCalendar_HolidayExcluded_FromCount()
+        {
+            var calc = CreateCalculator(NonWorkingDayMode.CustomCalendar);
+
+            // Holiday on Wed 4 Jun 2025
+            var holiday = new HolidayModel
+            {
+                Id = 1,
+                StartDateTime = Local(2025, 6, 4),
+                RecurrencePattern = "FREQ=DAILY;COUNT=1",
+            };
+            calc.SetNonWorkingDayCalendarEvents([holiday]);
+
+            // Mon 2 Jun → Fri 6 Jun 2025: 4 days — Wed is a holiday so count = 3
+            calc.CountDays(Local(2025, 6, 2), Local(2025, 6, 6)).ShouldBe(3);
+        }
+
+        [Fact]
+        public void SetNonWorkingDayCalendarEvents_Replacing_List_Clears_Previous_Holidays()
+        {
+            var calc = CreateCalculator(NonWorkingDayMode.CustomCalendar);
+
+            var holiday = new HolidayModel
+            {
+                Id = 1,
+                StartDateTime = Local(2025, 6, 4),
+                RecurrencePattern = "FREQ=DAILY;COUNT=1",
+            };
+            calc.SetNonWorkingDayCalendarEvents([holiday]);
+
+            // Remove all holidays — counting should now include Wednesday
+            calc.SetNonWorkingDayCalendarEvents([]);
+            calc.CountDays(Local(2025, 6, 2), Local(2025, 6, 6)).ShouldBe(4);
+        }
+
+        #endregion
+
+        #region Mode switching resets cached state
+
+        [Fact]
+        public void SwitchingMode_From_None_To_Weekends_Changes_Count()
+        {
+            var calc = CreateCalculator(NonWorkingDayMode.None);
+            int allDays = calc.CountDays(Local(2025, 6, 2), Local(2025, 6, 9));
+
+            calc.NonWorkingDayMode = NonWorkingDayMode.Weekends;
+            int workDays = calc.CountDays(Local(2025, 6, 2), Local(2025, 6, 9));
+
+            allDays.ShouldBe(7);
+            workDays.ShouldBe(5);
+        }
+
+        #endregion
+
+        #region CalculateTimeAndDateTime
+
+        [Fact]
+        public void CalculateTimeAndDateTime_FromInt_ZeroInput_Returns_ProjectStart()
+        {
+            var calc = CreateCalculator(NonWorkingDayMode.None);
+            var projectStart = Local(2025, 1, 6);
+            calc.ProjectStart = projectStart;
+
+            (int? days, DateTimeOffset? dto) = calc.CalculateTimeAndDateTime(projectStart, 0);
+
+            days.ShouldBe(0);
+            dto.ShouldNotBeNull();
+            dto!.Value.Date.ShouldBe(projectStart.Date);
+        }
+
+        [Fact]
+        public void CalculateTimeAndDateTime_FromInt_NullInput_Returns_Nulls()
+        {
+            var calc = CreateCalculator(NonWorkingDayMode.None);
+            var projectStart = Local(2025, 1, 6);
+
+            (int? days, DateTimeOffset? dto) = calc.CalculateTimeAndDateTime(projectStart, (int?)null);
+
+            days.ShouldBeNull();
+            dto.ShouldBeNull();
+        }
+
+        [Fact]
+        public void CalculateTimeAndDateTime_FromInt_NegativeInput_Clamps_To_Zero()
+        {
+            var calc = CreateCalculator(NonWorkingDayMode.None);
+            var projectStart = Local(2025, 1, 6);
+            calc.ProjectStart = projectStart;
+
+            (int? days, DateTimeOffset? dto) = calc.CalculateTimeAndDateTime(projectStart, -5);
+
+            days.ShouldBe(0);
+        }
+
+        #endregion
+
+        #region GetLocal
+
+        [Fact]
+        public void GetLocal_Returns_DateTimeOffset_With_Local_Offset()
+        {
+            var calc = CreateCalculator();
+            var input = new DateTime(2025, 6, 2, 9, 0, 0);
+            var result = calc.GetLocal(input);
+
+            result.DateTime.Date.ShouldBe(input.Date);
+            result.Offset.ShouldBe(TimeZoneInfo.Local.GetUtcOffset(input));
+        }
+
+        #endregion
+    }
+}

--- a/test/Zametek.ViewModel.ProjectPlan.Tests/Miscellaneous/DateTimeHelperTests.cs
+++ b/test/Zametek.ViewModel.ProjectPlan.Tests/Miscellaneous/DateTimeHelperTests.cs
@@ -1,0 +1,202 @@
+using Shouldly;
+using System;
+using Xunit;
+
+namespace Zametek.ViewModel.ProjectPlan.Tests
+{
+    /// <summary>
+    /// Tests for the DateTimeHelper extension methods. All six public methods
+    /// are pure comparisons, so every branch can be exercised with simple values.
+    /// </summary>
+    public class DateTimeHelperTests
+    {
+        #region DateOnly.IsBeforeOrOn
+
+        [Fact]
+        public void DateOnly_IsBeforeOrOn_When_Equal_Returns_True()
+        {
+            var d = new DateOnly(2025, 6, 10);
+            d.IsBeforeOrOn(d).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void DateOnly_IsBeforeOrOn_When_Before_Returns_True()
+        {
+            var earlier = new DateOnly(2025, 6, 9);
+            var later   = new DateOnly(2025, 6, 10);
+            earlier.IsBeforeOrOn(later).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void DateOnly_IsBeforeOrOn_When_After_Returns_False()
+        {
+            var earlier = new DateOnly(2025, 6, 9);
+            var later   = new DateOnly(2025, 6, 10);
+            later.IsBeforeOrOn(earlier).ShouldBeFalse();
+        }
+
+        #endregion
+
+        #region DateOnly.IsAfterOrOn
+
+        [Fact]
+        public void DateOnly_IsAfterOrOn_When_Equal_Returns_True()
+        {
+            var d = new DateOnly(2025, 6, 10);
+            d.IsAfterOrOn(d).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void DateOnly_IsAfterOrOn_When_After_Returns_True()
+        {
+            var earlier = new DateOnly(2025, 6, 9);
+            var later   = new DateOnly(2025, 6, 10);
+            later.IsAfterOrOn(earlier).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void DateOnly_IsAfterOrOn_When_Before_Returns_False()
+        {
+            var earlier = new DateOnly(2025, 6, 9);
+            var later   = new DateOnly(2025, 6, 10);
+            earlier.IsAfterOrOn(later).ShouldBeFalse();
+        }
+
+        #endregion
+
+        #region DateTime.IsBeforeOrOn
+
+        [Fact]
+        public void DateTime_IsBeforeOrOn_When_Equal_Returns_True()
+        {
+            var dt = new DateTime(2025, 6, 10, 12, 0, 0);
+            dt.IsBeforeOrOn(dt).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void DateTime_IsBeforeOrOn_When_Before_Returns_True()
+        {
+            var earlier = new DateTime(2025, 6, 10, 11, 59, 59);
+            var later   = new DateTime(2025, 6, 10, 12, 0, 0);
+            earlier.IsBeforeOrOn(later).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void DateTime_IsBeforeOrOn_When_After_Returns_False()
+        {
+            var earlier = new DateTime(2025, 6, 10, 11, 59, 59);
+            var later   = new DateTime(2025, 6, 10, 12, 0, 0);
+            later.IsBeforeOrOn(earlier).ShouldBeFalse();
+        }
+
+        #endregion
+
+        #region DateTime.IsAfterOrOn
+
+        [Fact]
+        public void DateTime_IsAfterOrOn_When_Equal_Returns_True()
+        {
+            var dt = new DateTime(2025, 6, 10, 12, 0, 0);
+            dt.IsAfterOrOn(dt).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void DateTime_IsAfterOrOn_When_After_Returns_True()
+        {
+            var earlier = new DateTime(2025, 6, 10, 11, 0, 0);
+            var later   = new DateTime(2025, 6, 10, 12, 0, 0);
+            later.IsAfterOrOn(earlier).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void DateTime_IsAfterOrOn_When_Before_Returns_False()
+        {
+            var earlier = new DateTime(2025, 6, 10, 11, 0, 0);
+            var later   = new DateTime(2025, 6, 10, 12, 0, 0);
+            earlier.IsAfterOrOn(later).ShouldBeFalse();
+        }
+
+        #endregion
+
+        #region DateTimeOffset.IsBefore
+
+        [Fact]
+        public void DateTimeOffset_IsBefore_When_Before_Returns_True()
+        {
+            var earlier = new DateTimeOffset(2025, 6, 10, 0, 0, 0, TimeSpan.Zero);
+            var later   = new DateTimeOffset(2025, 6, 11, 0, 0, 0, TimeSpan.Zero);
+            earlier.IsBefore(later).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void DateTimeOffset_IsBefore_When_Equal_Returns_False()
+        {
+            var d = new DateTimeOffset(2025, 6, 10, 0, 0, 0, TimeSpan.Zero);
+            d.IsBefore(d).ShouldBeFalse();
+        }
+
+        [Fact]
+        public void DateTimeOffset_IsBefore_When_After_Returns_False()
+        {
+            var earlier = new DateTimeOffset(2025, 6, 10, 0, 0, 0, TimeSpan.Zero);
+            var later   = new DateTimeOffset(2025, 6, 11, 0, 0, 0, TimeSpan.Zero);
+            later.IsBefore(earlier).ShouldBeFalse();
+        }
+
+        #endregion
+
+        #region DateTimeOffset.IsAfter
+
+        [Fact]
+        public void DateTimeOffset_IsAfter_When_After_Returns_True()
+        {
+            var earlier = new DateTimeOffset(2025, 6, 10, 0, 0, 0, TimeSpan.Zero);
+            var later   = new DateTimeOffset(2025, 6, 11, 0, 0, 0, TimeSpan.Zero);
+            later.IsAfter(earlier).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void DateTimeOffset_IsAfter_When_Equal_Returns_False()
+        {
+            var d = new DateTimeOffset(2025, 6, 10, 0, 0, 0, TimeSpan.Zero);
+            d.IsAfter(d).ShouldBeFalse();
+        }
+
+        [Fact]
+        public void DateTimeOffset_IsAfter_When_Before_Returns_False()
+        {
+            var earlier = new DateTimeOffset(2025, 6, 10, 0, 0, 0, TimeSpan.Zero);
+            var later   = new DateTimeOffset(2025, 6, 11, 0, 0, 0, TimeSpan.Zero);
+            earlier.IsAfter(later).ShouldBeFalse();
+        }
+
+        #endregion
+
+        #region DateTimeOffset.IsAfterOrOn
+
+        [Fact]
+        public void DateTimeOffset_IsAfterOrOn_When_Equal_Returns_True()
+        {
+            var d = new DateTimeOffset(2025, 6, 10, 0, 0, 0, TimeSpan.Zero);
+            d.IsAfterOrOn(d).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void DateTimeOffset_IsAfterOrOn_When_After_Returns_True()
+        {
+            var earlier = new DateTimeOffset(2025, 6, 10, 0, 0, 0, TimeSpan.Zero);
+            var later   = new DateTimeOffset(2025, 6, 11, 0, 0, 0, TimeSpan.Zero);
+            later.IsAfterOrOn(earlier).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void DateTimeOffset_IsAfterOrOn_When_Before_Returns_False()
+        {
+            var earlier = new DateTimeOffset(2025, 6, 10, 0, 0, 0, TimeSpan.Zero);
+            var later   = new DateTimeOffset(2025, 6, 11, 0, 0, 0, TimeSpan.Zero);
+            earlier.IsAfterOrOn(later).ShouldBeFalse();
+        }
+
+        #endregion
+    }
+}

--- a/test/Zametek.ViewModel.ProjectPlan.Tests/Miscellaneous/MetricsHelperInvariantTests.cs
+++ b/test/Zametek.ViewModel.ProjectPlan.Tests/Miscellaneous/MetricsHelperInvariantTests.cs
@@ -1,0 +1,223 @@
+using Shouldly;
+using System.Collections.Generic;
+using Xunit;
+using Zametek.Common.ProjectPlan;
+
+namespace Zametek.ViewModel.ProjectPlan.Tests
+{
+    /// <summary>
+    /// Property-based style invariant tests for MetricsHelper using [Theory]+[InlineData].
+    /// These verify mathematical contracts that must hold for all valid inputs:
+    ///   • Risk values are always in [0, 1]
+    ///   • Efficiency with equal arguments is always 1.0
+    ///   • Margin = (billing - cost) / billing
+    ///   • ActivityRisk is monotonically non-increasing as slack increases (for fixed activity set shape)
+    /// </summary>
+    public class MetricsHelperInvariantTests
+    {
+        #region Helpers
+
+        private static ActivitySeverityLookup DefaultLookup() =>
+            new ActivitySeverityLookup(
+            [
+                new ActivitySeverityModel { SlackLimit = 0,  CriticalityWeight = 1.0,  FibonacciWeight = 1.0  },
+                new ActivitySeverityModel { SlackLimit = 5,  CriticalityWeight = 0.8,  FibonacciWeight = 0.5  },
+                new ActivitySeverityModel { SlackLimit = 10, CriticalityWeight = 0.6,  FibonacciWeight = 0.25 },
+            ]);
+
+        private static ActivityModel Activity(int slack) =>
+            new ActivityModel { Id = 1, TotalSlack = slack };
+
+        private static IEnumerable<ActivityModel> Activities(int slack) => [Activity(slack)];
+
+        #endregion
+
+        #region Risk invariants — result is always in [0, 1] for valid inputs
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(5)]
+        [InlineData(10)]
+        [InlineData(100)]
+        public void CalculateActivityRisk_IsAlwaysInZeroToOneRange(int slack)
+        {
+            double? risk = MetricsHelper.CalculateActivityRisk(Activities(slack));
+            risk.ShouldNotBeNull();
+            risk!.Value.ShouldBeInRange(0.0, 1.0);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(5)]
+        [InlineData(10)]
+        [InlineData(50)]
+        public void CalculateCriticalityRisk_IsAlwaysInZeroToOneRange(int slack)
+        {
+            var lookup = DefaultLookup();
+            double? risk = MetricsHelper.CalculateCriticalityRisk(Activities(slack), lookup);
+            risk.ShouldNotBeNull();
+            risk!.Value.ShouldBeInRange(0.0, 1.0);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(5)]
+        [InlineData(10)]
+        [InlineData(50)]
+        public void CalculateFibonacciRisk_IsAlwaysInZeroToOneRange(int slack)
+        {
+            var lookup = DefaultLookup();
+            double? risk = MetricsHelper.CalculateFibonacciRisk(Activities(slack), lookup);
+            risk.ShouldNotBeNull();
+            risk!.Value.ShouldBeInRange(0.0, 1.0);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(5)]
+        [InlineData(20)]
+        public void CalculateActivityRiskWithStdDevCorrection_IsAlwaysInZeroToOneRange(int slack)
+        {
+            // Multiple activities with the same slack => stddev = 0.
+            ActivityModel[] activities =
+            [
+                new ActivityModel { Id = 1, TotalSlack = slack },
+                new ActivityModel { Id = 2, TotalSlack = slack },
+                new ActivityModel { Id = 3, TotalSlack = slack },
+            ];
+            double? risk = MetricsHelper.CalculateActivityRiskWithStdDevCorrection(activities);
+            risk.ShouldNotBeNull();
+            risk!.Value.ShouldBeInRange(0.0, 1.0);
+        }
+
+        #endregion
+
+        #region Efficiency invariant — equal inputs always produce 1.0
+
+        [Theory]
+        [InlineData(1.0)]
+        [InlineData(10.0)]
+        [InlineData(100.0)]
+        [InlineData(0.001)]
+        [InlineData(999999.9)]
+        public void CalculateEfficiency_EqualInputs_AlwaysReturnsOne(double value)
+        {
+            MetricsHelper.CalculateEfficiency(value, value).ShouldBe(1.0);
+        }
+
+        #endregion
+
+        #region Efficiency invariant — result = activityEffort / totalEffort
+
+        [Theory]
+        [InlineData(1.0, 2.0, 0.5)]
+        [InlineData(3.0, 4.0, 0.75)]
+        [InlineData(7.0, 10.0, 0.7)]
+        [InlineData(1.0, 1.0, 1.0)]
+        public void CalculateEfficiency_ReturnsCorrectRatio(double activity, double total, double expected)
+        {
+            double? result = MetricsHelper.CalculateEfficiency(activity, total);
+            result.ShouldNotBeNull();
+            result!.Value.ShouldBe(expected, tolerance: 1e-9);
+        }
+
+        #endregion
+
+        #region Margin invariant — margin = (billing - cost) / billing
+
+        [Theory]
+        [InlineData(80.0, 100.0, 0.2)]
+        [InlineData(50.0, 100.0, 0.5)]
+        [InlineData(0.0,  100.0, 1.0)]   // zero cost => abs = billing => margin = 1
+        [InlineData(100.0, 100.0, 0.0)]
+        public void CalculateMargin_SatisfiesBillingMinusCostOverBillingFormula(double cost, double billing, double expected)
+        {
+            double? margin = MetricsHelper.CalculateMargin(cost, billing);
+            margin.ShouldNotBeNull();
+            margin!.Value.ShouldBe(expected, tolerance: 1e-9);
+        }
+
+        #endregion
+
+        #region ActivityRisk monotonicity — more slack = lower (or equal) risk
+
+        [Theory]
+        [InlineData(0, 1)]
+        [InlineData(1, 5)]
+        [InlineData(5, 10)]
+        [InlineData(10, 20)]
+        [InlineData(0, 50)]
+        public void CalculateActivityRisk_IncreasedSlack_Produces_LowerOrEqualRisk(int lowerSlack, int higherSlack)
+        {
+            // Build a two-activity set: one at slack=0 (fixed) and one at the varying slack.
+            // Increasing the varying slack should not increase the risk.
+            ActivityModel[] lowerSet =
+            [
+                new ActivityModel { Id = 1, TotalSlack = 0 },
+                new ActivityModel { Id = 2, TotalSlack = lowerSlack },
+            ];
+            ActivityModel[] higherSet =
+            [
+                new ActivityModel { Id = 1, TotalSlack = 0 },
+                new ActivityModel { Id = 2, TotalSlack = higherSlack },
+            ];
+
+            double? riskLower  = MetricsHelper.CalculateActivityRisk(lowerSet);
+            double? riskHigher = MetricsHelper.CalculateActivityRisk(higherSet);
+
+            riskLower.ShouldNotBeNull();
+            riskHigher.ShouldNotBeNull();
+            riskHigher!.Value.ShouldBeLessThanOrEqualTo(riskLower!.Value);
+        }
+
+        #endregion
+
+        #region MarginAbsolute invariant — always = billing - cost
+
+        [Theory]
+        [InlineData(80.0, 100.0, 20.0)]
+        [InlineData(120.0, 100.0, -20.0)]
+        [InlineData(100.0, 100.0, 0.0)]
+        [InlineData(0.0, 50.0, 50.0)]
+        public void CalculateMarginAbsolute_AlwaysBillingMinusCost(double cost, double billing, double expected)
+        {
+            double? abs = MetricsHelper.CalculateMarginAbsolute(cost, billing);
+            abs.ShouldNotBeNull();
+            abs!.Value.ShouldBe(expected, tolerance: 1e-9);
+        }
+
+        #endregion
+
+        #region CalculateProjectCosts — totals are sum of parts
+
+        [Fact]
+        public void CalculateProjectCosts_Total_Equals_Sum_Of_Direct_Indirect_Other()
+        {
+            var resourceSeries = new List<ResourceSeriesModel>();
+            var result = MetricsHelper.CalculateProjectCosts(resourceSeries);
+            result.Total.ShouldBe(result.Direct + result.Indirect + result.Other);
+        }
+
+        [Fact]
+        public void CalculateProjectBillings_Total_Equals_Sum_Of_Direct_Indirect_Other()
+        {
+            var resourceSeries = new List<ResourceSeriesModel>();
+            var result = MetricsHelper.CalculateProjectBillings(resourceSeries);
+            result.Total.ShouldBe(result.Direct + result.Indirect + result.Other);
+        }
+
+        [Fact]
+        public void CalculateProjectEfforts_Total_Equals_Sum_Of_Direct_Indirect_Other()
+        {
+            var resourceSeries = new List<ResourceSeriesModel>();
+            var result = MetricsHelper.CalculateProjectEfforts(resourceSeries);
+            result.Total.ShouldBe(result.Direct + result.Indirect + result.Other);
+        }
+
+        #endregion
+    }
+}

--- a/test/Zametek.ViewModel.ProjectPlan.Tests/Miscellaneous/MetricsHelperTests.cs
+++ b/test/Zametek.ViewModel.ProjectPlan.Tests/Miscellaneous/MetricsHelperTests.cs
@@ -1,0 +1,353 @@
+using Shouldly;
+using System.Collections.Generic;
+using Xunit;
+using Zametek.Common.ProjectPlan;
+
+namespace Zametek.ViewModel.ProjectPlan.Tests
+{
+    public class MetricsHelperTests
+    {
+        #region Helpers
+
+        private static ActivitySeverityModel MakeSeverity(int slackLimit, double criticalityWeight, double fibonacciWeight) =>
+            new ActivitySeverityModel
+            {
+                SlackLimit = slackLimit,
+                CriticalityWeight = criticalityWeight,
+                FibonacciWeight = fibonacciWeight,
+            };
+
+        private static ActivityModel MakeActivity(int? totalSlack, bool hasNoRisk = false) =>
+            new ActivityModel
+            {
+                Id = 1,
+                TotalSlack = totalSlack,
+                HasNoRisk = hasNoRisk,
+            };
+
+        private static IEnumerable<ActivitySeverityModel> DefaultSeverities() =>
+        [
+            MakeSeverity(slackLimit: 0, criticalityWeight: 1.0, fibonacciWeight: 1.0),
+            MakeSeverity(slackLimit: 5, criticalityWeight: 0.8, fibonacciWeight: 0.5),
+            MakeSeverity(slackLimit: 10, criticalityWeight: 0.6, fibonacciWeight: 0.25),
+        ];
+
+        #endregion
+
+        #region CalculateActivityRisk
+
+        [Fact]
+        public void CalculateActivityRisk_Given_EmptyList_Then_ReturnsOne()
+        {
+            var result = MetricsHelper.CalculateActivityRisk([]);
+            result.ShouldBe(1.0);
+        }
+
+        [Fact]
+        public void CalculateActivityRisk_Given_AllZeroSlack_Then_ReturnsOne()
+        {
+            var activities = new[] { MakeActivity(0), MakeActivity(0), MakeActivity(0) };
+            var result = MetricsHelper.CalculateActivityRisk(activities);
+            result.ShouldBe(1.0);
+        }
+
+        [Fact]
+        public void CalculateActivityRisk_Given_MixedSlack_Then_ReturnsExpectedRatio()
+        {
+            // Activities: slack 0, 0, 10 => numerator = 10, maxSlack = 10, denominator = 10 * 3 = 30
+            // result = 1 - 10/30 = 0.667
+            var activities = new[] { MakeActivity(0), MakeActivity(0), MakeActivity(10) };
+            var result = MetricsHelper.CalculateActivityRisk(activities);
+            result.ShouldNotBeNull();
+            result!.Value.ShouldBeInRange(0.66, 0.68);
+        }
+
+        [Fact]
+        public void CalculateActivityRisk_Given_AllNullSlack_Then_ReturnsOne()
+        {
+            // Activities with null TotalSlack are excluded from numerator/denominator calc
+            // denominator = 0 * count = 0, numerator = 0 => return 1.0
+            var activities = new[] { MakeActivity(null), MakeActivity(null) };
+            var result = MetricsHelper.CalculateActivityRisk(activities);
+            result.ShouldBe(1.0);
+        }
+
+        [Fact]
+        public void CalculateActivityRisk_Given_SingleActivityWithSlack_Then_ReturnsZero()
+        {
+            // numerator = 5, maxSlack = 5, denominator = 5 * 1 = 5
+            // result = 1 - 5/5 = 0
+            var activities = new[] { MakeActivity(5) };
+            var result = MetricsHelper.CalculateActivityRisk(activities);
+            result.ShouldBe(0.0);
+        }
+
+        #endregion
+
+        #region CalculateActivityRiskWithStdDevCorrection
+
+        [Fact]
+        public void CalculateActivityRiskWithStdDevCorrection_Given_EmptyList_Then_ReturnsOne()
+        {
+            var result = MetricsHelper.CalculateActivityRiskWithStdDevCorrection([]);
+            result.ShouldBe(1.0);
+        }
+
+        [Fact]
+        public void CalculateActivityRiskWithStdDevCorrection_Given_AllZeroSlack_Then_ReturnsOne()
+        {
+            var activities = new[] { MakeActivity(0), MakeActivity(0) };
+            var result = MetricsHelper.CalculateActivityRiskWithStdDevCorrection(activities);
+            result.ShouldBe(1.0);
+        }
+
+        [Fact]
+        public void CalculateActivityRiskWithStdDevCorrection_Given_UniformSlack_Then_CorrectValueWithStdDevOfZero()
+        {
+            // All slack = 5, mean = 5, stddev = 0, correction = round(5+0) = 5
+            // Each capped at 5, so numerator = 5*3 = 15, maxSlack = 5, denominator = 5*3 = 15
+            // result = 1 - 15/15 = 0
+            var activities = new[] { MakeActivity(5), MakeActivity(5), MakeActivity(5) };
+            var result = MetricsHelper.CalculateActivityRiskWithStdDevCorrection(activities);
+            result.ShouldBe(0.0);
+        }
+
+        #endregion
+
+        #region CalculateCriticalityRisk
+
+        [Fact]
+        public void CalculateCriticalityRisk_Given_EmptyList_Then_ReturnsOne()
+        {
+            var lookup = new ActivitySeverityLookup(DefaultSeverities());
+            var result = MetricsHelper.CalculateCriticalityRisk([], lookup);
+            result.ShouldBe(1.0);
+        }
+
+        [Fact]
+        public void CalculateCriticalityRisk_Given_AllCriticalActivities_Then_ReturnsOne()
+        {
+            var lookup = new ActivitySeverityLookup(DefaultSeverities());
+            // SlackLimit 0 => criticalityWeight 1.0. Critical weight = 1.0.
+            // numerator = 1.0 * 2 = 2, denominator = 1.0 * 2 = 2 => result = 1.0
+            var activities = new[] { MakeActivity(0), MakeActivity(0) };
+            var result = MetricsHelper.CalculateCriticalityRisk(activities, lookup);
+            result.ShouldBe(1.0);
+        }
+
+        [Fact]
+        public void CalculateCriticalityRisk_Given_MixedSlack_Then_ReturnsExpectedRatio()
+        {
+            var lookup = new ActivitySeverityLookup(DefaultSeverities());
+            // slack=0 => weight 1.0, slack=5 => weight 0.8
+            // numerator = 1.0 + 0.8 = 1.8, denominator = 1.0 * 2 = 2.0
+            var activities = new[] { MakeActivity(0), MakeActivity(5) };
+            var result = MetricsHelper.CalculateCriticalityRisk(activities, lookup);
+            result.ShouldNotBeNull();
+            result!.Value.ShouldBeInRange(0.89, 0.91);
+        }
+
+        #endregion
+
+        #region CalculateFibonacciRisk
+
+        [Fact]
+        public void CalculateFibonacciRisk_Given_EmptyList_Then_ReturnsOne()
+        {
+            var lookup = new ActivitySeverityLookup(DefaultSeverities());
+            var result = MetricsHelper.CalculateFibonacciRisk([], lookup);
+            result.ShouldBe(1.0);
+        }
+
+        [Fact]
+        public void CalculateFibonacciRisk_Given_AllCriticalActivities_Then_ReturnsOne()
+        {
+            var lookup = new ActivitySeverityLookup(DefaultSeverities());
+            var activities = new[] { MakeActivity(0), MakeActivity(0) };
+            var result = MetricsHelper.CalculateFibonacciRisk(activities, lookup);
+            result.ShouldBe(1.0);
+        }
+
+        #endregion
+
+        #region CalculateGeometricActivityRisk
+
+        [Fact]
+        public void CalculateGeometricActivityRisk_Given_EmptyList_Then_ReturnsOne()
+        {
+            var result = MetricsHelper.CalculateGeometricActivityRisk([]);
+            result.ShouldBe(1.0);
+        }
+
+        [Fact]
+        public void CalculateGeometricActivityRisk_Given_AllZeroSlack_Then_ReturnsOne()
+        {
+            // totalSlack=0 => (0+1) = 1, numerator = pow(1,1/n) - 1 = 0, denominator = maxSlack = 0
+            // both 0 => return 1.0
+            var activities = new[] { MakeActivity(0), MakeActivity(0) };
+            var result = MetricsHelper.CalculateGeometricActivityRisk(activities);
+            result.ShouldBe(1.0);
+        }
+
+        #endregion
+
+        #region CalculateEfficiency
+
+        [Fact]
+        public void CalculateEfficiency_Given_BothNull_Then_ReturnsNull()
+        {
+            MetricsHelper.CalculateEfficiency(null, null).ShouldBeNull();
+        }
+
+        [Fact]
+        public void CalculateEfficiency_Given_ActivityEffortNull_Then_ReturnsNull()
+        {
+            MetricsHelper.CalculateEfficiency(null, 10.0).ShouldBeNull();
+        }
+
+        [Fact]
+        public void CalculateEfficiency_Given_TotalEffortNull_Then_ReturnsNull()
+        {
+            MetricsHelper.CalculateEfficiency(10.0, null).ShouldBeNull();
+        }
+
+        [Fact]
+        public void CalculateEfficiency_Given_TotalEffortZero_Then_ReturnsNull()
+        {
+            MetricsHelper.CalculateEfficiency(10.0, 0.0).ShouldBeNull();
+        }
+
+        [Fact]
+        public void CalculateEfficiency_Given_ActivityEffortZero_Then_ReturnsNull()
+        {
+            MetricsHelper.CalculateEfficiency(0.0, 10.0).ShouldBeNull();
+        }
+
+        [Fact]
+        public void CalculateEfficiency_Given_ValidInputs_Then_ReturnsRatio()
+        {
+            var result = MetricsHelper.CalculateEfficiency(5.0, 10.0);
+            result.ShouldBe(0.5);
+        }
+
+        [Fact]
+        public void CalculateEfficiency_Given_EqualInputs_Then_ReturnsOne()
+        {
+            var result = MetricsHelper.CalculateEfficiency(10.0, 10.0);
+            result.ShouldBe(1.0);
+        }
+
+        #endregion
+
+        #region CalculateMarginAbsolute
+
+        [Fact]
+        public void CalculateMarginAbsolute_Given_BothNull_Then_ReturnsNull()
+        {
+            MetricsHelper.CalculateMarginAbsolute(null, null).ShouldBeNull();
+        }
+
+        [Fact]
+        public void CalculateMarginAbsolute_Given_CostNull_Then_ReturnsNull()
+        {
+            MetricsHelper.CalculateMarginAbsolute(null, 100.0).ShouldBeNull();
+        }
+
+        [Fact]
+        public void CalculateMarginAbsolute_Given_BillingNull_Then_ReturnsNull()
+        {
+            MetricsHelper.CalculateMarginAbsolute(100.0, null).ShouldBeNull();
+        }
+
+        [Fact]
+        public void CalculateMarginAbsolute_Given_ValidInputs_Then_ReturnsBillingMinusCost()
+        {
+            MetricsHelper.CalculateMarginAbsolute(80.0, 100.0).ShouldBe(20.0);
+        }
+
+        [Fact]
+        public void CalculateMarginAbsolute_Given_CostExceedsBilling_Then_ReturnsNegative()
+        {
+            MetricsHelper.CalculateMarginAbsolute(120.0, 100.0).ShouldBe(-20.0);
+        }
+
+        [Fact]
+        public void CalculateMarginAbsolute_Given_EqualValues_Then_ReturnsZero()
+        {
+            MetricsHelper.CalculateMarginAbsolute(100.0, 100.0).ShouldBe(0.0);
+        }
+
+        #endregion
+
+        #region CalculateMargin
+
+        [Fact]
+        public void CalculateMargin_Given_BothNull_Then_ReturnsZero()
+        {
+            // abs=null, billing=null => return 0
+            MetricsHelper.CalculateMargin(null, null).ShouldBe(0.0);
+        }
+
+        [Fact]
+        public void CalculateMargin_Given_ZeroCostAndZeroBilling_Then_ReturnsZero()
+        {
+            // abs=0, billing=0 => return 0
+            MetricsHelper.CalculateMargin(0.0, 0.0).ShouldBe(0.0);
+        }
+
+        [Fact]
+        public void CalculateMargin_Given_CostNullAndPositiveBilling_Then_ReturnsOne()
+        {
+            // abs=null, billing=100 (non-null, non-zero) => return 1.0
+            MetricsHelper.CalculateMargin(null, 100.0).ShouldBe(1.0);
+        }
+
+        [Fact]
+        public void CalculateMargin_Given_PositiveCostAndBilling_Then_ReturnsRatio()
+        {
+            // abs = 100 - 80 = 20, billing = 100 => margin = 20/100 = 0.2
+            MetricsHelper.CalculateMargin(80.0, 100.0).ShouldBe(0.2);
+        }
+
+        [Fact]
+        public void CalculateMargin_Given_NonZeroAbsAndZeroBilling_Then_ReturnsNull()
+        {
+            // abs = 0 - 80 = -80 (non-zero), billing = 0 => null
+            MetricsHelper.CalculateMargin(80.0, 0.0).ShouldBeNull();
+        }
+
+        #endregion
+
+        #region CalculateProjectRisks
+
+        [Fact]
+        public void CalculateProjectRisks_Given_EmptyActivities_Then_ReturnsAllOnes()
+        {
+            var result = MetricsHelper.CalculateProjectRisks([], DefaultSeverities());
+            result.Criticality.ShouldBe(1.0);
+            result.Fibonacci.ShouldBe(1.0);
+            result.Activity.ShouldBe(1.0);
+            result.ActivityStdDevCorrection.ShouldBe(1.0);
+            result.GeometricCriticality.ShouldBe(1.0);
+            result.GeometricFibonacci.ShouldBe(1.0);
+            result.GeometricActivity.ShouldBe(1.0);
+        }
+
+        [Fact]
+        public void CalculateProjectRisks_Given_ActivitiesWithNoRisk_Then_ExcludesThemFromCalc()
+        {
+            // Activities with HasNoRisk=true should be excluded
+            var activities = new[]
+            {
+                MakeActivity(0, hasNoRisk: false),
+                MakeActivity(100, hasNoRisk: true),  // excluded
+            };
+            var result = MetricsHelper.CalculateProjectRisks(activities, DefaultSeverities());
+            // Only the critical activity (slack=0) is included
+            result.Criticality.ShouldBe(1.0);
+            result.Activity.ShouldBe(1.0);
+        }
+
+        #endregion
+    }
+}

--- a/test/Zametek.ViewModel.ProjectPlan.Tests/Miscellaneous/SerializationRoundTripTests.cs
+++ b/test/Zametek.ViewModel.ProjectPlan.Tests/Miscellaneous/SerializationRoundTripTests.cs
@@ -1,0 +1,279 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+using Zametek.Common.ProjectPlan;
+using Zametek.Data.ProjectPlan;
+using Zametek.ViewModel.ProjectPlan;
+
+namespace Zametek.ViewModel.ProjectPlan.Tests
+{
+    /// <summary>
+    /// Round-trip serialization tests for ProjectFileOpen / ProjectFileSave.
+    /// Each test saves a model to a temp file, reopens it, and asserts key fields
+    /// are preserved. We verify the JSON version tag is written correctly.
+    /// </summary>
+    public class SerializationRoundTripTests : IDisposable
+    {
+        private readonly List<string> m_TempFiles = [];
+        private readonly DateTimeCalculator m_Calculator;
+        private readonly ProjectFileSave m_Saver;
+        private readonly ProjectFileOpen m_Opener;
+
+        public SerializationRoundTripTests()
+        {
+            m_Calculator = new DateTimeCalculator(TimeProvider.System);
+            m_Saver = new ProjectFileSave();
+            m_Opener = new ProjectFileOpen(m_Calculator);
+        }
+
+        public void Dispose()
+        {
+            foreach (string file in m_TempFiles)
+            {
+                if (File.Exists(file))
+                {
+                    File.Delete(file);
+                }
+            }
+        }
+
+        private string CreateTempFile()
+        {
+            string path = Path.Combine(Path.GetTempPath(), $"zpp_test_{Guid.NewGuid():N}.zpp");
+            m_TempFiles.Add(path);
+            return path;
+        }
+
+        /// <summary>
+        /// Builds the simplest possible v0.6.0 ProjectModel to use as a fixture.
+        /// </summary>
+        private static ProjectModel BuildMinimalProjectModel()
+        {
+            Guid projectId = Guid.Parse("aaaaaa00-0000-0000-0000-000000000001");
+            Guid rootId = Guid.Parse("aaaaaa00-0000-0000-0000-000000000002");
+            Guid scenarioId = Guid.Parse("aaaaaa00-0000-0000-0000-000000000003");
+            var createdOn = new DateTimeOffset(2025, 1, 6, 0, 0, 0, TimeSpan.Zero);
+
+            return new ProjectModel
+            {
+                Version = Versions.v0_6_0,
+                Id = projectId,
+                Root = rootId,
+                Current = scenarioId,
+                Nodes =
+                [
+                    new ProjectScenarioNodeModel
+                    {
+                        Id = scenarioId,
+                        ParentId = rootId,
+                        NodeType = ProjectScenarioNodeType.File,
+                        Name = "Base",
+                        CreatedOn = createdOn,
+                        ModifiedOn = createdOn,
+                    },
+                ],
+                Files =
+                [
+                    new ProjectScenarioFileModel
+                    {
+                        NodeId = scenarioId,
+                        Scenario = new ProjectScenarioModel
+                        {
+                            ProjectStart = createdOn,
+                            Today = createdOn,
+                        },
+                    },
+                ],
+                Tags =
+                [
+                    new ProjectScenarioTagModel
+                    {
+                        NodeId = rootId,
+                        Label = "Root",
+                    },
+                ],
+            };
+        }
+
+        #region Version field
+
+        [Fact]
+        public async Task SaveProject_Writes_CorrectVersionField()
+        {
+            string path = CreateTempFile();
+            ProjectModel model = BuildMinimalProjectModel();
+
+            await m_Saver.SaveProjectFileAsync(model, path);
+
+            string json = await File.ReadAllTextAsync(path);
+            JObject obj = JObject.Parse(json);
+            string? version = obj.GetValue("Version", StringComparison.OrdinalIgnoreCase)?.ToString();
+            version.ShouldBe(Versions.v0_6_0);
+        }
+
+        #endregion
+
+        #region Minimal model round-trip
+
+        [Fact]
+        public async Task RoundTrip_Minimal_ProjectModel_Preserves_Version()
+        {
+            string path = CreateTempFile();
+            ProjectModel original = BuildMinimalProjectModel();
+
+            await m_Saver.SaveProjectFileAsync(original, path);
+            ProjectModel loaded = await m_Opener.OpenProjectFileAsync(path);
+
+            loaded.Version.ShouldBe(Versions.v0_6_0);
+        }
+
+        [Fact]
+        public async Task RoundTrip_Minimal_ProjectModel_Preserves_NodeCount()
+        {
+            string path = CreateTempFile();
+            ProjectModel original = BuildMinimalProjectModel();
+
+            await m_Saver.SaveProjectFileAsync(original, path);
+            ProjectModel loaded = await m_Opener.OpenProjectFileAsync(path);
+
+            loaded.Nodes.Count.ShouldBe(original.Nodes.Count);
+        }
+
+        [Fact]
+        public async Task RoundTrip_Minimal_ProjectModel_Preserves_FileCount()
+        {
+            string path = CreateTempFile();
+            ProjectModel original = BuildMinimalProjectModel();
+
+            await m_Saver.SaveProjectFileAsync(original, path);
+            ProjectModel loaded = await m_Opener.OpenProjectFileAsync(path);
+
+            loaded.Files.Count.ShouldBe(original.Files.Count);
+        }
+
+        [Fact]
+        public async Task RoundTrip_Minimal_ProjectModel_Preserves_ProjectStart()
+        {
+            string path = CreateTempFile();
+            ProjectModel original = BuildMinimalProjectModel();
+            DateTimeOffset expectedStart = original.Files[0].Scenario.ProjectStart;
+
+            await m_Saver.SaveProjectFileAsync(original, path);
+            ProjectModel loaded = await m_Opener.OpenProjectFileAsync(path);
+
+            loaded.Files[0].Scenario.ProjectStart.ShouldBe(expectedStart);
+        }
+
+        [Fact]
+        public async Task RoundTrip_Minimal_ProjectModel_Preserves_NodeNames()
+        {
+            string path = CreateTempFile();
+            ProjectModel original = BuildMinimalProjectModel();
+
+            await m_Saver.SaveProjectFileAsync(original, path);
+            ProjectModel loaded = await m_Opener.OpenProjectFileAsync(path);
+
+            for (int i = 0; i < original.Nodes.Count; i++)
+            {
+                loaded.Nodes[i].Name.ShouldBe(original.Nodes[i].Name);
+            }
+        }
+
+        [Fact]
+        public async Task RoundTrip_Minimal_ProjectModel_Preserves_TagLabels()
+        {
+            string path = CreateTempFile();
+            ProjectModel original = BuildMinimalProjectModel();
+
+            await m_Saver.SaveProjectFileAsync(original, path);
+            ProjectModel loaded = await m_Opener.OpenProjectFileAsync(path);
+
+            loaded.Tags.Count.ShouldBe(original.Tags.Count);
+            for (int i = 0; i < original.Tags.Count; i++)
+            {
+                loaded.Tags[i].Label.ShouldBe(original.Tags[i].Label);
+            }
+        }
+
+        #endregion
+
+        #region Double round-trip idempotency
+
+        [Fact]
+        public async Task DoubleRoundTrip_Produces_Same_Version()
+        {
+            string path1 = CreateTempFile();
+            string path2 = CreateTempFile();
+            ProjectModel original = BuildMinimalProjectModel();
+
+            await m_Saver.SaveProjectFileAsync(original, path1);
+            ProjectModel pass1 = await m_Opener.OpenProjectFileAsync(path1);
+
+            await m_Saver.SaveProjectFileAsync(pass1, path2);
+            ProjectModel pass2 = await m_Opener.OpenProjectFileAsync(path2);
+
+            pass2.Version.ShouldBe(Versions.v0_6_0);
+        }
+
+        [Fact]
+        public async Task DoubleRoundTrip_Preserves_NodeCount()
+        {
+            string path1 = CreateTempFile();
+            string path2 = CreateTempFile();
+            ProjectModel original = BuildMinimalProjectModel();
+
+            await m_Saver.SaveProjectFileAsync(original, path1);
+            ProjectModel pass1 = await m_Opener.OpenProjectFileAsync(path1);
+            await m_Saver.SaveProjectFileAsync(pass1, path2);
+            ProjectModel pass2 = await m_Opener.OpenProjectFileAsync(path2);
+
+            pass2.Nodes.Count.ShouldBe(original.Nodes.Count);
+        }
+
+        #endregion
+
+        #region Loading existing v0.6.0 fixture
+
+        /// <summary>
+        /// Loads the test_v0_6_0.zpp fixture (used by the Data.ProjectPlan converter
+        /// tests) and verifies that resaving it produces a file that re-opens
+        /// with the same node/file/tag counts.
+        /// The fixture path is the Data test project's TestFiles directory, so we
+        /// use the copy that is embedded in the ViewModel test project as a Content
+        /// item — but since that fixture is not included here, we skip gracefully if
+        /// the file is not found.
+        /// </summary>
+        [Fact]
+        public async Task RoundTrip_ExistingV0_6_0_Fixture_PreservesStructure()
+        {
+            // The Data.ProjectPlan.Tests project copies its TestFiles next to its dll.
+            // We resolve from the running assembly location.
+            string assemblyDir = AppContext.BaseDirectory;
+            string fixturePath = Path.Combine(assemblyDir, "TestFiles", "test_v0_6_0.zpp");
+
+            if (!File.Exists(fixturePath))
+            {
+                // Fixture is in the Data test project, not here — skip gracefully.
+                return;
+            }
+
+            ProjectModel loaded = await m_Opener.OpenProjectFileAsync(fixturePath);
+
+            string roundTripPath = CreateTempFile();
+            await m_Saver.SaveProjectFileAsync(loaded, roundTripPath);
+            ProjectModel reloaded = await m_Opener.OpenProjectFileAsync(roundTripPath);
+
+            reloaded.Version.ShouldBe(Versions.v0_6_0);
+            reloaded.Nodes.Count.ShouldBe(loaded.Nodes.Count);
+            reloaded.Files.Count.ShouldBe(loaded.Files.Count);
+            reloaded.Tags.Count.ShouldBe(loaded.Tags.Count);
+        }
+
+        #endregion
+    }
+}

--- a/test/Zametek.ViewModel.ProjectPlan.Tests/ProjectScenarioManagement/ProjectScenarioHelperEdgeCaseTests.cs
+++ b/test/Zametek.ViewModel.ProjectPlan.Tests/ProjectScenarioManagement/ProjectScenarioHelperEdgeCaseTests.cs
@@ -1,0 +1,173 @@
+using Shouldly;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Zametek.ViewModel.ProjectPlan.Tests
+{
+    /// <summary>
+    /// Edge-case tests for ProjectScenarioHelper.RefineIdMaps that are not
+    /// covered by the fixture-driven theory tests.
+    /// All tests call RefineIdMaps directly — no file I/O is required.
+    /// </summary>
+    public class ProjectScenarioHelperEdgeCaseTests
+    {
+        #region Empty input
+
+        [Fact]
+        public void RefineIdMaps_EmptyOriginalIds_And_EmptyMaps_Returns_EmptyList()
+        {
+            List<(int, int)> result = ProjectScenarioHelper.RefineIdMaps([], []);
+            result.ShouldBeEmpty();
+        }
+
+        #endregion
+
+        #region Single element
+
+        [Fact]
+        public void RefineIdMaps_SingleId_NoMaps_Returns_IdentityMap()
+        {
+            List<(int, int)> result = ProjectScenarioHelper.RefineIdMaps([42], []);
+            result.ShouldHaveSingleItem();
+            result[0].ShouldBe((42, 42));
+        }
+
+        [Fact]
+        public void RefineIdMaps_SingleId_MappedToItself_Returns_IdentityMap()
+        {
+            List<(int, int)> result = ProjectScenarioHelper.RefineIdMaps([7], [(7, 7)]);
+            result.ShouldHaveSingleItem();
+            result[0].ShouldBe((7, 7));
+        }
+
+        [Fact]
+        public void RefineIdMaps_SingleId_MappedToHigherValue_Returns_RequestedMap()
+        {
+            // [5] remapped to [(5, 99)] — no conflicts, so the mapping is honoured exactly.
+            List<(int, int)> result = ProjectScenarioHelper.RefineIdMaps([5], [(5, 99)]);
+            result.ShouldHaveSingleItem();
+            result[0].ShouldBe((5, 99));
+        }
+
+        #endregion
+
+        #region No maps — identity
+
+        [Fact]
+        public void RefineIdMaps_NoMaps_Returns_IdentityForAllOriginalIds()
+        {
+            int[] ids = [3, 7, 15];
+            List<(int, int)> result = ProjectScenarioHelper.RefineIdMaps([.. ids], []);
+            result.Count.ShouldBe(ids.Length);
+            foreach (int id in ids)
+            {
+                result.ShouldContain((id, id));
+            }
+        }
+
+        #endregion
+
+        #region Gaps in ID sequence
+
+        [Fact]
+        public void RefineIdMaps_GappedIds_NoMaps_Returns_IdentityForEachId()
+        {
+            // Non-contiguous IDs: 1, 5, 10, 100
+            List<(int, int)> result = ProjectScenarioHelper.RefineIdMaps([1, 5, 10, 100], []);
+            result.Count.ShouldBe(4);
+            result.ShouldContain((1, 1));
+            result.ShouldContain((5, 5));
+            result.ShouldContain((10, 10));
+            result.ShouldContain((100, 100));
+        }
+
+        [Fact]
+        public void RefineIdMaps_GappedIds_WithMap_LockedIdIsPreserved()
+        {
+            // IDs: 1, 5, 10. Map ID 1 → 5. Since 5 is already in use, it gets bumped.
+            List<(int, int)> result = ProjectScenarioHelper.RefineIdMaps([1, 5, 10], [(1, 5)]);
+            // ID 1 must land on 5 (locked).
+            result.ShouldContain((1, 5));
+            // ID 5 must NOT land on 5 (it was the locked target, so it gets bumped).
+            result.Single(x => x.Item1 == 5).Item2.ShouldNotBe(5);
+        }
+
+        #endregion
+
+        #region Target higher than all existing IDs (no conflict)
+
+        [Fact]
+        public void RefineIdMaps_MapToIdFarAboveExisting_NoOtherIdsMoved()
+        {
+            // IDs: 1, 2, 3. Map 2 → 1000. IDs 1 and 3 should stay at 1 and 3.
+            List<(int, int)> result = ProjectScenarioHelper.RefineIdMaps([1, 2, 3], [(2, 1000)]);
+            result.ShouldContain((2, 1000));
+            result.ShouldContain((1, 1));
+            result.ShouldContain((3, 3));
+        }
+
+        #endregion
+
+        #region Map where source and target IDs overlap (swap-like)
+
+        [Fact]
+        public void RefineIdMaps_HighIdsRemappedToLowValues_DoesNotDoubleMap()
+        {
+            // Based on the existing fixture case: [4..13], map 11→1, 12→2, 13→3.
+            // This is a "downward" remap of the high IDs into the range below the existing IDs.
+            List<int> original = [4, 5, 6, 7, 8, 9, 10, 11, 12, 13];
+            List<(int, int)> maps = [(11, 1), (12, 2), (13, 3)];
+            List<(int, int)> result = ProjectScenarioHelper.RefineIdMaps(original, maps);
+
+            // Locked mappings must be honoured.
+            result.ShouldContain((11, 1));
+            result.ShouldContain((12, 2));
+            result.ShouldContain((13, 3));
+
+            // All ToIds must be unique (no two source IDs land on the same target).
+            var toIds = result.Select(x => x.Item2).ToList();
+            toIds.Distinct().Count().ShouldBe(toIds.Count);
+        }
+
+        #endregion
+
+        #region All target IDs are unique (invariant)
+
+        [Theory]
+        [InlineData(new[] { 1, 2, 3, 4, 5 }, new int[] { }, new int[] { })]
+        [InlineData(new[] { 1, 2, 3, 4, 5 }, new[] { 1, 3 }, new[] { 4, 7 })]
+        [InlineData(new[] { 1, 2, 3, 4, 5 }, new[] { 5 }, new[] { 2 })]
+        public void RefineIdMaps_AllResultingToIds_AreUnique(
+            int[] originalIds,
+            int[] fromIds,
+            int[] toIds)
+        {
+            List<(int, int)> maps = fromIds.Zip(toIds, (f, t) => (f, t)).ToList();
+            List<(int, int)> result = ProjectScenarioHelper.RefineIdMaps([.. originalIds], maps);
+
+            var resultToIds = result.Select(x => x.Item2).ToList();
+            resultToIds.Distinct().Count().ShouldBe(resultToIds.Count,
+                "All ToIds in the result must be unique");
+        }
+
+        #endregion
+
+        #region Order of result is by FromId
+
+        [Fact]
+        public void RefineIdMaps_Result_IsOrderedByFromId()
+        {
+            List<(int, int)> result = ProjectScenarioHelper.RefineIdMaps(
+                [10, 5, 3, 1],
+                []);
+
+            for (int i = 0; i < result.Count - 1; i++)
+            {
+                result[i].Item1.ShouldBeLessThan(result[i + 1].Item1);
+            }
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
## Summary

- Extracts `GraphCompilationService`, `ResourceSchedulingService`, and `MetricCalculationService` from the 2,666-line `CoreViewModel` god object
- Each service is interface-backed (`IGraphCompilationService`, `IResourceSchedulingService`, `IMetricCalculationService`) and registered as a singleton in Autofac
- `CoreViewModel` becomes a coordinator: the four private static computation methods are removed and the seven `Build*` public methods are reduced to 1–4 line service delegation calls
- No behavioral change — pure structural refactoring

## What was extracted

| Service | Methods moved |
|---------|--------------|
| `GraphCompilationService` | `BuildArrowGraph`, `BuildVertexGraph` |
| `ResourceSchedulingService` | `CalculateResourceSeriesSet` → `BuildResourceSeriesSet`, `CalculateTrackingSeriesSet` → `BuildTrackingSeriesSet` |
| `MetricCalculationService` | `CalculateCyclomaticComplexity`, `CalculateDurationManMonths` → `BuildNetworkMetrics`, `BuildRiskMetrics`, `BuildFinancialMetrics` |

## Commits

1. `Extract IGraphCompilationService from CoreViewModel`
2. `Extract IResourceSchedulingService from CoreViewModel`
3. `Extract IMetricCalculationService from CoreViewModel`
4. `Wire extracted services into CoreViewModel and Autofac registration`
5. `Inject services into CoreViewModel and delegate Build* methods`

## Test plan

- [ ] Build compiles with 0 errors (`dotnet build`)
- [ ] All 343 ViewModel tests pass
- [ ] App launches and compiles a project plan end-to-end
- [ ] Arrow graph, vertex graph, resource chart, Gantt chart, and earned value chart all render correctly
- [ ] Metrics (network, risk, financial) display correctly after compile