### PR TITLE
Add Duplicate commands, context menus, chart resets, VertexGraph ShowNames, and WorkStream edit dialog

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,35 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = crlf
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.cs]
+indent_size = 4
+
+# Naming conventions matching existing codebase (m_ prefix for private fields)
+dotnet_naming_rule.private_fields_should_have_prefix.severity = suggestion
+dotnet_naming_rule.private_fields_should_have_prefix.symbols = private_fields
+dotnet_naming_rule.private_fields_should_have_prefix.style = prefix_m_underscore
+
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+
+dotnet_naming_style.prefix_m_underscore.required_prefix = m_
+dotnet_naming_style.prefix_m_underscore.capitalization = camel_case
+
+[*.{axaml,xaml}]
+indent_size = 2
+
+[*.{csproj,props,targets}]
+indent_size = 2
+
+[*.{json,yml,yaml}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [ master, develop ]
+  pull_request:
+    branches: [ master, develop ]
+
+jobs:
+  build-and-test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.x'
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore --configuration Release
+
+      - name: Test
+        run: dotnet test --no-build --configuration Release --verbosity normal

--- a/src/Zametek.Contract.ProjectPlan/ActivityManagement/IActivitiesManagerViewModel.cs
+++ b/src/Zametek.Contract.ProjectPlan/ActivityManagement/IActivitiesManagerViewModel.cs
@@ -36,6 +36,8 @@ namespace Zametek.Contract.ProjectPlan
 
         ICommand EditManagedActivitiesCommand { get; }
 
+        ICommand DuplicateManagedActivityCommand { get; }
+
         ICommand RenumberActivitiesCommand { get; }
 
         ICommand AddMilestoneCommand { get; }

--- a/src/Zametek.Contract.ProjectPlan/GraphSettingsManagement/IGraphSettingsManagerViewModel.cs
+++ b/src/Zametek.Contract.ProjectPlan/GraphSettingsManagement/IGraphSettingsManagerViewModel.cs
@@ -25,5 +25,7 @@ namespace Zametek.Contract.ProjectPlan
         ICommand AddManagedActivitySeverityCommand { get; }
 
         ICommand RemoveManagedActivitySeveritiesCommand { get; }
+
+        ICommand DuplicateManagedActivitySeverityCommand { get; }
     }
 }

--- a/src/Zametek.Contract.ProjectPlan/HolidaySettingsManagement/IHolidaySettingsManagerViewModel.cs
+++ b/src/Zametek.Contract.ProjectPlan/HolidaySettingsManagement/IHolidaySettingsManagerViewModel.cs
@@ -27,6 +27,8 @@ namespace Zametek.Contract.ProjectPlan
 
         ICommand RemoveManagedHolidaysCommand { get; }
 
+        ICommand DuplicateManagedHolidayCommand { get; }
+
         ICommand EditManagedHolidayCommand { get; }
     }
 }

--- a/src/Zametek.Contract.ProjectPlan/ResourceChartManagement/IResourceChartManagerViewModel.cs
+++ b/src/Zametek.Contract.ProjectPlan/ResourceChartManagement/IResourceChartManagerViewModel.cs
@@ -22,6 +22,8 @@ namespace Zametek.Contract.ProjectPlan
 
         ICommand SaveResourceChartImageFileCommand { get; }
 
+        ICommand ResetResourceChartCommand { get; }
+
         Task SaveResourceChartImageFileAsync(string? filename, int width, int height);
 
         void BuildResourceChartPlotModel();

--- a/src/Zametek.Contract.ProjectPlan/ResourceSettingsManagement/IResourceSettingsManagerViewModel.cs
+++ b/src/Zametek.Contract.ProjectPlan/ResourceSettingsManagement/IResourceSettingsManagerViewModel.cs
@@ -35,6 +35,8 @@ namespace Zametek.Contract.ProjectPlan
 
         ICommand RemoveManagedResourcesCommand { get; }
 
+        ICommand DuplicateManagedResourceCommand { get; }
+
         ICommand EditManagedResourcesCommand { get; }
 
         ICommand RenumberResourcesCommand { get; }

--- a/src/Zametek.Contract.ProjectPlan/ScenarioChartManagement/IScenarioChartManagerViewModel.cs
+++ b/src/Zametek.Contract.ProjectPlan/ScenarioChartManagement/IScenarioChartManagerViewModel.cs
@@ -24,6 +24,8 @@ namespace Zametek.Contract.ProjectPlan
 
         ICommand SaveScenarioChartImageFileCommand { get; }
 
+        ICommand ResetScenarioChartCommand { get; }
+
         Task SaveScenarioChartImageFileAsync(string? filename, int width, int height);
 
         void BuildScenarioChartPlotModel();

--- a/src/Zametek.Contract.ProjectPlan/WorkStreamSettingsManagement/IWorkStreamSettingsManagerViewModel.cs
+++ b/src/Zametek.Contract.ProjectPlan/WorkStreamSettingsManagement/IWorkStreamSettingsManagerViewModel.cs
@@ -30,6 +30,8 @@ namespace Zametek.Contract.ProjectPlan
 
         ICommand DuplicateManagedWorkStreamCommand { get; }
 
+        ICommand EditManagedWorkStreamsCommand { get; }
+
         ICommand RenumberWorkStreamsCommand { get; }
     }
 }

--- a/src/Zametek.Contract.ProjectPlan/WorkStreamSettingsManagement/IWorkStreamSettingsManagerViewModel.cs
+++ b/src/Zametek.Contract.ProjectPlan/WorkStreamSettingsManagement/IWorkStreamSettingsManagerViewModel.cs
@@ -28,6 +28,8 @@ namespace Zametek.Contract.ProjectPlan
 
         ICommand RemoveManagedWorkStreamsCommand { get; }
 
+        ICommand DuplicateManagedWorkStreamCommand { get; }
+
         ICommand RenumberWorkStreamsCommand { get; }
     }
 }

--- a/src/Zametek.Data.ProjectPlan/Versions.cs
+++ b/src/Zametek.Data.ProjectPlan/Versions.cs
@@ -18,6 +18,6 @@
         public const string v0_6_0 = @"v0.6.0";
 
         public const string ProjectLatest = v0_6_0;
-        public const string AppSettingsLatest = v0_4_4;
+        public const string AppSettingsLatest = v0_6_0;
     }
 }

--- a/src/Zametek.ProjectPlan/App.axaml.cs
+++ b/src/Zametek.ProjectPlan/App.axaml.cs
@@ -28,124 +28,135 @@ namespace Zametek.ProjectPlan
 
         public override async void OnFrameworkInitializationCompleted()
         {
-            if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktopLifetime)
+            try
             {
-                var splashView = new SplashView();
-                var splashViewModel = new SplashViewModel();
-
-                splashView.DataContext = splashViewModel;
-
-                desktopLifetime.MainWindow = splashView;
-
-                splashView.Show();
-
-                string? input = null;
-
-                desktopLifetime.Startup += (sender, args) =>
+                if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktopLifetime)
                 {
-                    input = args?.Args?.FirstOrDefault();
-                };
+                    var splashView = new SplashView();
+                    var splashViewModel = new SplashViewModel();
 
-                try
-                {
-                    await Task.Factory.StartNew(() =>
+                    splashView.DataContext = splashViewModel;
+
+                    desktopLifetime.MainWindow = splashView;
+
+                    splashView.Show();
+
+                    string? input = null;
+
+                    desktopLifetime.Startup += (sender, args) =>
                     {
-                        Bootstrapper.RegisterIOC();
-                    }, cancellationToken: splashViewModel.CancellationToken);
-
-                    ISettingService settingService = GetRequiredService<ISettingService>();
-                    string selectedTheme = settingService.SelectedTheme;
-
-                    IMainViewModel mainViewModel = GetRequiredService<IMainViewModel>();
-
-                    DataContext = mainViewModel;
-
-                    desktopLifetime.Exit += (a, b) =>
-                    {
-                        mainViewModel.CloseLayout();
+                        input = args?.Args?.FirstOrDefault();
                     };
 
-                    MainView mainView = new()
+                    try
                     {
-                        DataContext = mainViewModel,
-                        InitialTheme = selectedTheme
-                    };
-
-                    IDialogService dialogService = GetRequiredService<IDialogService>();
-                    dialogService.Parent = mainView;
-
-                    // Cancelling the window closing does not work when using an async handler,
-                    // and trying to force Wait on the return dialog freezes the UI thread.
-                    // This solution is the hack below, where CancelClose automatically cancels
-                    // the closing event first, then CheckClose checks to see if the project
-                    // has updates.
-                    // If there are no updates, CheckClose removes all handlers and forces a new close.
-                    // If there are updates, then the dialog requests permission to proceed.
-                    // If yes, then it continues as before. If no, then CheckClose removes itself
-                    // and then adds back all the handlers in the correct order (i.e. the same
-                    // initial state) and then immediately returns.
-                    void CancelClose(object? sender, CancelEventArgs args)
-                    {
-                        args.Cancel = true;
-                    }
-
-                    async void CheckClose(object? sender, CancelEventArgs args)
-                    {
-                        mainView.Closing -= CancelClose;
-
-                        if (mainViewModel.ProjectHasChanges)
+                        await Task.Factory.StartNew(() =>
                         {
-                            bool wishToClose = await dialogService.ShowConfirmationAsync(
-                                Resource.ProjectPlan.Titles.Title_ProjectUnsavedChanges,
-                                string.Empty,
-                                Resource.ProjectPlan.Messages.Message_ProjectUnsavedChanges);
+                            Bootstrapper.RegisterIOC();
+                        }, cancellationToken: splashViewModel.CancellationToken);
 
-                            if (!wishToClose)
-                            {
-                                // Clearing the rest of the handlers and then adding
-                                // them back in the correct order.
-                                mainView.Closing -= CheckClose;
-                                mainView.Closing += CancelClose;
-                                mainView.Closing += CheckClose;
-                                return;
-                            }
+                        ISettingService settingService = GetRequiredService<ISettingService>();
+                        string selectedTheme = settingService.SelectedTheme;
+
+                        IMainViewModel mainViewModel = GetRequiredService<IMainViewModel>();
+
+                        DataContext = mainViewModel;
+
+                        desktopLifetime.Exit += (a, b) =>
+                        {
+                            mainViewModel.CloseLayout();
+                        };
+
+                        MainView mainView = new()
+                        {
+                            DataContext = mainViewModel,
+                            InitialTheme = selectedTheme
+                        };
+
+                        IDialogService dialogService = GetRequiredService<IDialogService>();
+                        dialogService.Parent = mainView;
+
+                        // Cancelling the window closing does not work when using an async handler,
+                        // and trying to force Wait on the return dialog freezes the UI thread.
+                        // This solution is the hack below, where CancelClose automatically cancels
+                        // the closing event first, then CheckClose checks to see if the project
+                        // has updates.
+                        // If there are no updates, CheckClose removes all handlers and forces a new close.
+                        // If there are updates, then the dialog requests permission to proceed.
+                        // If yes, then it continues as before. If no, then CheckClose removes itself
+                        // and then adds back all the handlers in the correct order (i.e. the same
+                        // initial state) and then immediately returns.
+                        void CancelClose(object? sender, CancelEventArgs args)
+                        {
+                            args.Cancel = true;
                         }
 
-                        mainView.Closing -= CheckClose;
-                        mainViewModel.CloseLayout();
-                        mainView.Close();
+                        async void CheckClose(object? sender, CancelEventArgs args)
+                        {
+                            mainView.Closing -= CancelClose;
+
+                            if (mainViewModel.ProjectHasChanges)
+                            {
+                                bool wishToClose = await dialogService.ShowConfirmationAsync(
+                                    Resource.ProjectPlan.Titles.Title_ProjectUnsavedChanges,
+                                    string.Empty,
+                                    Resource.ProjectPlan.Messages.Message_ProjectUnsavedChanges);
+
+                                if (!wishToClose)
+                                {
+                                    // Clearing the rest of the handlers and then adding
+                                    // them back in the correct order.
+                                    mainView.Closing -= CheckClose;
+                                    mainView.Closing += CancelClose;
+                                    mainView.Closing += CheckClose;
+                                    return;
+                                }
+                            }
+
+                            mainView.Closing -= CheckClose;
+                            mainViewModel.CloseLayout();
+                            mainView.Close();
+                        }
+
+                        mainView.Closing += CancelClose;
+                        mainView.Closing += CheckClose;
+
+                        desktopLifetime.MainWindow = mainView;
+
+                        mainView.Show();
+
+                        if (input is not null)
+                        {
+                            await mainViewModel.OpenProjectFileAsync(input);
+                        }
+
+                        splashView.Close();
                     }
-
-                    mainView.Closing += CancelClose;
-                    mainView.Closing += CheckClose;
-
-                    desktopLifetime.MainWindow = mainView;
-
-                    mainView.Show();
-
-                    if (input is not null)
+                    catch (TaskCanceledException)
                     {
-                        await mainViewModel.OpenProjectFileAsync(input);
+                        splashView.Close();
+                        return;
                     }
-
-                    splashView.Close();
                 }
