### PR TITLE
Add context menus to Resource and Scenario charts

### DIFF
--- a/src/Zametek.Contract.ProjectPlan/ResourceChartManagement/IResourceChartManagerViewModel.cs
+++ b/src/Zametek.Contract.ProjectPlan/ResourceChartManagement/IResourceChartManagerViewModel.cs
@@ -20,9 +20,17 @@ namespace Zametek.Contract.ProjectPlan
 
         bool ShowToday { get; set; }
 
+        bool ShowMilestones { get; set; }
+
         ICommand ResetResourceChartCommand { get; }
 
         ICommand SaveResourceChartImageFileCommand { get; }
+
+        ICommand ChangeAllocationModeCommand { get; }
+
+        ICommand ChangeScheduleModeCommand { get; }
+
+        ICommand ChangeDisplayStyleCommand { get; }
 
         Task SaveResourceChartImageFileAsync(string? filename, int width, int height);
 

--- a/src/Zametek.Contract.ProjectPlan/ScenarioChartManagement/IScenarioChartManagerViewModel.cs
+++ b/src/Zametek.Contract.ProjectPlan/ScenarioChartManagement/IScenarioChartManagerViewModel.cs
@@ -26,6 +26,12 @@ namespace Zametek.Contract.ProjectPlan
 
         ICommand ResetScenarioChartCommand { get; }
 
+        ICommand ChangeTrackedMetricXAxisCommand { get; }
+
+        ICommand ChangeTrackedMetricYAxisCommand { get; }
+
+        ICommand ChangeCurveFittingTypeCommand { get; }
+
         Task SaveScenarioChartImageFileAsync(string? filename, int width, int height);
 
         void BuildScenarioChartPlotModel();

--- a/src/Zametek.View.ProjectPlan/ResourceChartManagement/ResourceChartManagerView.axaml
+++ b/src/Zametek.View.ProjectPlan/ResourceChartManagement/ResourceChartManagerView.axaml
@@ -7,15 +7,17 @@
 			       xmlns:scottplot="clr-namespace:ScottPlot.Avalonia;assembly=ScottPlot.Avalonia"
 			       xmlns:vm="using:Zametek.ViewModel.ProjectPlan"
 			       xmlns:common="using:Zametek.Common.ProjectPlan"
+			       xmlns:converters="using:Avalonia.Controls.Converters"
 			       x:DataType="vm:ResourceChartManagerViewModel"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="Zametek.View.ProjectPlan.ResourceChartManagerView">
 	<UserControl.Resources>
+		<converters:EnumToBoolConverter x:Key="enumToBool" />
 	</UserControl.Resources>
 
 	<DockPanel Margin="7">
 		<ScrollViewer DockPanel.Dock="Right"
-					  VerticalScrollBarVisibility="Hidden"
+					  VerticalScrollBarVisibility="Auto"
 					  HorizontalScrollBarVisibility="Disabled">
 			<DockPanel MinWidth="120"
 					   Margin="11,0,0,0">
@@ -128,7 +130,7 @@
 								  OnContent="{x:Static resources:Labels.Label_Yes}"
 								  IsChecked="{Binding Path=ShowToday, Mode=TwoWay}"/>
 				</DockPanel>
-				
+
 				<DockPanel DockPanel.Dock="Top">
 					<Label VerticalContentAlignment="Center"
 						   HorizontalContentAlignment="Left"
@@ -161,11 +163,87 @@
 							Bounds="{Binding Path=ImageBounds, Mode=OneWayToSource}">
 				<ContentControl.ContextMenu>
 					<ContextMenu>
+						<MenuItem Header="{x:Static resources:Labels.Label_ShowToday}"
+								  IsChecked="{Binding Path=ShowToday, Mode=TwoWay}"
+								  ToggleType="CheckBox" />
+
+						<MenuItem Header="{x:Static resources:Labels.Label_ShowMilestones}"
+								  IsChecked="{Binding Path=ShowMilestones, Mode=TwoWay}"
+								  ToggleType="CheckBox" />
+
+						<Separator />
+
+						<MenuItem Header="{x:Static resources:Labels.Label_AllocationMode}">
+							<MenuItem Header="{x:Static resources:Enums.Enum_AllocationMode_Activity}"
+									  IsChecked="{Binding Path=AllocationMode, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:AllocationMode.Activity}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeAllocationModeCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:AllocationMode.Activity}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_AllocationMode_Cost}"
+									  IsChecked="{Binding Path=AllocationMode, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:AllocationMode.Cost}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeAllocationModeCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:AllocationMode.Cost}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_AllocationMode_Billing}"
+									  IsChecked="{Binding Path=AllocationMode, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:AllocationMode.Billing}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeAllocationModeCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:AllocationMode.Billing}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_AllocationMode_Effort}"
+									  IsChecked="{Binding Path=AllocationMode, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:AllocationMode.Effort}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeAllocationModeCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:AllocationMode.Effort}"
+									  ToggleType="Radio" />
+						</MenuItem>
+
+						<Separator />
+
+						<MenuItem Header="{x:Static resources:Labels.Label_ScheduleMode}">
+							<MenuItem Header="{x:Static resources:Enums.Enum_ScheduleMode_Combined}"
+									  IsChecked="{Binding Path=ScheduleMode, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:ScheduleMode.Combined}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeScheduleModeCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:ScheduleMode.Combined}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_ScheduleMode_Scheduled}"
+									  IsChecked="{Binding Path=ScheduleMode, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:ScheduleMode.Scheduled}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeScheduleModeCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:ScheduleMode.Scheduled}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_ScheduleMode_Unscheduled}"
+									  IsChecked="{Binding Path=ScheduleMode, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:ScheduleMode.Unscheduled}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeScheduleModeCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:ScheduleMode.Unscheduled}"
+									  ToggleType="Radio" />
+						</MenuItem>
+
+						<Separator />
+
+						<MenuItem Header="{x:Static resources:Labels.Label_DisplayStyle}">
+							<MenuItem Header="{x:Static resources:Enums.Enum_DisplayStyle_Slanted}"
+									  IsChecked="{Binding Path=DisplayStyle, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:DisplayStyle.Slanted}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeDisplayStyleCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:DisplayStyle.Slanted}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_DisplayStyle_Block}"
+									  IsChecked="{Binding Path=DisplayStyle, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:DisplayStyle.Block}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeDisplayStyleCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:DisplayStyle.Block}"
+									  ToggleType="Radio" />
+						</MenuItem>
+
+						<Separator />
+
 						<MenuItem Header="{x:Static resources:Menus.Menu_SaveAs}"
-                      Command="{Binding Path=SaveResourceChartImageFileCommand, Mode=OneWay}" />
+								  Command="{Binding Path=SaveResourceChartImageFileCommand, Mode=OneWay}" />
 
 						<MenuItem Header="{x:Static resources:Menus.Menu_Reset}"
-								      Command="{Binding Path=ResetResourceChartCommand, Mode=OneWay}" />
+								  Command="{Binding Path=ResetResourceChartCommand, Mode=OneWay}" />
 					</ContextMenu>
 				</ContentControl.ContextMenu>
 			</ContentControl>

--- a/src/Zametek.View.ProjectPlan/ScenarioChartManagement/ScenarioChartManagerView.axaml
+++ b/src/Zametek.View.ProjectPlan/ScenarioChartManagement/ScenarioChartManagerView.axaml
@@ -7,15 +7,17 @@
 			 xmlns:scottplot="clr-namespace:ScottPlot.Avalonia;assembly=ScottPlot.Avalonia"
 			 xmlns:vm="using:Zametek.ViewModel.ProjectPlan"
 			 xmlns:common="using:Zametek.Common.ProjectPlan"
+			 xmlns:converters="using:Avalonia.Controls.Converters"
 			 x:DataType="vm:ScenarioChartManagerViewModel"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="Zametek.View.ProjectPlan.ScenarioChartManagerView">
 	<UserControl.Resources>
+		<converters:EnumToBoolConverter x:Key="enumToBool" />
 	</UserControl.Resources>
 
 	<DockPanel Margin="7">
 		<ScrollViewer DockPanel.Dock="Right"
-					  VerticalScrollBarVisibility="Hidden"
+					  VerticalScrollBarVisibility="Auto"
 					  HorizontalScrollBarVisibility="Disabled">
 			<DockPanel Width="205"
 					   Margin="11,0,0,0">
@@ -128,7 +130,7 @@
 								  OnContent="{x:Static resources:Labels.Label_Yes}"
 								  IsChecked="{Binding Path=ShowNames, Mode=TwoWay}"/>
 				</DockPanel>