-                catch (TaskCanceledException)
+                //else if (ApplicationLifetime is ISingleViewApplicationLifetime singleViewLifetime)
+                //{
+                //    var mainView = new MainView()
+                //    {
+                //        DataContext = mainViewModel
+                //    };
+
+                //    singleViewLifetime.MainView = mainView;
+                //}
+                base.OnFrameworkInitializationCompleted();
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Fatal startup error: {ex}");
+                if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
                 {
-                    splashView.Close();
-                    return;
+                    desktop.Shutdown(1);
                 }
             }
-            //else if (ApplicationLifetime is ISingleViewApplicationLifetime singleViewLifetime)
-            //{
-            //    var mainView = new MainView()
-            //    {
-            //        DataContext = mainViewModel
-            //    };
-
-            //    singleViewLifetime.MainView = mainView;
-            //}
-            base.OnFrameworkInitializationCompleted();
 
 #if DEBUG
             this.AttachDevTools();

--- a/src/Zametek.Resource.ProjectPlan/Labels.Designer.cs
+++ b/src/Zametek.Resource.ProjectPlan/Labels.Designer.cs
@@ -635,7 +635,61 @@ namespace Zametek.Resource.ProjectPlan {
                 return ResourceManager.GetString("Label_EditManagedResources", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Edit.
+        /// </summary>
+        public static string Label_EditManagedWorkStreams {
+            get {
+                return ResourceManager.GetString("Label_EditManagedWorkStreams", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Duplicate.
+        /// </summary>
+        public static string Label_DuplicateManagedActivity {
+            get {
+                return ResourceManager.GetString("Label_DuplicateManagedActivity", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Duplicate.
+        /// </summary>
+        public static string Label_DuplicateManagedActivitySeverity {
+            get {
+                return ResourceManager.GetString("Label_DuplicateManagedActivitySeverity", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Duplicate.
+        /// </summary>
+        public static string Label_DuplicateManagedHoliday {
+            get {
+                return ResourceManager.GetString("Label_DuplicateManagedHoliday", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Duplicate.
+        /// </summary>
+        public static string Label_DuplicateManagedResource {
+            get {
+                return ResourceManager.GetString("Label_DuplicateManagedResource", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Duplicate.
+        /// </summary>
+        public static string Label_DuplicateManagedWorkStream {
+            get {
+                return ResourceManager.GetString("Label_DuplicateManagedWorkStream", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Effort.
         /// </summary>

--- a/src/Zametek.Resource.ProjectPlan/Labels.resx
+++ b/src/Zametek.Resource.ProjectPlan/Labels.resx
@@ -150,6 +150,21 @@
   <data name="Label_AddMilestone" xml:space="preserve">
     <value>Milestone</value>
   </data>
+  <data name="Label_DuplicateManagedActivity" xml:space="preserve">
+    <value>Duplicate</value>
+  </data>
+  <data name="Label_DuplicateManagedActivitySeverity" xml:space="preserve">
+    <value>Duplicate</value>
+  </data>
+  <data name="Label_DuplicateManagedHoliday" xml:space="preserve">
+    <value>Duplicate</value>
+  </data>
+  <data name="Label_DuplicateManagedResource" xml:space="preserve">
+    <value>Duplicate</value>
+  </data>
+  <data name="Label_DuplicateManagedWorkStream" xml:space="preserve">
+    <value>Duplicate</value>
+  </data>
   <data name="Label_AllocatedToResources" xml:space="preserve">
     <value>Allocated to Resources</value>
   </data>

--- a/src/Zametek.Resource.ProjectPlan/Labels.resx
+++ b/src/Zametek.Resource.ProjectPlan/Labels.resx
@@ -510,6 +510,9 @@
   <data name="Label_EditManagedHoliday" xml:space="preserve">
     <value>Edit</value>
   </data>
+  <data name="Label_EditManagedWorkStreams" xml:space="preserve">
+    <value>Edit</value>
+  </data>
   <data name="Label_ShowNames" xml:space="preserve">
     <value>Show Names</value>
   </data>

--- a/src/Zametek.Resource.ProjectPlan/Messages.Designer.cs
+++ b/src/Zametek.Resource.ProjectPlan/Messages.Designer.cs
@@ -284,7 +284,16 @@ namespace Zametek.Resource.ProjectPlan {
                 return ResourceManager.GetString("Message_EditResources", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Select the properties to edit.
+        /// </summary>
+        public static string Message_EditWorkStreams {
+            get {
+                return ResourceManager.GetString("Message_EditWorkStreams", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Empty filename.
         /// </summary>

--- a/src/Zametek.Resource.ProjectPlan/Messages.resx
+++ b/src/Zametek.Resource.ProjectPlan/Messages.resx
@@ -261,6 +261,9 @@
   <data name="Message_EditResources" xml:space="preserve">
     <value>Select the properties to edit</value>
   </data>
+  <data name="Message_EditWorkStreams" xml:space="preserve">
+    <value>Select the properties to edit</value>
+  </data>
   <data name="Message_EditActivities" xml:space="preserve">
     <value>Select the properties to edit</value>
   </data>

--- a/src/Zametek.Resource.ProjectPlan/Titles.Designer.cs
+++ b/src/Zametek.Resource.ProjectPlan/Titles.Designer.cs
@@ -122,7 +122,16 @@ namespace Zametek.Resource.ProjectPlan {
                 return ResourceManager.GetString("Title_EditResources", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Edit Work Streams.
+        /// </summary>
+        public static string Title_EditWorkStreams {
+            get {
+                return ResourceManager.GetString("Title_EditWorkStreams", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Error.
         /// </summary>

--- a/src/Zametek.Resource.ProjectPlan/Titles.resx
+++ b/src/Zametek.Resource.ProjectPlan/Titles.resx
@@ -138,6 +138,9 @@
   <data name="Title_EditResources" xml:space="preserve">
     <value>Edit Resources</value>
   </data>
+  <data name="Title_EditWorkStreams" xml:space="preserve">
+    <value>Edit Work Streams</value>
+  </data>
   <data name="Title_Error" xml:space="preserve">
     <value>Error</value>
   </data>

--- a/src/Zametek.View.ProjectPlan/ActivityManagement/ActivitiesManagerView.axaml
+++ b/src/Zametek.View.ProjectPlan/ActivityManagement/ActivitiesManagerView.axaml
@@ -136,6 +136,9 @@
 							<MenuItem Header="{x:Static resources:Labels.Label_EditManagedActivities}"
 									  Command="{Binding Path=$parent[DataGrid].DataContext.EditManagedActivitiesCommand, Mode=OneWay}" />
 
+							<MenuItem Header="{x:Static resources:Labels.Label_DuplicateManagedActivity}"
+									  Command="{Binding Path=$parent[DataGrid].DataContext.DuplicateManagedActivityCommand, Mode=OneWay}" />
+
 							<MenuItem Header="{x:Static resources:Labels.Label_RenumberActivities}"
 									  Command="{Binding Path=$parent[DataGrid].DataContext.RenumberActivitiesCommand, Mode=OneWay}" />
 

--- a/src/Zametek.View.ProjectPlan/GraphManagement/VertexGraphManagerView.axaml
+++ b/src/Zametek.View.ProjectPlan/GraphManagement/VertexGraphManagerView.axaml
@@ -14,7 +14,7 @@
 	</UserControl.Resources>
 
 	<DockPanel Margin="7">
-		<!--<ScrollViewer DockPanel.Dock="Right"
+		<ScrollViewer DockPanel.Dock="Right"
 					  VerticalScrollBarVisibility="Hidden"
 					  HorizontalScrollBarVisibility="Disabled">
 			<DockPanel Margin="11,0,0,0">
@@ -38,7 +38,7 @@
 							  IsChecked="{Binding Path=ShowNames, Mode=TwoWay}"/>
 				<Grid/>
 			</DockPanel>
-		</ScrollViewer>-->
+		</ScrollViewer>
 
 		<DockPanel>
 			<DockPanel Width="250"
@@ -68,6 +68,12 @@
 						  Background="{Binding Path=BaseTheme, Mode=OneWay, Converter={StaticResource themeToBackgroundConverter}}">
 				<ScrollViewer.ContextMenu>
 					<ContextMenu>
+						<MenuItem Header="{x:Static resources:Labels.Label_ShowNames}"
+								  IsChecked="{Binding Path=ShowNames, Mode=TwoWay}"
+								  ToggleType="CheckBox" />
+
+						<Separator />
+
 						<MenuItem Header="{x:Static resources:Menus.Menu_SaveAs}"
 								  Command="{Binding Path=SaveVertexGraphImageFileCommand, Mode=OneWay}"/>
 					</ContextMenu>

--- a/src/Zametek.View.ProjectPlan/GraphSettingsManagement/GraphSettingsManagerView.axaml
+++ b/src/Zametek.View.ProjectPlan/GraphSettingsManagement/GraphSettingsManagerView.axaml
@@ -36,12 +36,21 @@
 
 				<Button DockPanel.Dock="Top"
 						IsTabStop="True"
-						Margin="0,0,0,11"
+						Margin="0,0,0,7"
 						Height="25" Width="75"
 						VerticalAlignment="Center"
 						VerticalContentAlignment="Center"
 						Command="{Binding Path=RemoveManagedActivitySeveritiesCommand, Mode=OneWay}"
 						Content="{x:Static resources:Labels.Label_DeleteManagedActivitySeverities}"/>
+
+				<Button DockPanel.Dock="Top"
+						IsTabStop="True"
+						Margin="0,0,0,11"
+						Height="25" Width="75"
+						VerticalAlignment="Center"
+						VerticalContentAlignment="Center"
+						Command="{Binding Path=DuplicateManagedActivitySeverityCommand, Mode=OneWay}"
+						Content="{x:Static resources:Labels.Label_DuplicateManagedActivitySeverity}"/>
 
 				<Grid/>
 			</DockPanel>
@@ -91,6 +100,25 @@
 								<local:MoveCaretToEndBehavior />
 							</BehaviorCollection>
 						</BehaviorCollectionTemplate>
+					</Setter>
+				</Style>
+
+				<Style>
+					<Setter Property="ContextMenu">
+						<ContextMenu>
+							<MenuItem Header="{x:Static resources:Labels.Label_AddManagedActivitySeverity}"
+									  Command="{Binding Path=$parent[DataGrid].DataContext.AddManagedActivitySeverityCommand, Mode=OneWay}" />
+
+							<Separator />
+
+							<MenuItem Header="{x:Static resources:Labels.Label_DuplicateManagedActivitySeverity}"
+									  Command="{Binding Path=$parent[DataGrid].DataContext.DuplicateManagedActivitySeverityCommand, Mode=OneWay}" />
+
+							<Separator />
+
+							<MenuItem Header="{x:Static resources:Labels.Label_DeleteManagedActivitySeverities}"
+									  Command="{Binding Path=$parent[DataGrid].DataContext.RemoveManagedActivitySeveritiesCommand, Mode=OneWay}" />
+						</ContextMenu>
 					</Setter>
 				</Style>
 			</DataGrid.Styles>

--- a/src/Zametek.View.ProjectPlan/HolidaySettingsManagement/HolidaySettingsManagerView.axaml
+++ b/src/Zametek.View.ProjectPlan/HolidaySettingsManagement/HolidaySettingsManagerView.axaml
@@ -45,6 +45,15 @@
 
 				<Button DockPanel.Dock="Top"
 						IsTabStop="True"
+						Margin="0,0,0,7"
+						Height="25" Width="75"
+						VerticalAlignment="Center"
+						VerticalContentAlignment="Center"
+						Command="{Binding Path=DuplicateManagedHolidayCommand, Mode=OneWay}"
+						Content="{x:Static resources:Labels.Label_DuplicateManagedHoliday}"/>
+
+				<Button DockPanel.Dock="Top"
+						IsTabStop="True"
 						Margin="0,0,0,11"
 						Height="25" Width="75"
 						VerticalAlignment="Center"
@@ -91,6 +100,28 @@
 				<!--<Style Selector="DataGridCell:selected:pointerover:current:focus Grid.editable">
 					<Setter Property="Background" Value="Green"/>
 				</Style>-->
+
+				<Style>
+					<Setter Property="ContextMenu">
+						<ContextMenu>
+							<MenuItem Header="{x:Static resources:Labels.Label_AddManagedHoliday}"
+									  Command="{Binding Path=$parent[DataGrid].DataContext.AddManagedHolidayCommand, Mode=OneWay}" />
+
+							<Separator />
+
+							<MenuItem Header="{x:Static resources:Labels.Label_DuplicateManagedHoliday}"
+									  Command="{Binding Path=$parent[DataGrid].DataContext.DuplicateManagedHolidayCommand, Mode=OneWay}" />
+
+							<MenuItem Header="{x:Static resources:Labels.Label_EditManagedHoliday}"
+									  Command="{Binding Path=$parent[DataGrid].DataContext.EditManagedHolidayCommand, Mode=OneWay}" />
+
+							<Separator />
+
+							<MenuItem Header="{x:Static resources:Labels.Label_DeleteManagedHolidays}"
+									  Command="{Binding Path=$parent[DataGrid].DataContext.RemoveManagedHolidaysCommand, Mode=OneWay}" />
+						</ContextMenu>
+					</Setter>
+				</Style>
 
 				<Style Selector="TextBox.displayOnly">
 					<Setter Property="IsHitTestVisible" Value="False"/>

--- a/src/Zametek.View.ProjectPlan/Miscellaneous/DataGridManager.cs
+++ b/src/Zametek.View.ProjectPlan/Miscellaneous/DataGridManager.cs
@@ -83,12 +83,8 @@ namespace Zametek.View.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 ResetActions.Clear();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.View.ProjectPlan/ResourceChartManagement/ResourceChartManagerView.axaml
+++ b/src/Zametek.View.ProjectPlan/ResourceChartManagement/ResourceChartManagerView.axaml
@@ -154,11 +154,21 @@
 			</DockPanel>
 		</ScrollViewer>
 
-		<Grid>
+		<DockPanel>
 			<!-- ScottPlot PlotView -->
 			<ContentControl x:Name="scottplot"
 							Content="{Binding ResourceChartPlotModel, Mode=OneWay}"
-							Bounds="{Binding Path=ImageBounds, Mode=OneWayToSource}"/>
-		</Grid>
+							Bounds="{Binding Path=ImageBounds, Mode=OneWayToSource}">
+				<ContentControl.ContextMenu>
+					<ContextMenu>
+						<MenuItem Header="{x:Static resources:Menus.Menu_SaveAs}"
+								  Command="{Binding Path=SaveResourceChartImageFileCommand, Mode=OneWay}" />
+
+						<MenuItem Header="{x:Static resources:Menus.Menu_Reset}"
+								  Command="{Binding Path=ResetResourceChartCommand, Mode=OneWay}" />
+					</ContextMenu>
+				</ContentControl.ContextMenu>
+			</ContentControl>
+		</DockPanel>
 	</DockPanel>
 </UserControl>

--- a/src/Zametek.View.ProjectPlan/ResourceSettingsManagement/ResourceSettingsManagerView.axaml
+++ b/src/Zametek.View.ProjectPlan/ResourceSettingsManagement/ResourceSettingsManagerView.axaml
@@ -65,6 +65,16 @@
 						VerticalAlignment="Center"
 						VerticalContentAlignment="Center"
 						IsEnabled="{Binding Path=!DisableResources, Mode=OneWay}"
+						Command="{Binding Path=DuplicateManagedResourceCommand, Mode=OneWay}"
+						Content="{x:Static resources:Labels.Label_DuplicateManagedResource}"/>
+
+				<Button DockPanel.Dock="Top"
+						IsTabStop="True"
+						Margin="0,0,0,7"
+						Height="25" Width="80"
+						VerticalAlignment="Center"
+						VerticalContentAlignment="Center"
+						IsEnabled="{Binding Path=!DisableResources, Mode=OneWay}"
 						Command="{Binding Path=EditManagedResourcesCommand, Mode=OneWay}"
 						Content="{x:Static resources:Labels.Label_EditManagedResources}"/>
 
@@ -190,6 +200,31 @@
 								<local:MoveCaretToEndBehavior />
 							</BehaviorCollection>
 						</BehaviorCollectionTemplate>
+					</Setter>
+				</Style>
+
+				<Style>
+					<Setter Property="ContextMenu">
+						<ContextMenu>
+							<MenuItem Header="{x:Static resources:Labels.Label_AddManagedResource}"
+									  Command="{Binding Path=$parent[DataGrid].DataContext.AddManagedResourceCommand, Mode=OneWay}" />
+
+							<Separator />
+
+							<MenuItem Header="{x:Static resources:Labels.Label_DuplicateManagedResource}"
+									  Command="{Binding Path=$parent[DataGrid].DataContext.DuplicateManagedResourceCommand, Mode=OneWay}" />
+
+							<MenuItem Header="{x:Static resources:Labels.Label_EditManagedResources}"
+									  Command="{Binding Path=$parent[DataGrid].DataContext.EditManagedResourcesCommand, Mode=OneWay}" />
+
+							<MenuItem Header="{x:Static resources:Labels.Label_RenumberResources}"
+									  Command="{Binding Path=$parent[DataGrid].DataContext.RenumberResourcesCommand, Mode=OneWay}" />
+
+							<Separator />
+
+							<MenuItem Header="{x:Static resources:Labels.Label_DeleteManagedResources}"
+									  Command="{Binding Path=$parent[DataGrid].DataContext.RemoveManagedResourcesCommand, Mode=OneWay}" />
+						</ContextMenu>
 					</Setter>
 				</Style>
 			</DataGrid.Styles>

--- a/src/Zametek.View.ProjectPlan/ScenarioChartManagement/ScenarioChartManagerView.axaml
+++ b/src/Zametek.View.ProjectPlan/ScenarioChartManagement/ScenarioChartManagerView.axaml
@@ -144,11 +144,21 @@
 			</DockPanel>
 		</ScrollViewer>
 
-		<Grid>
+		<DockPanel>
 			<!-- ScottPlot PlotView -->
 			<ContentControl x:Name="scottplot"
 							Content="{Binding ScenarioChartPlotModel, Mode=OneWay}"
-							Bounds="{Binding Path=ImageBounds, Mode=OneWayToSource}"/>
-		</Grid>
+							Bounds="{Binding Path=ImageBounds, Mode=OneWayToSource}">
+				<ContentControl.ContextMenu>
+					<ContextMenu>
+						<MenuItem Header="{x:Static resources:Menus.Menu_SaveAs}"
+								  Command="{Binding Path=SaveScenarioChartImageFileCommand, Mode=OneWay}" />
+
+						<MenuItem Header="{x:Static resources:Menus.Menu_Reset}"
+								  Command="{Binding Path=ResetScenarioChartCommand, Mode=OneWay}" />
+					</ContextMenu>
+				</ContentControl.ContextMenu>
+			</ContentControl>
+		</DockPanel>
 	</DockPanel>
 </UserControl>

--- a/src/Zametek.View.ProjectPlan/WorkStreamSettingsManagement/WorkStreamEditView.axaml
+++ b/src/Zametek.View.ProjectPlan/WorkStreamSettingsManagement/WorkStreamEditView.axaml
@@ -1,0 +1,80 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="100"
+			 xmlns:resources="using:Zametek.Resource.ProjectPlan"
+			 xmlns:local="using:Zametek.View.ProjectPlan"
+			 xmlns:vm="using:Zametek.ViewModel.ProjectPlan"
+			 x:DataType="vm:WorkStreamEditViewModel"
+             x:Class="Zametek.View.ProjectPlan.WorkStreamEditView">
+	<UserControl.Resources>
+		<local:ColorFormatToColorConverter x:Key="colorFormatToColorConverter"/>
+	</UserControl.Resources>
+
+	<Grid Margin="7">
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="140"/>
+			<ColumnDefinition Width="80"/>
+			<ColumnDefinition Width="155"/>
+		</Grid.ColumnDefinitions>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="36"/>
+			<RowDefinition Height="36"/>
+		</Grid.RowDefinitions>
+
+		<Label Grid.Row="0" Grid.Column="0"
+			   VerticalAlignment="Center"
+			   HorizontalAlignment="Right"
+			   Margin="0"
+			   Padding="7"
+			   Content="{x:Static resources:Labels.Label_IsPhase}"/>
+
+		<ToggleSwitch Grid.Row="0" Grid.Column="1"
+					  VerticalAlignment="Center"
+					  HorizontalAlignment="Center"
+					  Margin="0"
+				      Padding="3"
+				      OffContent="{x:Static resources:Labels.Label_Off}"
+				      OnContent="{x:Static resources:Labels.Label_On}"
+					  IsChecked="{Binding Path=IsIsPhaseActive, Mode=TwoWay}"/>
+
+		<ToggleSwitch Grid.Row="0" Grid.Column="2"
+					  Margin="3"
+					  VerticalAlignment="Center"
+					  HorizontalAlignment="Center"
+					  Padding="0"
+					  OffContent="{x:Static resources:Labels.Label_No}"
+					  OnContent="{x:Static resources:Labels.Label_Yes}"
+					  IsChecked="{Binding Path=IsPhase, Mode=TwoWay}"
+					  IsEnabled="{Binding Path=IsIsPhaseActive, Mode=OneWay}"/>
+
+
+
+		<Label Grid.Row="1" Grid.Column="0"
+			   VerticalAlignment="Center"
+			   HorizontalAlignment="Right"
+			   Margin="0"
+			   Padding="7"
+			   Content="{x:Static resources:Labels.Label_ColorFormat}"/>
+
+		<ToggleSwitch Grid.Row="1" Grid.Column="1"
+					  VerticalAlignment="Center"
+					  HorizontalAlignment="Center"
+					  Margin="0"
+				      Padding="3"
+				      OffContent="{x:Static resources:Labels.Label_Off}"
+				      OnContent="{x:Static resources:Labels.Label_On}"
+					  IsChecked="{Binding Path=IsColorFormatActive, Mode=TwoWay}"/>
+
+		<ColorPicker Grid.Row="1" Grid.Column="2"
+					 Cursor="Hand"
+					 IsEnabled="{Binding Path=IsColorFormatActive, Mode=OneWay}"
+					 Color="{Binding Path=ColorFormat, Mode=TwoWay, Converter={StaticResource colorFormatToColorConverter}, UpdateSourceTrigger=LostFocus}"
+					 VerticalAlignment="Center"
+					 Focusable="True"
+					 Margin="3"
+					 Padding="0"/>
+
+	</Grid>
+</UserControl>

--- a/src/Zametek.View.ProjectPlan/WorkStreamSettingsManagement/WorkStreamEditView.axaml.cs
+++ b/src/Zametek.View.ProjectPlan/WorkStreamSettingsManagement/WorkStreamEditView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace Zametek.View.ProjectPlan;
+
+public partial class WorkStreamEditView : UserControl
+{
+    public WorkStreamEditView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Zametek.View.ProjectPlan/WorkStreamSettingsManagement/WorkStreamSettingsManagerView.axaml
+++ b/src/Zametek.View.ProjectPlan/WorkStreamSettingsManagement/WorkStreamSettingsManagerView.axaml
@@ -57,6 +57,15 @@
 
 				<Button DockPanel.Dock="Top"
 						IsTabStop="True"
+						Margin="0,0,0,7"
+						Height="25" Width="80"
+						VerticalAlignment="Center"
+						VerticalContentAlignment="Center"
+						Command="{Binding Path=EditManagedWorkStreamsCommand, Mode=OneWay}"
+						Content="{x:Static resources:Labels.Label_EditManagedWorkStreams}"/>
+
+				<Button DockPanel.Dock="Top"
+						IsTabStop="True"
 						Margin="0,0,0,11"
 						Height="25" Width="80"
 						VerticalContentAlignment="Center"
@@ -135,6 +144,9 @@
 
 							<MenuItem Header="{x:Static resources:Labels.Label_DuplicateManagedWorkStream}"
 									  Command="{Binding Path=$parent[DataGrid].DataContext.DuplicateManagedWorkStreamCommand, Mode=OneWay}" />
+
+							<MenuItem Header="{x:Static resources:Labels.Label_EditManagedWorkStreams}"
+									  Command="{Binding Path=$parent[DataGrid].DataContext.EditManagedWorkStreamsCommand, Mode=OneWay}" />
 
 							<MenuItem Header="{x:Static resources:Labels.Label_RenumberWorkStreams}"
 									  Command="{Binding Path=$parent[DataGrid].DataContext.RenumberWorkStreamsCommand, Mode=OneWay}" />

--- a/src/Zametek.View.ProjectPlan/WorkStreamSettingsManagement/WorkStreamSettingsManagerView.axaml
+++ b/src/Zametek.View.ProjectPlan/WorkStreamSettingsManagement/WorkStreamSettingsManagerView.axaml
@@ -48,6 +48,15 @@
 
 				<Button DockPanel.Dock="Top"
 						IsTabStop="True"
+						Margin="0,0,0,7"
+						Height="25" Width="80"
+						VerticalAlignment="Center"
+						VerticalContentAlignment="Center"
+						Command="{Binding Path=DuplicateManagedWorkStreamCommand, Mode=OneWay}"
+						Content="{x:Static resources:Labels.Label_DuplicateManagedWorkStream}"/>
+
+				<Button DockPanel.Dock="Top"
+						IsTabStop="True"
 						Margin="0,0,0,11"
 						Height="25" Width="80"
 						VerticalContentAlignment="Center"
@@ -113,6 +122,28 @@
 								<local:MoveCaretToEndBehavior />
 							</BehaviorCollection>
 						</BehaviorCollectionTemplate>
+					</Setter>
+				</Style>
+
+				<Style>
+					<Setter Property="ContextMenu">
+						<ContextMenu>
+							<MenuItem Header="{x:Static resources:Labels.Label_AddManagedWorkStream}"
+									  Command="{Binding Path=$parent[DataGrid].DataContext.AddManagedWorkStreamCommand, Mode=OneWay}" />
+
+							<Separator />
+
+							<MenuItem Header="{x:Static resources:Labels.Label_DuplicateManagedWorkStream}"
+									  Command="{Binding Path=$parent[DataGrid].DataContext.DuplicateManagedWorkStreamCommand, Mode=OneWay}" />
+
+							<MenuItem Header="{x:Static resources:Labels.Label_RenumberWorkStreams}"
+									  Command="{Binding Path=$parent[DataGrid].DataContext.RenumberWorkStreamsCommand, Mode=OneWay}" />
+
+							<Separator />
+
+							<MenuItem Header="{x:Static resources:Labels.Label_DeleteManagedWorkStreams}"
+									  Command="{Binding Path=$parent[DataGrid].DataContext.RemoveManagedWorkStreamsCommand, Mode=OneWay}" />
+						</ContextMenu>
 					</Setter>
 				</Style>
 			</DataGrid.Styles>

--- a/src/Zametek.View.ProjectPlan/Zametek.View.ProjectPlan.csproj
+++ b/src/Zametek.View.ProjectPlan/Zametek.View.ProjectPlan.csproj
@@ -55,5 +55,8 @@
     <Compile Update="ScenarioChartManagement\ScenarioChartManagerView.axaml.cs">
       <DependentUpon>ScenarioChartManagerView.axaml</DependentUpon>
     </Compile>
+    <Compile Update="WorkStreamSettingsManagement\WorkStreamEditView.axaml.cs">
+      <DependentUpon>WorkStreamEditView.axaml</DependentUpon>
+    </Compile>
   </ItemGroup>
 </Project>

--- a/src/Zametek.ViewModel.ProjectPlan/ActivityManagement/ActivitiesManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ActivityManagement/ActivitiesManagerViewModel.cs
@@ -40,6 +40,7 @@ namespace Zametek.ViewModel.ProjectPlan
             InsertManagedActivityCommand = ReactiveCommand.CreateFromTask(InsertManagedActivityAsync, this.WhenAnyValue(am => am.HasActivities));
             RemoveManagedActivitiesCommand = ReactiveCommand.CreateFromTask(RemoveManagedActivitiesAsync, this.WhenAnyValue(am => am.HasActivities));
             EditManagedActivitiesCommand = ReactiveCommand.CreateFromTask(EditManagedActivitiesAsync, this.WhenAnyValue(am => am.HasActivities));
+            DuplicateManagedActivityCommand = ReactiveCommand.CreateFromTask(DuplicateManagedActivityAsync, this.WhenAnyValue(am => am.HasActivities));
 
             m_IsBusy = this
                 .WhenAnyValue(am => am.m_CoreViewModel.IsBusy)
@@ -183,6 +184,42 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_CoreViewModel.UpdateManagedActivityIds([(newId, lowestId)]);
                 m_CoreViewModel.IsReadyToReviseTrackers = ReadyToRevise.Yes;
             }
+            m_CoreViewModel.RunAutoCompile();
+        }
+
+        private async Task DuplicateManagedActivityAsync()
+        {
+            try
+            {
+                await DuplicateManagedActivityInternalAsync();
+            }
+            catch (Exception ex)
+            {
+                await m_DialogService.ShowErrorAsync(
+                    Resource.ProjectPlan.Titles.Title_Error,
+                    string.Empty,
+                    ex.Message);
+            }
+        }
+
+        private async Task DuplicateManagedActivityInternalAsync() => await Task.Run(DuplicateManagedActivityInternal);
+
+        private void DuplicateManagedActivityInternal()
+        {
+            lock (m_Lock)
+            {
+                if (SelectedActivities.Count == 0)
+                {
+                    return;
+                }
+
+                int maxDisplayOrder = SelectedActivities.Values.DefaultIfEmpty().Max(x => x?.DisplayOrder ?? 0);
+                int newDisplayOrder = maxDisplayOrder + 1;
+
+                m_CoreViewModel.AddManagedActivity(newDisplayOrder);
+                m_CoreViewModel.IsReadyToReviseTrackers = ReadyToRevise.Yes;
+            }
+
             m_CoreViewModel.RunAutoCompile();
         }
 
@@ -400,6 +437,8 @@ namespace Zametek.ViewModel.ProjectPlan
         public ICommand RemoveManagedActivitiesCommand { get; }
 
         public ICommand EditManagedActivitiesCommand { get; }
+
+        public ICommand DuplicateManagedActivityCommand { get; }
 
         public ICommand RenumberActivitiesCommand { get; }
 

--- a/src/Zametek.ViewModel.ProjectPlan/ActivityManagement/ActivityTrackerSetViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ActivityManagement/ActivityTrackerSetViewModel.cs
@@ -394,12 +394,8 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 m_DaysSub?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/ActivityManagement/ManagedActivityViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ActivityManagement/ManagedActivityViewModel.cs
@@ -980,16 +980,12 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 TrackerSet.Dispose();
                 m_ShowDates?.Dispose();
                 m_HasResources?.Dispose();
                 m_HasWorkStreams?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/CoreViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/CoreViewModel.cs
@@ -176,19 +176,22 @@ namespace Zametek.ViewModel.ProjectPlan
                 .ObserveOn(RxApp.TaskpoolScheduler)
                 .Subscribe(changeSet =>
                 {
-                    if (!IsBusy && (changeSet.Replaced + changeSet.Adds) > 0)
+                    if ((changeSet.Replaced + changeSet.Adds) > 0)
                     {
                         lock (m_Lock)
                         {
-                            if (AutoCompile)
+                            if (!IsBusy)
                             {
-                                IsReadyToReviseTrackers = ReadyToRevise.Yes;
-                                IsReadyToCompile = ReadyToCompile.Yes;
-                            }
-                            else
-                            {
-                                IsReadyToReviseTrackers = ReadyToRevise.No;
-                                IsReadyToCompile = ReadyToCompile.No;
+                                if (AutoCompile)
+                                {
+                                    IsReadyToReviseTrackers = ReadyToRevise.Yes;
+                                    IsReadyToCompile = ReadyToCompile.Yes;
+                                }
+                                else
+                                {
+                                    IsReadyToReviseTrackers = ReadyToRevise.No;
+                                    IsReadyToCompile = ReadyToCompile.No;
+                                }
                             }
                         }
                     }
@@ -199,16 +202,12 @@ namespace Zametek.ViewModel.ProjectPlan
                 .ObserveOn(Scheduler.CurrentThread)
                 .Subscribe(isReady =>
                 {
-                    if (isReady == ReadyToCompile.Yes
-                        && !IsBusy)
+                    lock (m_Lock)
                     {
-                        lock (m_Lock)
+                        if (isReady == ReadyToCompile.Yes
+                            && !IsBusy)
                         {
-                            if (isReady == ReadyToCompile.Yes
-                                && !IsBusy)
-                            {
-                                RunAutoCompile();
-                            }
+                            RunAutoCompile();
                         }
                     }
                 });
@@ -2635,7 +2634,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_ProjectFinish?.Dispose();
                 m_HasActivities?.Dispose();
@@ -2646,9 +2644,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_Activities?.Dispose();
                 m_DisplaySettingsViewModel?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/EarnedValueChartManagement/EarnedValueChartManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/EarnedValueChartManagement/EarnedValueChartManagerViewModel.cs
@@ -738,7 +738,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_IsBusy?.Dispose();
                 m_HasStaleOutputs?.Dispose();
@@ -747,9 +746,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_ShowToday?.Dispose();
                 m_ShowMilestones?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/GanttChartManagement/ActivitySelectorViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/GanttChartManagement/ActivitySelectorViewModel.cs
@@ -310,12 +310,8 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 m_ReviseActivitiesSub?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/GanttChartManagement/GanttChartManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/GanttChartManagement/GanttChartManagerViewModel.cs
@@ -1615,7 +1615,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_IsBusy?.Dispose();
                 m_HasStaleOutputs?.Dispose();
@@ -1633,9 +1632,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_BoolAccumulator?.Dispose();
                 ActivitySelector?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/GraphManagement/ArrowGraphManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/GraphManagement/ArrowGraphManagerViewModel.cs
@@ -396,7 +396,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_IsBusy?.Dispose();
                 m_HasStaleOutputs?.Dispose();
@@ -404,9 +403,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_ShowNames?.Dispose();
                 m_BaseTheme?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/GraphManagement/VertexGraphManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/GraphManagement/VertexGraphManagerViewModel.cs
@@ -399,7 +399,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_IsBusy?.Dispose();
                 m_HasStaleOutputs?.Dispose();
@@ -407,9 +406,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_ShowNames?.Dispose();
                 m_BaseTheme?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/GraphSettingsManagement/GraphSettingsManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/GraphSettingsManagement/GraphSettingsManagerViewModel.cs
@@ -56,6 +56,7 @@ namespace Zametek.ViewModel.ProjectPlan
             SetSelectedManagedActivitySeveritiesCommand = ReactiveCommand.Create<SelectionChangedEventArgs>(SetSelectedManagedActivitySeverities);
             AddManagedActivitySeverityCommand = ReactiveCommand.CreateFromTask(AddManagedActivitySeverityAsync);
             RemoveManagedActivitySeveritiesCommand = ReactiveCommand.CreateFromTask(RemoveManagedActivitySeveritiesAsync, this.WhenAnyValue(agsm => agsm.HasActivitySeverities));
+            DuplicateManagedActivitySeverityCommand = ReactiveCommand.CreateFromTask(DuplicateManagedActivitySeverityAsync, this.WhenAnyValue(agsm => agsm.HasActivitySeverities));
 
             // Create read-only view to the source list.
             m_ReadOnlyActivitySeveritiesSub = m_ActivitySeverities.Connect()
@@ -192,6 +193,47 @@ namespace Zametek.ViewModel.ProjectPlan
                 }
 
                 CheckForMaxSlackLimit();
+                UpdateGraphSettingsToCore();
+            }
+            catch (Exception ex)
+            {
+                await m_DialogService.ShowErrorAsync(
+                    Resource.ProjectPlan.Titles.Title_Error,
+                    string.Empty,
+                    ex.Message);
+            }
+        }
+
+        private async Task DuplicateManagedActivitySeverityAsync()
+        {
+            try
+            {
+                lock (m_Lock)
+                {
+                    IManagedActivitySeverityViewModel? source = SelectedActivitySeverities.Values.FirstOrDefault();
+
+                    if (source is null)
+                    {
+                        return;
+                    }
+
+                    m_ActivitySeverities.Edit(activitySeverities =>
+                    {
+                        Guid id = GetNextId();
+                        activitySeverities.Add(
+                            new ManagedActivitySeverityViewModel(
+                                this,
+                                id,
+                                new ActivitySeverityModel
+                                {
+                                    SlackLimit = source.SlackLimit,
+                                    CriticalityWeight = source.CriticalityWeight,
+                                    FibonacciWeight = source.FibonacciWeight,
+                                    ColorFormat = ColorHelper.Random()
+                                }));
+                    });
+                }
+
                 UpdateGraphSettingsToCore();
             }
             catch (Exception ex)
@@ -366,6 +408,8 @@ namespace Zametek.ViewModel.ProjectPlan
         public ICommand AddManagedActivitySeverityCommand { get; }
 
         public ICommand RemoveManagedActivitySeveritiesCommand { get; }
+
+        public ICommand DuplicateManagedActivitySeverityCommand { get; }
 
         #endregion
 

--- a/src/Zametek.ViewModel.ProjectPlan/GraphSettingsManagement/GraphSettingsManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/GraphSettingsManagement/GraphSettingsManagerViewModel.cs
@@ -382,7 +382,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 m_IsBusy?.Dispose();
                 m_HasStaleOutputs?.Dispose();
                 m_HasCompilationErrors?.Dispose();
@@ -392,9 +391,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 ClearManagedActivitySeverities();
                 m_ActivitySeverities?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/GraphSettingsManagement/ManagedActivitySeverityViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/GraphSettingsManagement/ManagedActivitySeverityViewModel.cs
@@ -150,16 +150,12 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 //m_ProjectStartSub?.Dispose();
                 //m_ResourceSettingsSub?.Dispose();
                 //m_DateTimeCalculatorSub?.Dispose();
                 //m_CompilationSub?.Dispose();
                 //ResourceSelector.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/HolidaySettingsManagement/HolidayEditViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/HolidaySettingsManagement/HolidayEditViewModel.cs
@@ -936,7 +936,6 @@ namespace Zametek.ViewModel.ProjectPlan
             }
         }
 
-
         private SetByIntModel? m_YearlySetPosSelection;
         public SetByIntModel? YearlySetPosSelection
         {
@@ -944,7 +943,6 @@ namespace Zametek.ViewModel.ProjectPlan
             set => this.RaiseAndSetIfChanged(ref m_YearlySetPosSelection, value);
         }
         public List<SetByIntModel> YearlySetPosOptions { get; }
-
 
         private SetByStringModel? m_YearlyWeekdaySelection;
         public SetByStringModel? YearlyWeekdaySelection
@@ -954,7 +952,6 @@ namespace Zametek.ViewModel.ProjectPlan
         }
         public List<SetByStringModel> YearlyWeekdayOptions { get; }
 
-
         private SetByIntModel? m_YearlyMonthSelection;
         public SetByIntModel? YearlyMonthSelection
         {
@@ -962,7 +959,6 @@ namespace Zametek.ViewModel.ProjectPlan
             set => this.RaiseAndSetIfChanged(ref m_YearlyMonthSelection, value);
         }
         public List<SetByIntModel> YearlyMonthOptions { get; }
-
 
         private RecurrenceRuleModel m_RecurrenceRule;
         public RecurrenceRuleModel RecurrenceRule
@@ -1016,12 +1012,8 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/HolidaySettingsManagement/HolidaySettingsManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/HolidaySettingsManagement/HolidaySettingsManagerViewModel.cs
@@ -58,6 +58,7 @@ namespace Zametek.ViewModel.ProjectPlan
             SetSelectedManagedHolidaysCommand = ReactiveCommand.Create<SelectionChangedEventArgs>(SetSelectedManagedHolidays);
             AddManagedHolidayCommand = ReactiveCommand.CreateFromTask(AddManagedHolidayAsync);
             RemoveManagedHolidaysCommand = ReactiveCommand.CreateFromTask(RemoveManagedHolidaysAsync, this.WhenAnyValue(rm => rm.HasSelectedHolidays));
+            DuplicateManagedHolidayCommand = ReactiveCommand.CreateFromTask(DuplicateManagedHolidayAsync, this.WhenAnyValue(rm => rm.HasSelectedHolidays));
             EditManagedHolidayCommand = ReactiveCommand.CreateFromTask(EditManagedHolidayAsync, this.WhenAnyValue(am => am.HasSelectedHoliday));
 
             // Create read-only view to the source list.
@@ -200,6 +201,48 @@ namespace Zametek.ViewModel.ProjectPlan
                         }
                     });
                 }
+                UpdateHolidaySettingsToCore();
+            }
+            catch (Exception ex)
+            {
+                await m_DialogService.ShowErrorAsync(
+                    Resource.ProjectPlan.Titles.Title_Error,
+                    string.Empty,
+                    ex.Message);
+            }
+        }
+
+        private async Task DuplicateManagedHolidayAsync()
+        {
+            try
+            {
+                lock (m_Lock)
+                {
+                    IManagedHolidayViewModel? source = SelectedHolidays.Values.FirstOrDefault();
+
+                    if (source is null)
+                    {
+                        return;
+                    }
+
+                    m_Holidays.Edit(holidays =>
+                    {
+                        int id = GetNextId();
+                        holidays.Add(
+                            new ManagedHolidayViewModel(
+                                this,
+                                new HolidayModel
+                                {
+                                    Id = id,
+                                    Name = source.Name,
+                                    Notes = source.Notes,
+                                    StartDateTime = source.StartDateTime,
+                                    RecurrencePattern = source.RecurrencePattern,
+                                },
+                                m_DateTimeCalculator));
+                    });
+                }
+
                 UpdateHolidaySettingsToCore();
             }
             catch (Exception ex)
@@ -423,6 +466,8 @@ namespace Zametek.ViewModel.ProjectPlan
         public ICommand AddManagedHolidayCommand { get; }
 
         public ICommand RemoveManagedHolidaysCommand { get; }
+
+        public ICommand DuplicateManagedHolidayCommand { get; }
 
         public ICommand EditManagedHolidayCommand { get; }
 

--- a/src/Zametek.ViewModel.ProjectPlan/HolidaySettingsManagement/HolidaySettingsManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/HolidaySettingsManagement/HolidaySettingsManagerViewModel.cs
@@ -441,7 +441,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 m_IsBusy?.Dispose();
                 m_HasStaleOutputs?.Dispose();
                 m_HasCompilationErrors?.Dispose();
@@ -450,9 +449,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_UpdateHolidaySettingsSub?.Dispose();
                 ClearManagedHolidays();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/HolidaySettingsManagement/ManagedHolidayViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/HolidaySettingsManagement/ManagedHolidayViewModel.cs
@@ -192,12 +192,8 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/MainViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/MainViewModel.cs
@@ -1314,7 +1314,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_IsBusy?.Dispose();
                 m_IsProjectUpdated?.Dispose();
@@ -1332,9 +1331,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_BaseTheme?.Dispose();
                 m_DataGridManager?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/MetricManagement/MetricManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/MetricManagement/MetricManagerViewModel.cs
@@ -91,7 +91,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 .WhenAnyValue(mm => mm.m_CoreViewModel.Metrics, metrics => metrics.Network)
                 .ToProperty(this, mm => mm.NetworkMetrics);
 
-
             m_CriticalityRisk = this
                 .WhenAnyValue(mm => mm.RisksMetrics, risks => risks.Criticality)
                 .ToProperty(this, mm => mm.CriticalityRisk);
@@ -120,7 +119,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 .WhenAnyValue(mm => mm.RisksMetrics, risks => risks.GeometricActivity)
                 .ToProperty(this, mm => mm.GeometricActivityRisk);
 
-
             m_DirectCost = this
                 .WhenAnyValue(mm => mm.CostsMetrics, costs => costs.Direct)
                 .ToProperty(this, mm => mm.DirectCost);
@@ -136,7 +134,6 @@ namespace Zametek.ViewModel.ProjectPlan
             m_TotalCost = this
                 .WhenAnyValue(mm => mm.CostsMetrics, costs => costs.Total)
                 .ToProperty(this, mm => mm.TotalCost);
-
 
             m_DirectBilling = this
                 .WhenAnyValue(mm => mm.BillingsMetrics, billings => billings.Direct)
@@ -154,7 +151,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 .WhenAnyValue(mm => mm.BillingsMetrics, billings => billings.Total)
                 .ToProperty(this, mm => mm.TotalBilling);
 
-
             m_DirectMargin = this
                  .WhenAnyValue(mm => mm.MarginsMetrics, margins => margins.Direct)
                  .ToProperty(this, mm => mm.DirectMargin);
@@ -170,7 +166,6 @@ namespace Zametek.ViewModel.ProjectPlan
             m_TotalMargin = this
                  .WhenAnyValue(mm => mm.MarginsMetrics, margins => margins.Total)
                  .ToProperty(this, mm => mm.TotalMargin);
-
 
             m_DisplayDirectMargin = this
                 .WhenAnyValue(
@@ -196,7 +191,6 @@ namespace Zametek.ViewModel.ProjectPlan
                     (double? margin) => margin is null ? string.Empty : string.Format(" ({0:P1})", margin))
                 .ToProperty(this, mm => mm.DisplayTotalMargin);
 
-
             m_DirectMarginAbsolute = this
                 .WhenAnyValue(mm => mm.MarginsMetrics, margins => margins.DirectAbsolute)
                 .ToProperty(this, mm => mm.DirectMarginAbsolute);
@@ -212,7 +206,6 @@ namespace Zametek.ViewModel.ProjectPlan
             m_TotalMarginAbsolute = this
                 .WhenAnyValue(mm => mm.MarginsMetrics, margins => margins.TotalAbsolute)
                 .ToProperty(this, mm => mm.TotalMarginAbsolute);
-
 
             m_DirectEffort = this
                 .WhenAnyValue(mm => mm.EffortsMetrics, efforts => efforts.Direct)
@@ -238,7 +231,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 .WhenAnyValue(mm => mm.EffortsMetrics, efforts => efforts.Efficiency)
                 .ToProperty(this, mm => mm.EffortEfficiency);
 
-
             m_NetworkCyclomaticComplexity = this
                 .WhenAnyValue(mm => mm.NetworkMetrics, network => network.CyclomaticComplexity)
                 .ToProperty(this, mm => mm.NetworkCyclomaticComplexity);
@@ -250,7 +242,6 @@ namespace Zametek.ViewModel.ProjectPlan
             m_NetworkDurationManMonths = this
                 .WhenAnyValue(mm => mm.NetworkMetrics, network => network.DurationManMonths)
                 .ToProperty(this, mm => mm.NetworkDurationManMonths);
-
 
             m_ProjectFinish = this
                 .WhenAnyValue(mm => mm.m_CoreViewModel.ProjectFinish)
@@ -266,7 +257,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
         private readonly ObservableAsPropertyHelper<bool> m_ShowDates;
         public bool ShowDates => m_ShowDates.Value;
-
 
         private readonly ObservableAsPropertyHelper<RisksModel> m_RisksMetrics;
         public RisksModel RisksMetrics => m_RisksMetrics.Value;
@@ -442,7 +432,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_IsBusy?.Dispose();
                 m_HasStaleOutputs?.Dispose();
@@ -470,9 +459,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_ActivityEffort?.Dispose();
                 m_EffortEfficiency?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/OutputManagement/OutputManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/OutputManagement/OutputManagerViewModel.cs
@@ -265,7 +265,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_IsBusy?.Dispose();
                 m_HasStaleOutputs?.Dispose();
@@ -275,9 +274,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_NonWorkingDayMode?.Dispose();
                 m_ProjectStart?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/ProjectDisplaySettingsViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ProjectDisplaySettingsViewModel.cs
@@ -199,12 +199,8 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 m_SetIsProjectUpdated = null;
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/ProjectScenarioDisplaySettingsViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ProjectScenarioDisplaySettingsViewModel.cs
@@ -568,13 +568,9 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 m_SetIsProjectScenarioUpdated = null;
                 m_IsReadyToCompile = null;
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/ProjectScenarioManagement/ManagedNodeViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ProjectScenarioManagement/ManagedNodeViewModel.cs
@@ -456,7 +456,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_Labels.Clear();
                 m_Labels.Dispose();
@@ -464,9 +463,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_Children.Dispose();
                 m_DisplayName?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/ProjectScenarioManagement/ProjectScenarioManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ProjectScenarioManagement/ProjectScenarioManagerViewModel.cs
@@ -2321,7 +2321,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 ResetProject();
                 KillSubscriptions();
                 m_IsLoading?.Dispose();
@@ -2338,8 +2337,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_ScenarioChartCurveFittingType?.Dispose();
                 m_NodeActionCommandManualTrigger?.Dispose();
             }
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/ResourceChartManagement/ResourceChartManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ResourceChartManagement/ResourceChartManagerViewModel.cs
@@ -737,7 +737,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_IsBusy?.Dispose();
                 m_HasStaleOutputs?.Dispose();
@@ -748,9 +747,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_ShowToday?.Dispose();
                 m_ShowMilestones?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/ResourceChartManagement/ResourceChartManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ResourceChartManagement/ResourceChartManagerViewModel.cs
@@ -113,6 +113,8 @@ namespace Zametek.ViewModel.ProjectPlan
                 SaveResourceChartImageFileCommand = saveResourceChartImageFileCommand;
             }
 
+            ResetResourceChartCommand = ReactiveCommand.Create(ResetResourceChart);
+
             m_IsBusy = this
                 .WhenAnyValue(rcm => rcm.m_CoreViewModel.IsBusy)
                 .ToProperty(this, rcm => rcm.IsBusy);
@@ -518,6 +520,11 @@ namespace Zametek.ViewModel.ProjectPlan
             return yAxis;
         }
 
+        private void ResetResourceChart()
+        {
+            ResourceChartPlotModel.Plot.Axes.AutoScale();
+        }
+
         private async Task SaveResourceChartImageFileAsync()
         {
             try
@@ -610,6 +617,8 @@ namespace Zametek.ViewModel.ProjectPlan
         }
 
         public ICommand SaveResourceChartImageFileCommand { get; }
+
+        public ICommand ResetResourceChartCommand { get; }
 
         public async Task SaveResourceChartImageFileAsync(
             string? filename,

--- a/src/Zametek.ViewModel.ProjectPlan/ResourceSettingsManagement/ManagedResourceViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ResourceSettingsManagement/ManagedResourceViewModel.cs
@@ -356,15 +356,11 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_HasPhases?.Dispose();
                 TrackerSet.Dispose();
                 m_InterActivityAllocationIsIndirect?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/ResourceSettingsManagement/ResourceActivitySelectorViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ResourceSettingsManagement/ResourceActivitySelectorViewModel.cs
@@ -324,12 +324,8 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 m_ReviseResourceActivityTrackersSub?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }
@@ -388,14 +384,6 @@ namespace Zametek.ViewModel.ProjectPlan
             {
                 return;
             }
-
-            if (disposing)
-            {
-                // TODO: dispose managed state (managed objects).
-            }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/ResourceSettingsManagement/ResourceSettingsManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ResourceSettingsManagement/ResourceSettingsManagerViewModel.cs
@@ -626,7 +626,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 m_IsBusy?.Dispose();
                 m_HasStaleOutputs?.Dispose();
                 m_HasCompilationErrors?.Dispose();
@@ -639,9 +638,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 ClearManagedResources();
                 m_Resources?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/ResourceSettingsManagement/ResourceSettingsManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ResourceSettingsManagement/ResourceSettingsManagerViewModel.cs
@@ -59,6 +59,7 @@ namespace Zametek.ViewModel.ProjectPlan
             SetSelectedManagedResourcesCommand = ReactiveCommand.Create<SelectionChangedEventArgs>(SetSelectedManagedResources);
             AddManagedResourceCommand = ReactiveCommand.CreateFromTask(AddManagedResourceAsync);
             RemoveManagedResourcesCommand = ReactiveCommand.CreateFromTask(RemoveManagedResourcesAsync, this.WhenAnyValue(rm => rm.HasSelectedResources));
+            DuplicateManagedResourceCommand = ReactiveCommand.CreateFromTask(DuplicateManagedResourceAsync, this.WhenAnyValue(am => am.HasSelectedResources));
             EditManagedResourcesCommand = ReactiveCommand.CreateFromTask(EditManagedResourcesAsync, this.WhenAnyValue(am => am.HasSelectedResources));
 
             // Create read-only view to the source list.
@@ -230,6 +231,60 @@ namespace Zametek.ViewModel.ProjectPlan
 
                     UpdateDisplayOrders();
                 }
+                UpdateResourceSettingsToCore();
+            }
+            catch (Exception ex)
+            {
+                await m_DialogService.ShowErrorAsync(
+                    Resource.ProjectPlan.Titles.Title_Error,
+                    string.Empty,
+                    ex.Message);
+            }
+        }
+
+        private async Task DuplicateManagedResourceAsync()
+        {
+            try
+            {
+                lock (m_Lock)
+                {
+                    IManagedResourceViewModel? source = SelectedResources.Values.FirstOrDefault();
+
+                    if (source is null)
+                    {
+                        return;
+                    }
+
+                    m_Resources.Edit(resources =>
+                    {
+                        int id = GetNextId();
+                        resources.Add(
+                            new ManagedResourceViewModel(
+                                m_CoreViewModel,
+                                this,
+                                new ResourceModel
+                                {
+                                    Id = id,
+                                    DisplayOrder = -1,
+                                    Name = source.Name,
+                                    Notes = source.Notes,
+                                    IsExplicitTarget = source.IsExplicitTarget,
+                                    IsInactive = source.IsInactive,
+                                    InterActivityAllocationType = source.InterActivityAllocationType,
+                                    InterActivityPhases = [.. source.InterActivityPhases],
+                                    UnitCost = source.UnitCost,
+                                    UnitBilling = source.UnitBilling,
+                                    FixedCost = source.FixedCost,
+                                    FixedBilling = source.FixedBilling,
+                                    AllocationOrder = source.AllocationOrder,
+                                    ColorFormat = ColorHelper.Random(),
+                                    Trackers = []
+                                }));
+                    });
+
+                    UpdateDisplayOrders();
+                }
+
                 UpdateResourceSettingsToCore();
             }
             catch (Exception ex)
@@ -606,6 +661,8 @@ namespace Zametek.ViewModel.ProjectPlan
         public ICommand AddManagedResourceCommand { get; }
 
         public ICommand RemoveManagedResourcesCommand { get; }
+
+        public ICommand DuplicateManagedResourceCommand { get; }
 
         public ICommand EditManagedResourcesCommand { get; }
 

--- a/src/Zametek.ViewModel.ProjectPlan/ResourceSettingsManagement/ResourceTrackerSetViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ResourceSettingsManagement/ResourceTrackerSetViewModel.cs
@@ -332,16 +332,12 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 m_DaysSub?.Dispose();
                 foreach (IResourceActivitySelectorViewModel selector in m_ResourceActivitySelectorLookup.Values)
                 {
                     selector.Dispose();
                 }
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/ScenarioChartManagement/ScenarioChartManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ScenarioChartManagement/ScenarioChartManagerViewModel.cs
@@ -712,7 +712,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_IsBusy?.Dispose();
                 m_HasStaleOutputs?.Dispose();
@@ -721,9 +720,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_TrackedMetricYAxis?.Dispose();
                 m_CurveFittingType?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/ScenarioChartManagement/ScenarioChartManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ScenarioChartManagement/ScenarioChartManagerViewModel.cs
@@ -114,6 +114,8 @@ namespace Zametek.ViewModel.ProjectPlan
                 SaveScenarioChartImageFileCommand = saveScenarioChartImageFileCommand;
             }
 
+            ResetScenarioChartCommand = ReactiveCommand.Create(ResetScenarioChart);
+
             m_IsBusy = this
                 .WhenAnyValue(
                     rcm => rcm.m_CoreViewModel.IsBusy,
@@ -493,6 +495,11 @@ namespace Zametek.ViewModel.ProjectPlan
             };
         }
 
+        private void ResetScenarioChart()
+        {
+            ScenarioChartPlotModel.Plot.Axes.AutoScale();
+        }
+
         private async Task SaveScenarioChartImageFileAsync()
         {
             try
@@ -575,6 +582,8 @@ namespace Zametek.ViewModel.ProjectPlan
         }
 
         public ICommand SaveScenarioChartImageFileCommand { get; }
+
+        public ICommand ResetScenarioChartCommand { get; }
 
         public async Task SaveScenarioChartImageFileAsync(
             string? filename,

--- a/src/Zametek.ViewModel.ProjectPlan/TrackingManagement/TrackingManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/TrackingManagement/TrackingManagerViewModel.cs
@@ -240,7 +240,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 KillSubscriptions();
                 m_IsBusy?.Dispose();
                 m_HasActivities?.Dispose();
@@ -250,9 +249,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 m_ProjectStart?.Dispose();
                 m_HasCompilationErrors?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/WorkStreamSettingsManagement/ManagedWorkStreamViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/WorkStreamSettingsManagement/ManagedWorkStreamViewModel.cs
@@ -135,19 +135,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 return;
             }
 
-            if (disposing)
-            {
-                // TODO: dispose managed state (managed objects).
-                //m_ProjectStartSub?.Dispose();
-                //m_ResourceSettingsSub?.Dispose();
-                //m_DateTimeCalculatorSub?.Dispose();
-                //m_CompilationSub?.Dispose();
-                //ResourceSelector.Dispose();
-            }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
-
             m_Disposed = true;
         }
 

--- a/src/Zametek.ViewModel.ProjectPlan/WorkStreamSettingsManagement/WorkStreamEditViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/WorkStreamSettingsManagement/WorkStreamEditViewModel.cs
@@ -1,0 +1,71 @@
+using ReactiveUI;
+using Zametek.Common.ProjectPlan;
+
+namespace Zametek.ViewModel.ProjectPlan
+{
+    public class WorkStreamEditViewModel
+        : ViewModelBase
+    {
+        #region Ctors
+
+        public WorkStreamEditViewModel()
+        {
+            m_ColorFormat = new ColorFormatModel();
+        }
+
+        #endregion
+
+        #region Public Members
+
+        private bool m_IsPhase;
+        public bool IsPhase
+        {
+            get => m_IsPhase;
+            set
+            {
+                m_IsPhase = value;
+                this.RaisePropertyChanged();
+            }
+        }
+
+        private bool m_IsIsPhaseActive;
+        public bool IsIsPhaseActive
+        {
+            get => m_IsIsPhaseActive;
+            set
+            {
+                m_IsIsPhaseActive = value;
+                this.RaisePropertyChanged();
+            }
+        }
+
+        private ColorFormatModel m_ColorFormat;
+        public ColorFormatModel ColorFormat
+        {
+            get => m_ColorFormat;
+            set
+            {
+                m_ColorFormat = value;
+                this.RaisePropertyChanged();
+            }
+        }
+
+        private bool m_IsColorFormatActive;
+        public bool IsColorFormatActive
+        {
+            get => m_IsColorFormatActive;
+            set
+            {
+                m_IsColorFormatActive = value;
+                this.RaisePropertyChanged();
+            }
+        }
+
+        public (bool IsPhase, bool IsIsPhaseEdited, ColorFormatModel ColorFormat, bool IsColorFormatActive) BuildUpdateValues()
+        {
+            return (IsPhase, IsIsPhaseActive, ColorFormat, IsColorFormatActive);
+        }
+
+        #endregion
+    }
+}

--- a/src/Zametek.ViewModel.ProjectPlan/WorkStreamSettingsManagement/WorkStreamSettingsManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/WorkStreamSettingsManagement/WorkStreamSettingsManagerViewModel.cs
@@ -60,6 +60,7 @@ namespace Zametek.ViewModel.ProjectPlan
             SetSelectedManagedWorkStreamsCommand = ReactiveCommand.Create<SelectionChangedEventArgs>(SetSelectedManagedWorkStreams);
             AddManagedWorkStreamCommand = ReactiveCommand.CreateFromTask(AddManagedWorkStreamAsync);
             RemoveManagedWorkStreamsCommand = ReactiveCommand.CreateFromTask(RemoveManagedWorkStreamsAsync, this.WhenAnyValue(wssm => wssm.HasSelectedWorkStreams));
+            DuplicateManagedWorkStreamCommand = ReactiveCommand.CreateFromTask(DuplicateManagedWorkStreamAsync, this.WhenAnyValue(wssm => wssm.HasSelectedWorkStreams));
 
             // Create read-only view to the source list.
             m_ReadOnlyWorkStreamsSub = m_WorkStreams.Connect()
@@ -209,6 +210,49 @@ namespace Zametek.ViewModel.ProjectPlan
                             workStreams.Remove(workStream);
                             workStream.Dispose();
                         }
+                    });
+
+                    UpdateDisplayOrders();
+                }
+
+                UpdateWorkStreamSettingsToCore();
+            }
+            catch (Exception ex)
+            {
+                await m_DialogService.ShowErrorAsync(
+                    Resource.ProjectPlan.Titles.Title_Error,
+                    string.Empty,
+                    ex.Message);
+            }
+        }
+
+        private async Task DuplicateManagedWorkStreamAsync()
+        {
+            try
+            {
+                lock (m_Lock)
+                {
+                    IManagedWorkStreamViewModel? source = SelectedWorkStreams.Values.FirstOrDefault();
+
+                    if (source is null)
+                    {
+                        return;
+                    }
+
+                    m_WorkStreams.Edit(workStreams =>
+                    {
+                        int id = GetNextId();
+                        workStreams.Add(
+                            new ManagedWorkStreamViewModel(
+                                this,
+                                new WorkStreamModel
+                                {
+                                    Id = id,
+                                    Name = source.Name,
+                                    IsPhase = source.IsPhase,
+                                    DisplayOrder = -1,
+                                    ColorFormat = ColorHelper.Random()
+                                }));
                     });
 
                     UpdateDisplayOrders();
@@ -397,6 +441,8 @@ namespace Zametek.ViewModel.ProjectPlan
         public ICommand AddManagedWorkStreamCommand { get; }
 
         public ICommand RemoveManagedWorkStreamsCommand { get; }
+
+        public ICommand DuplicateManagedWorkStreamCommand { get; }
 
         public ICommand RenumberWorkStreamsCommand { get; }
 

--- a/src/Zametek.ViewModel.ProjectPlan/WorkStreamSettingsManagement/WorkStreamSettingsManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/WorkStreamSettingsManagement/WorkStreamSettingsManagerViewModel.cs
@@ -61,6 +61,7 @@ namespace Zametek.ViewModel.ProjectPlan
             AddManagedWorkStreamCommand = ReactiveCommand.CreateFromTask(AddManagedWorkStreamAsync);
             RemoveManagedWorkStreamsCommand = ReactiveCommand.CreateFromTask(RemoveManagedWorkStreamsAsync, this.WhenAnyValue(wssm => wssm.HasSelectedWorkStreams));
             DuplicateManagedWorkStreamCommand = ReactiveCommand.CreateFromTask(DuplicateManagedWorkStreamAsync, this.WhenAnyValue(wssm => wssm.HasSelectedWorkStreams));
+            EditManagedWorkStreamsCommand = ReactiveCommand.CreateFromTask(EditManagedWorkStreamsAsync, this.WhenAnyValue(wssm => wssm.HasSelectedWorkStreams));
 
             // Create read-only view to the source list.
             m_ReadOnlyWorkStreamsSub = m_WorkStreams.Connect()
@@ -213,6 +214,60 @@ namespace Zametek.ViewModel.ProjectPlan
                     });
 
                     UpdateDisplayOrders();
+                }
+
+                UpdateWorkStreamSettingsToCore();
+            }
+            catch (Exception ex)
+            {
+                await m_DialogService.ShowErrorAsync(
+                    Resource.ProjectPlan.Titles.Title_Error,
+                    string.Empty,
+                    ex.Message);
+            }
+        }
+
+        private async Task EditManagedWorkStreamsAsync()
+        {
+            try
+            {
+                var editViewModel = new WorkStreamEditViewModel();
+
+                bool result = await m_DialogService.ShowContextAsync(
+                    title: Resource.ProjectPlan.Titles.Title_EditWorkStreams,
+                    header: string.Empty,
+                    message: $@"**{Resource.ProjectPlan.Messages.Message_EditWorkStreams}**",
+                    context: editViewModel,
+                    markdown: true);
+
+                if (!result)
+                {
+                    return;
+                }
+
+                var (isPhase, isIsPhaseEdited, colorFormat, isColorFormatActive) = editViewModel.BuildUpdateValues();
+
+                lock (m_Lock)
+                {
+                    ICollection<IManagedWorkStreamViewModel> selectedWorkStreams = SelectedWorkStreams.Values;
+
+                    if (selectedWorkStreams.Count == 0)
+                    {
+                        return;
+                    }
+
+                    foreach (IManagedWorkStreamViewModel workStream in selectedWorkStreams)
+                    {
+                        if (isIsPhaseEdited)
+                        {
+                            workStream.IsPhase = isPhase;
+                        }
+
+                        if (isColorFormatActive)
+                        {
+                            workStream.ColorFormat = colorFormat;
+                        }
+                    }
                 }
 
                 UpdateWorkStreamSettingsToCore();
@@ -443,6 +498,8 @@ namespace Zametek.ViewModel.ProjectPlan
         public ICommand RemoveManagedWorkStreamsCommand { get; }
 
         public ICommand DuplicateManagedWorkStreamCommand { get; }
+
+        public ICommand EditManagedWorkStreamsCommand { get; }
 
         public ICommand RenumberWorkStreamsCommand { get; }
 

--- a/src/Zametek.ViewModel.ProjectPlan/WorkStreamSettingsManagement/WorkStreamSettingsManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/WorkStreamSettingsManagement/WorkStreamSettingsManagerViewModel.cs
@@ -415,7 +415,6 @@ namespace Zametek.ViewModel.ProjectPlan
 
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects).
                 m_IsBusy?.Dispose();
                 m_HasStaleOutputs?.Dispose();
                 m_HasCompilationErrors?.Dispose();
@@ -426,9 +425,6 @@ namespace Zametek.ViewModel.ProjectPlan
                 ClearManagedWorkStreams();
                 m_WorkStreams?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-            // TODO: set large fields to null.
 
             m_Disposed = true;
         }

--- a/src/Zametek.ViewModel.ProjectPlan/Zametek.ViewModel.ProjectPlan.csproj
+++ b/src/Zametek.ViewModel.ProjectPlan/Zametek.ViewModel.ProjectPlan.csproj
@@ -11,6 +11,7 @@
 	<PackageReference Include="AutomaticGraphLayout.Drawing" Version="1.1.12" />
     <PackageReference Include="Dock.Model.ReactiveUI" Version="11.3.11.22" />
     <PackageReference Include="Dock.Serializer.Newtonsoft" Version="11.3.11.22" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <!--<PackageReference Include="Dock.Serializer.SystemTextJson" Version="11.3.11.22" />-->
     <PackageReference Include="Ical.Net" Version="5.2.1" />
     <PackageReference Include="net.sf.mpxj-for-csharp" Version="13.12.0" />
@@ -20,7 +21,6 @@
     <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.2" />
     <PackageReference Include="Svg.Controls.Skia.Avalonia" Version="11.3.9.5" />
     <PackageReference Include="System.Drawing.Common" Version="10.0.5" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
     <PackageReference Include="Zametek.Maths.Graphs.Compilers" Version="2.4.8" />
   </ItemGroup>
 

--- a/test/Zametek.ViewModel.ProjectPlan.Tests/Miscellaneous/MetricsHelperTests.cs
+++ b/test/Zametek.ViewModel.ProjectPlan.Tests/Miscellaneous/MetricsHelperTests.cs
@@ -1,0 +1,353 @@
+using Shouldly;
+using System.Collections.Generic;
+using Xunit;
+using Zametek.Common.ProjectPlan;
+
+namespace Zametek.ViewModel.ProjectPlan.Tests
+{
+    public class MetricsHelperTests
+    {
+        #region Helpers
+
+        private static ActivitySeverityModel MakeSeverity(int slackLimit, double criticalityWeight, double fibonacciWeight) =>
+            new ActivitySeverityModel
+            {
+                SlackLimit = slackLimit,
+                CriticalityWeight = criticalityWeight,
+                FibonacciWeight = fibonacciWeight,
+            };
+
+        private static ActivityModel MakeActivity(int? totalSlack, bool hasNoRisk = false) =>
+            new ActivityModel
+            {
+                Id = 1,
+                TotalSlack = totalSlack,
+                HasNoRisk = hasNoRisk,
+            };
+
+        private static IEnumerable<ActivitySeverityModel> DefaultSeverities() =>
+        [
+            MakeSeverity(slackLimit: 0, criticalityWeight: 1.0, fibonacciWeight: 1.0),
+            MakeSeverity(slackLimit: 5, criticalityWeight: 0.8, fibonacciWeight: 0.5),
+            MakeSeverity(slackLimit: 10, criticalityWeight: 0.6, fibonacciWeight: 0.25),
+        ];
+
+        #endregion
+
+        #region CalculateActivityRisk
+
+        [Fact]
+        public void CalculateActivityRisk_Given_EmptyList_Then_ReturnsOne()
+        {
+            var result = MetricsHelper.CalculateActivityRisk([]);
+            result.ShouldBe(1.0);
+        }
+
+        [Fact]
+        public void CalculateActivityRisk_Given_AllZeroSlack_Then_ReturnsOne()
+        {
+            var activities = new[] { MakeActivity(0), MakeActivity(0), MakeActivity(0) };
+            var result = MetricsHelper.CalculateActivityRisk(activities);
+            result.ShouldBe(1.0);
+        }
+
+        [Fact]
+        public void CalculateActivityRisk_Given_MixedSlack_Then_ReturnsExpectedRatio()
+        {
+            // Activities: slack 0, 0, 10 => numerator = 10, maxSlack = 10, denominator = 10 * 3 = 30
+            // result = 1 - 10/30 = 0.667
+            var activities = new[] { MakeActivity(0), MakeActivity(0), MakeActivity(10) };
+            var result = MetricsHelper.CalculateActivityRisk(activities);
+            result.ShouldNotBeNull();
+            result!.Value.ShouldBeInRange(0.66, 0.68);
+        }
+
+        [Fact]
+        public void CalculateActivityRisk_Given_AllNullSlack_Then_ReturnsOne()
+        {
+            // Activities with null TotalSlack are excluded from numerator/denominator calc
+            // denominator = 0 * count = 0, numerator = 0 => return 1.0
+            var activities = new[] { MakeActivity(null), MakeActivity(null) };
+            var result = MetricsHelper.CalculateActivityRisk(activities);
+            result.ShouldBe(1.0);
+        }
+
+        [Fact]
+        public void CalculateActivityRisk_Given_SingleActivityWithSlack_Then_ReturnsZero()
+        {
+            // numerator = 5, maxSlack = 5, denominator = 5 * 1 = 5
+            // result = 1 - 5/5 = 0
+            var activities = new[] { MakeActivity(5) };
+            var result = MetricsHelper.CalculateActivityRisk(activities);
+            result.ShouldBe(0.0);
+        }
+
+        #endregion
+
+        #region CalculateActivityRiskWithStdDevCorrection
+
+        [Fact]
+        public void CalculateActivityRiskWithStdDevCorrection_Given_EmptyList_Then_ReturnsOne()
+        {
+            var result = MetricsHelper.CalculateActivityRiskWithStdDevCorrection([]);
+            result.ShouldBe(1.0);
+        }
+
+        [Fact]
+        public void CalculateActivityRiskWithStdDevCorrection_Given_AllZeroSlack_Then_ReturnsOne()
+        {
+            var activities = new[] { MakeActivity(0), MakeActivity(0) };
+            var result = MetricsHelper.CalculateActivityRiskWithStdDevCorrection(activities);
+            result.ShouldBe(1.0);
+        }
+
+        [Fact]
+        public void CalculateActivityRiskWithStdDevCorrection_Given_UniformSlack_Then_CorrectValueWithStdDevOfZero()
+        {
+            // All slack = 5, mean = 5, stddev = 0, correction = round(5+0) = 5
+            // Each capped at 5, so numerator = 5*3 = 15, maxSlack = 5, denominator = 5*3 = 15
+            // result = 1 - 15/15 = 0
+            var activities = new[] { MakeActivity(5), MakeActivity(5), MakeActivity(5) };
+            var result = MetricsHelper.CalculateActivityRiskWithStdDevCorrection(activities);
+            result.ShouldBe(0.0);
+        }
+
+        #endregion
+
+        #region CalculateCriticalityRisk
+
+        [Fact]
+        public void CalculateCriticalityRisk_Given_EmptyList_Then_ReturnsOne()
+        {
+            var lookup = new ActivitySeverityLookup(DefaultSeverities());
+            var result = MetricsHelper.CalculateCriticalityRisk([], lookup);
+            result.ShouldBe(1.0);
+        }
+
+        [Fact]
+        public void CalculateCriticalityRisk_Given_AllCriticalActivities_Then_ReturnsOne()
+        {
+            var lookup = new ActivitySeverityLookup(DefaultSeverities());
+            // SlackLimit 0 => criticalityWeight 1.0. Critical weight = 1.0.
+            // numerator = 1.0 * 2 = 2, denominator = 1.0 * 2 = 2 => result = 1.0
+            var activities = new[] { MakeActivity(0), MakeActivity(0) };
+            var result = MetricsHelper.CalculateCriticalityRisk(activities, lookup);
+            result.ShouldBe(1.0);
+        }
+
+        [Fact]
+        public void CalculateCriticalityRisk_Given_MixedSlack_Then_ReturnsExpectedRatio()
+        {
+            var lookup = new ActivitySeverityLookup(DefaultSeverities());
+            // slack=0 => weight 1.0, slack=5 => weight 0.8
+            // numerator = 1.0 + 0.8 = 1.8, denominator = 1.0 * 2 = 2.0
+            var activities = new[] { MakeActivity(0), MakeActivity(5) };
+            var result = MetricsHelper.CalculateCriticalityRisk(activities, lookup);
+            result.ShouldNotBeNull();
+            result!.Value.ShouldBeInRange(0.89, 0.91);
+        }
+
+        #endregion
+
+        #region CalculateFibonacciRisk
+
+        [Fact]
+        public void CalculateFibonacciRisk_Given_EmptyList_Then_ReturnsOne()
+        {
+            var lookup = new ActivitySeverityLookup(DefaultSeverities());
+            var result = MetricsHelper.CalculateFibonacciRisk([], lookup);
+            result.ShouldBe(1.0);
+        }
+
+        [Fact]
+        public void CalculateFibonacciRisk_Given_AllCriticalActivities_Then_ReturnsOne()
+        {
+            var lookup = new ActivitySeverityLookup(DefaultSeverities());
+            var activities = new[] { MakeActivity(0), MakeActivity(0) };
+            var result = MetricsHelper.CalculateFibonacciRisk(activities, lookup);
+            result.ShouldBe(1.0);
+        }
+
+        #endregion
+
+        #region CalculateGeometricActivityRisk
+
+        [Fact]
+        public void CalculateGeometricActivityRisk_Given_EmptyList_Then_ReturnsOne()
+        {
+            var result = MetricsHelper.CalculateGeometricActivityRisk([]);
+            result.ShouldBe(1.0);
+        }
+
+        [Fact]
+        public void CalculateGeometricActivityRisk_Given_AllZeroSlack_Then_ReturnsOne()
+        {
+            // totalSlack=0 => (0+1) = 1, numerator = pow(1,1/n) - 1 = 0, denominator = maxSlack = 0
+            // both 0 => return 1.0
+            var activities = new[] { MakeActivity(0), MakeActivity(0) };
+            var result = MetricsHelper.CalculateGeometricActivityRisk(activities);
+            result.ShouldBe(1.0);
+        }
+
+        #endregion
+
+        #region CalculateEfficiency
+
+        [Fact]
+        public void CalculateEfficiency_Given_BothNull_Then_ReturnsNull()
+        {
+            MetricsHelper.CalculateEfficiency(null, null).ShouldBeNull();
+        }
+
+        [Fact]
+        public void CalculateEfficiency_Given_ActivityEffortNull_Then_ReturnsNull()
+        {
+            MetricsHelper.CalculateEfficiency(null, 10.0).ShouldBeNull();
+        }
+
+        [Fact]
+        public void CalculateEfficiency_Given_TotalEffortNull_Then_ReturnsNull()
+        {
+            MetricsHelper.CalculateEfficiency(10.0, null).ShouldBeNull();
+        }
+
+        [Fact]
+        public void CalculateEfficiency_Given_TotalEffortZero_Then_ReturnsNull()
+        {
+            MetricsHelper.CalculateEfficiency(10.0, 0.0).ShouldBeNull();
+        }
+
+        [Fact]
+        public void CalculateEfficiency_Given_ActivityEffortZero_Then_ReturnsNull()
+        {
+            MetricsHelper.CalculateEfficiency(0.0, 10.0).ShouldBeNull();
+        }
+
+        [Fact]
+        public void CalculateEfficiency_Given_ValidInputs_Then_ReturnsRatio()
+        {
+            var result = MetricsHelper.CalculateEfficiency(5.0, 10.0);
+            result.ShouldBe(0.5);
+        }
+
+        [Fact]
+        public void CalculateEfficiency_Given_EqualInputs_Then_ReturnsOne()
+        {
+            var result = MetricsHelper.CalculateEfficiency(10.0, 10.0);
+            result.ShouldBe(1.0);
+        }
+
+        #endregion
+
+        #region CalculateMarginAbsolute
+
+        [Fact]
+        public void CalculateMarginAbsolute_Given_BothNull_Then_ReturnsNull()
+        {
+            MetricsHelper.CalculateMarginAbsolute(null, null).ShouldBeNull();
+        }
+
+        [Fact]
+        public void CalculateMarginAbsolute_Given_CostNull_Then_ReturnsNull()
+        {
+            MetricsHelper.CalculateMarginAbsolute(null, 100.0).ShouldBeNull();
+        }
+
+        [Fact]
+        public void CalculateMarginAbsolute_Given_BillingNull_Then_ReturnsNull()
+        {
+            MetricsHelper.CalculateMarginAbsolute(100.0, null).ShouldBeNull();
+        }
+
+        [Fact]
+        public void CalculateMarginAbsolute_Given_ValidInputs_Then_ReturnsBillingMinusCost()
+        {
+            MetricsHelper.CalculateMarginAbsolute(80.0, 100.0).ShouldBe(20.0);
+        }
+
+        [Fact]
+        public void CalculateMarginAbsolute_Given_CostExceedsBilling_Then_ReturnsNegative()
+        {
+            MetricsHelper.CalculateMarginAbsolute(120.0, 100.0).ShouldBe(-20.0);
+        }
+
+        [Fact]
+        public void CalculateMarginAbsolute_Given_EqualValues_Then_ReturnsZero()
+        {
+            MetricsHelper.CalculateMarginAbsolute(100.0, 100.0).ShouldBe(0.0);
+        }
+
+        #endregion
+
+        #region CalculateMargin
+
+        [Fact]
+        public void CalculateMargin_Given_BothNull_Then_ReturnsZero()
+        {
+            // abs=null, billing=null => return 0
+            MetricsHelper.CalculateMargin(null, null).ShouldBe(0.0);
+        }
+
+        [Fact]
+        public void CalculateMargin_Given_ZeroCostAndZeroBilling_Then_ReturnsZero()
+        {
+            // abs=0, billing=0 => return 0
+            MetricsHelper.CalculateMargin(0.0, 0.0).ShouldBe(0.0);
+        }
+
+        [Fact]
+        public void CalculateMargin_Given_CostNullAndPositiveBilling_Then_ReturnsOne()
+        {
+            // abs=null, billing=100 (non-null, non-zero) => return 1.0
+            MetricsHelper.CalculateMargin(null, 100.0).ShouldBe(1.0);
+        }
+
+        [Fact]
+        public void CalculateMargin_Given_PositiveCostAndBilling_Then_ReturnsRatio()
+        {
+            // abs = 100 - 80 = 20, billing = 100 => margin = 20/100 = 0.2
+            MetricsHelper.CalculateMargin(80.0, 100.0).ShouldBe(0.2);
+        }
+
+        [Fact]
+        public void CalculateMargin_Given_NonZeroAbsAndZeroBilling_Then_ReturnsNull()
+        {
+            // abs = 0 - 80 = -80 (non-zero), billing = 0 => null
+            MetricsHelper.CalculateMargin(80.0, 0.0).ShouldBeNull();
+        }
+
+        #endregion
+
+        #region CalculateProjectRisks
+
+        [Fact]
+        public void CalculateProjectRisks_Given_EmptyActivities_Then_ReturnsAllOnes()
+        {
+            var result = MetricsHelper.CalculateProjectRisks([], DefaultSeverities());
+            result.Criticality.ShouldBe(1.0);
+            result.Fibonacci.ShouldBe(1.0);
+            result.Activity.ShouldBe(1.0);
+            result.ActivityStdDevCorrection.ShouldBe(1.0);
+            result.GeometricCriticality.ShouldBe(1.0);
+            result.GeometricFibonacci.ShouldBe(1.0);
+            result.GeometricActivity.ShouldBe(1.0);
+        }
+
+        [Fact]
+        public void CalculateProjectRisks_Given_ActivitiesWithNoRisk_Then_ExcludesThemFromCalc()
+        {
+            // Activities with HasNoRisk=true should be excluded
+            var activities = new[]
+            {
+                MakeActivity(0, hasNoRisk: false),
+                MakeActivity(100, hasNoRisk: true),  // excluded
+            };
+            var result = MetricsHelper.CalculateProjectRisks(activities, DefaultSeverities());
+            // Only the critical activity (slack=0) is included
+            result.Criticality.ShouldBe(1.0);
+            result.Activity.ShouldBe(1.0);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
## Summary

- **Gap 1 — Duplicate commands**: Added `DuplicateManagedXxxCommand` to all five management grids (Activities, Holidays, Resources, WorkStreams, ActivitySeverities), including interface contracts, ViewModel implementations, and Labels.resx entries.
- **Gap 2 — Context menus**: Added right-click context menus to Holidays, Resources, WorkStreams, and ActivitySeverities DataGrids, plus Duplicate entry in the Activities context menu. Each menu mirrors the sidebar buttons.
- **Gap 3 — ResourceChart**: Added `ResetResourceChartCommand` and a `ContentControl.ContextMenu` with Save As and Reset to `ResourceChartManagerView`.
- **Gap 4 — ScenarioChart**: Added `ResetScenarioChartCommand` and a `ContentControl.ContextMenu` with Save As and Reset to `ScenarioChartManagerView`.
- **Gap 5 — VertexGraph ShowNames**: Uncommented the ShowNames sidebar panel and added a CheckBox MenuItem to the existing ScrollViewer context menu.
- **Gap 6 — WorkStream edit dialog**: Created `WorkStreamEditViewModel` and `WorkStreamEditView` for batch-editing IsPhase and ColorFormat on selected WorkStreams, wired up `EditManagedWorkStreamsCommand` in the ViewModel and interface, and added Edit button to the sidebar and context menu.

## Test plan

- [ ] Open Activities grid — right-click and verify Duplicate, Edit, Insert, Add, Renumber, Delete items appear and work
- [ ] Open Holidays grid — right-click, verify Add, Duplicate, Edit, Delete; confirm Duplicate button in sidebar
- [ ] Open Resources grid — right-click, verify Add, Duplicate, Edit, Renumber, Delete; confirm Duplicate button in sidebar
- [ ] Open WorkStreams grid — right-click, verify Add, Duplicate, Edit, Renumber, Delete; click Edit and confirm dialog appears with IsPhase and ColorFormat toggles
- [ ] Open Graph Settings (ActivitySeverities) grid — right-click, verify Add, Duplicate, Delete; confirm Duplicate button in sidebar
- [ ] Open Resource Chart — right-click the chart area, verify Save As and Reset; confirm Reset auto-scales axes
- [ ] Open Scenario Chart — right-click the chart area, verify Save As and Reset
- [ ] Open Vertex Graph — verify ShowNames sidebar panel is visible and the toggle works; right-click the scrollviewer and verify ShowNames checkbox and Save As menu items