-				
+
 				<DockPanel DockPanel.Dock="Top">
 					<ScrollViewer VerticalScrollBarVisibility="Auto"
 								  HorizontalScrollBarVisibility="Disabled">
@@ -139,7 +141,7 @@
 											 VerticalAlignment="Stretch"/>
 					</ScrollViewer>
 				</DockPanel>
-				
+
 				<Grid/>
 			</DockPanel>
 		</ScrollViewer>
@@ -151,6 +153,468 @@
 							Bounds="{Binding Path=ImageBounds, Mode=OneWayToSource}">
 				<ContentControl.ContextMenu>
 					<ContextMenu>
+						<MenuItem Header="{x:Static resources:Labels.Label_ShowNames}"
+								  IsChecked="{Binding Path=ShowNames, Mode=TwoWay}"
+								  ToggleType="CheckBox" />
+
+						<Separator />
+
+						<MenuItem Header="{x:Static resources:Labels.Label_TrackedMetricXAxis}">
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_None}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.None}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.None}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_RisksCriticality}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.RisksCriticality}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.RisksCriticality}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_RisksFibonacci}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.RisksFibonacci}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.RisksFibonacci}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_RisksActivity}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.RisksActivity}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.RisksActivity}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_RisksActivityStdDevCorrection}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.RisksActivityStdDevCorrection}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.RisksActivityStdDevCorrection}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_RisksGeometricCriticality}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.RisksGeometricCriticality}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.RisksGeometricCriticality}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_RisksGeometricFibonacci}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.RisksGeometricFibonacci}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.RisksGeometricFibonacci}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_RisksGeometricActivity}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.RisksGeometricActivity}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.RisksGeometricActivity}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_CostsDirect}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.CostsDirect}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.CostsDirect}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_CostsIndirect}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.CostsIndirect}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.CostsIndirect}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_CostsOther}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.CostsOther}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.CostsOther}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_CostsTotal}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.CostsTotal}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.CostsTotal}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_BillingsDirect}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.BillingsDirect}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.BillingsDirect}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_BillingsIndirect}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.BillingsIndirect}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.BillingsIndirect}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_BillingsOther}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.BillingsOther}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.BillingsOther}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_BillingsTotal}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.BillingsTotal}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.BillingsTotal}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_MarginsDirect}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.MarginsDirect}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.MarginsDirect}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_MarginsDirectAbsolute}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.MarginsDirectAbsolute}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.MarginsDirectAbsolute}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_MarginsIndirect}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.MarginsIndirect}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.MarginsIndirect}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_MarginsIndirectAbsolute}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.MarginsIndirectAbsolute}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.MarginsIndirectAbsolute}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_MarginsOther}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.MarginsOther}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.MarginsOther}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_MarginsOtherAbsolute}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.MarginsOtherAbsolute}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.MarginsOtherAbsolute}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_MarginsTotal}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.MarginsTotal}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.MarginsTotal}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_MarginsTotalAbsolute}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.MarginsTotalAbsolute}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.MarginsTotalAbsolute}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_EffortsDirect}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.EffortsDirect}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.EffortsDirect}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_EffortsIndirect}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.EffortsIndirect}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.EffortsIndirect}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_EffortsOther}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.EffortsOther}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.EffortsOther}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_EffortsTotal}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.EffortsTotal}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.EffortsTotal}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_EffortsActivity}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.EffortsActivity}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.EffortsActivity}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_EffortsEfficiency}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.EffortsEfficiency}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.EffortsEfficiency}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_NetworkCyclomaticComplexity}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.NetworkCyclomaticComplexity}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.NetworkCyclomaticComplexity}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_NetworkDuration}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.NetworkDuration}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.NetworkDuration}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_NetworkDurationManMonths}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.NetworkDurationManMonths}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.NetworkDurationManMonths}"
+									  ToggleType="Radio" />
+						</MenuItem>
+
+						<Separator />
+
+						<MenuItem Header="{x:Static resources:Labels.Label_TrackedMetricYAxis}">
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_None}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.None}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.None}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_RisksCriticality}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.RisksCriticality}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.RisksCriticality}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_RisksFibonacci}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.RisksFibonacci}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.RisksFibonacci}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_RisksActivity}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.RisksActivity}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.RisksActivity}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_RisksActivityStdDevCorrection}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.RisksActivityStdDevCorrection}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.RisksActivityStdDevCorrection}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_RisksGeometricCriticality}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.RisksGeometricCriticality}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.RisksGeometricCriticality}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_RisksGeometricFibonacci}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.RisksGeometricFibonacci}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.RisksGeometricFibonacci}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_RisksGeometricActivity}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.RisksGeometricActivity}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.RisksGeometricActivity}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_CostsDirect}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.CostsDirect}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.CostsDirect}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_CostsIndirect}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.CostsIndirect}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.CostsIndirect}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_CostsOther}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.CostsOther}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.CostsOther}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_CostsTotal}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.CostsTotal}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.CostsTotal}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_BillingsDirect}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.BillingsDirect}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.BillingsDirect}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_BillingsIndirect}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.BillingsIndirect}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.BillingsIndirect}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_BillingsOther}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.BillingsOther}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.BillingsOther}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_BillingsTotal}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.BillingsTotal}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.BillingsTotal}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_MarginsDirect}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.MarginsDirect}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.MarginsDirect}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_MarginsDirectAbsolute}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.MarginsDirectAbsolute}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.MarginsDirectAbsolute}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_MarginsIndirect}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.MarginsIndirect}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.MarginsIndirect}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_MarginsIndirectAbsolute}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.MarginsIndirectAbsolute}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.MarginsIndirectAbsolute}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_MarginsOther}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.MarginsOther}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.MarginsOther}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_MarginsOtherAbsolute}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.MarginsOtherAbsolute}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.MarginsOtherAbsolute}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_MarginsTotal}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.MarginsTotal}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.MarginsTotal}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_MarginsTotalAbsolute}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.MarginsTotalAbsolute}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.MarginsTotalAbsolute}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_EffortsDirect}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.EffortsDirect}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.EffortsDirect}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_EffortsIndirect}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.EffortsIndirect}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.EffortsIndirect}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_EffortsOther}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.EffortsOther}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.EffortsOther}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_EffortsTotal}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.EffortsTotal}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.EffortsTotal}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_EffortsActivity}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.EffortsActivity}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.EffortsActivity}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_EffortsEfficiency}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.EffortsEfficiency}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.EffortsEfficiency}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_NetworkCyclomaticComplexity}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.NetworkCyclomaticComplexity}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.NetworkCyclomaticComplexity}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_NetworkDuration}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.NetworkDuration}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.NetworkDuration}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_NetworkDurationManMonths}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.NetworkDurationManMonths}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.NetworkDurationManMonths}"
+									  ToggleType="Radio" />
+						</MenuItem>
+
+						<Separator />
+
+						<MenuItem Header="{x:Static resources:Labels.Label_CurveFittingType}">
+							<MenuItem Header="{x:Static resources:Enums.Enum_CurveFittingType_None}"
+									  IsChecked="{Binding Path=CurveFittingType, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:CurveFittingType.None}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeCurveFittingTypeCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:CurveFittingType.None}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_CurveFittingType_Linear}"
+									  IsChecked="{Binding Path=CurveFittingType, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:CurveFittingType.Linear}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeCurveFittingTypeCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:CurveFittingType.Linear}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_CurveFittingType_Exponential}"
+									  IsChecked="{Binding Path=CurveFittingType, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:CurveFittingType.Exponential}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeCurveFittingTypeCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:CurveFittingType.Exponential}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_CurveFittingType_Logarithmic}"
+									  IsChecked="{Binding Path=CurveFittingType, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:CurveFittingType.Logarithmic}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeCurveFittingTypeCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:CurveFittingType.Logarithmic}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_CurveFittingType_Power}"
+									  IsChecked="{Binding Path=CurveFittingType, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:CurveFittingType.Power}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeCurveFittingTypeCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:CurveFittingType.Power}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_CurveFittingType_PolynomialOrder2}"
+									  IsChecked="{Binding Path=CurveFittingType, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:CurveFittingType.PolynomialOrder2}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeCurveFittingTypeCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:CurveFittingType.PolynomialOrder2}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_CurveFittingType_PolynomialOrder3}"
+									  IsChecked="{Binding Path=CurveFittingType, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:CurveFittingType.PolynomialOrder3}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeCurveFittingTypeCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:CurveFittingType.PolynomialOrder3}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_CurveFittingType_PolynomialOrder4}"
+									  IsChecked="{Binding Path=CurveFittingType, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:CurveFittingType.PolynomialOrder4}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeCurveFittingTypeCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:CurveFittingType.PolynomialOrder4}"
+									  ToggleType="Radio" />
+						</MenuItem>
+
+						<Separator />
+
 						<MenuItem Header="{x:Static resources:Menus.Menu_SaveAs}"
 								  Command="{Binding Path=SaveScenarioChartImageFileCommand, Mode=OneWay}" />
 

--- a/src/Zametek.ViewModel.ProjectPlan/ResourceChartManagement/ResourceChartManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ResourceChartManagement/ResourceChartManagerViewModel.cs
@@ -119,6 +119,10 @@ namespace Zametek.ViewModel.ProjectPlan
                 SaveResourceChartImageFileCommand = saveResourceChartImageFileCommand;
             }
 
+            ChangeAllocationModeCommand = ReactiveCommand.CreateFromTask<AllocationMode>(ChangeAllocationModeAsync);
+            ChangeScheduleModeCommand = ReactiveCommand.CreateFromTask<ScheduleMode>(ChangeScheduleModeAsync);
+            ChangeDisplayStyleCommand = ReactiveCommand.CreateFromTask<DisplayStyle>(ChangeDisplayStyleAsync);
+
             m_IsBusy = this
                 .WhenAnyValue(rcm => rcm.m_CoreViewModel.IsBusy)
                 .ToProperty(this, rcm => rcm.IsBusy);
@@ -529,6 +533,51 @@ namespace Zametek.ViewModel.ProjectPlan
             ResourceChartPlotModel.Plot.Axes.AutoScale();
         }
 
+        private async Task ChangeAllocationModeAsync(AllocationMode allocationMode)
+        {
+            try
+            {
+                AllocationMode = allocationMode;
+            }
+            catch (Exception ex)
+            {
+                await m_DialogService.ShowErrorAsync(
+                    Resource.ProjectPlan.Titles.Title_Error,
+                    string.Empty,
+                    ex.Message);
+            }
+        }
+
+        private async Task ChangeScheduleModeAsync(ScheduleMode scheduleMode)
+        {
+            try
+            {
+                ScheduleMode = scheduleMode;
+            }
+            catch (Exception ex)
+            {
+                await m_DialogService.ShowErrorAsync(
+                    Resource.ProjectPlan.Titles.Title_Error,
+                    string.Empty,
+                    ex.Message);
+            }
+        }
+
+        private async Task ChangeDisplayStyleAsync(DisplayStyle displayStyle)
+        {
+            try
+            {
+                DisplayStyle = displayStyle;
+            }
+            catch (Exception ex)
+            {
+                await m_DialogService.ShowErrorAsync(
+                    Resource.ProjectPlan.Titles.Title_Error,
+                    string.Empty,
+                    ex.Message);
+            }
+        }
+
         private async Task SaveResourceChartImageFileAsync()
         {
             try
@@ -623,6 +672,12 @@ namespace Zametek.ViewModel.ProjectPlan
         public ICommand ResetResourceChartCommand { get; }
 
         public ICommand SaveResourceChartImageFileCommand { get; }
+
+        public ICommand ChangeAllocationModeCommand { get; }
+
+        public ICommand ChangeScheduleModeCommand { get; }
+
+        public ICommand ChangeDisplayStyleCommand { get; }
 
         public async Task SaveResourceChartImageFileAsync(
             string? filename,

--- a/src/Zametek.ViewModel.ProjectPlan/ScenarioChartManagement/ScenarioChartManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ScenarioChartManagement/ScenarioChartManagerViewModel.cs
@@ -116,6 +116,10 @@ namespace Zametek.ViewModel.ProjectPlan
 
             ResetScenarioChartCommand = ReactiveCommand.Create(ResetScenarioChart);
 
+            ChangeTrackedMetricXAxisCommand = ReactiveCommand.CreateFromTask<TrackedMetrics>(ChangeTrackedMetricXAxisAsync);
+            ChangeTrackedMetricYAxisCommand = ReactiveCommand.CreateFromTask<TrackedMetrics>(ChangeTrackedMetricYAxisAsync);
+            ChangeCurveFittingTypeCommand = ReactiveCommand.CreateFromTask<CurveFittingType>(ChangeCurveFittingTypeAsync);
+
             m_IsBusy = this
                 .WhenAnyValue(
                     rcm => rcm.m_CoreViewModel.IsBusy,
@@ -500,6 +504,51 @@ namespace Zametek.ViewModel.ProjectPlan
             ScenarioChartPlotModel.Plot.Axes.AutoScale();
         }
 
+        private async Task ChangeTrackedMetricXAxisAsync(TrackedMetrics trackedMetric)
+        {
+            try
+            {
+                TrackedMetricXAxis = trackedMetric;
+            }
+            catch (Exception ex)
+            {
+                await m_DialogService.ShowErrorAsync(
+                    Resource.ProjectPlan.Titles.Title_Error,
+                    string.Empty,
+                    ex.Message);
+            }
+        }
+
+        private async Task ChangeTrackedMetricYAxisAsync(TrackedMetrics trackedMetric)
+        {
+            try
+            {
+                TrackedMetricYAxis = trackedMetric;
+            }
+            catch (Exception ex)
+            {
+                await m_DialogService.ShowErrorAsync(
+                    Resource.ProjectPlan.Titles.Title_Error,
+                    string.Empty,
+                    ex.Message);
+            }
+        }
+
+        private async Task ChangeCurveFittingTypeAsync(CurveFittingType curveFittingType)
+        {
+            try
+            {
+                CurveFittingType = curveFittingType;
+            }
+            catch (Exception ex)
+            {
+                await m_DialogService.ShowErrorAsync(
+                    Resource.ProjectPlan.Titles.Title_Error,
+                    string.Empty,
+                    ex.Message);
+            }
+        }
+
         private async Task SaveScenarioChartImageFileAsync()
         {
             try
@@ -584,6 +633,12 @@ namespace Zametek.ViewModel.ProjectPlan
         public ICommand SaveScenarioChartImageFileCommand { get; }
 
         public ICommand ResetScenarioChartCommand { get; }
+
+        public ICommand ChangeTrackedMetricXAxisCommand { get; }
+
+        public ICommand ChangeTrackedMetricYAxisCommand { get; }
+
+        public ICommand ChangeCurveFittingTypeCommand { get; }
 
         public async Task SaveScenarioChartImageFileAsync(
             string? filename,


### PR DESCRIPTION
## Summary

Adds right-click context menus to the Resource chart and Scenario chart controls, following the exact same convention already established in the Gantt chart.

### Resource chart

- Right-click context menu includes **ShowToday** and **ShowMilestones** checkbox toggles (ToggleType=CheckBox)
- Dropdown submenus for **AllocationMode**, **ScheduleMode**, and **DisplayStyle** with radio button selection (ToggleType=Radio) via `ChangeAllocationModeCommand`, `ChangeScheduleModeCommand`, and `ChangeDisplayStyleCommand`
- Sidebar `ScrollViewer` changed from `VerticalScrollBarVisibility=Hidden` to `Auto` so options remain accessible when the panel is height-constrained

### Scenario chart

- Right-click context menu includes **ShowNames** checkbox toggle
- Dropdown submenus for **TrackedMetricXAxis**, **TrackedMetricYAxis**, and **CurveFittingType** with radio button selection via dedicated typed `ReactiveCommand`s
- All 34 `TrackedMetric` enum values enumerated in both X-axis and Y-axis submenus
- Sidebar `ScrollViewer` changed to `Auto` — required because the 34-value TrackedMetrics list makes the options panel taller than most viewports

### Convention

Both charts follow the Gantt chart pattern exactly:
- `EnumToBoolConverter` for radio-button checked state
- `ToggleType=Radio` on enum submenus, `ToggleType=CheckBox` on boolean toggles
- `Separator` before SaveAs/Reset menu items
- One `ICommand` per enum type with `async`/`await` error handling via `Interaction`
- New command interfaces added to `IResourceChartManagerViewModel` and `IScenarioChartManagerViewModel`

## Files changed

- `IResourceChartManagerViewModel.cs` — 3 new command properties
- `IScenarioChartManagerViewModel.cs` — 2 new command properties  
- `ResourceChartManagerView.axaml` — context menu markup + ScrollViewer fix
- `ScenarioChartManagerView.axaml` — context menu markup + ScrollViewer fix
- `ResourceChartManagerViewModel.cs` — command implementations
- `ScenarioChartManagerViewModel.cs` — command implementations