### PR TITLE
feat: context menus, full UX overhaul, Gantt interactivity, graph improvements, elbow connectors

### DIFF
--- a/src/Zametek.Common.ProjectPlan/ShellView.cs
+++ b/src/Zametek.Common.ProjectPlan/ShellView.cs
@@ -1,0 +1,12 @@
+namespace Zametek.Common.ProjectPlan
+{
+    public enum ShellView
+    {
+        ActivitiesGantt = 0,
+        Resources = 1,
+        Scenario = 2,
+        ArrowGraph = 3,
+        VertexGraph = 4,
+        Tracking = 5,
+    }
+}

--- a/src/Zametek.Common.ProjectPlan/ShellView.cs
+++ b/src/Zametek.Common.ProjectPlan/ShellView.cs
@@ -8,5 +8,13 @@ namespace Zametek.Common.ProjectPlan
         ArrowGraph = 3,
         VertexGraph = 4,
         Tracking = 5,
+        ResourceSettings = 6,
+        WorkStreams = 7,
+        GraphSettings = 8,
+        Holidays = 9,
+        Metrics = 10,
+        EarnedValue = 11,
+        ProjectScenario = 12,
+        Output = 13,
     }
 }

--- a/src/Zametek.Contract.ProjectPlan/ActivityManagement/IActivitiesManagerViewModel.cs
+++ b/src/Zametek.Contract.ProjectPlan/ActivityManagement/IActivitiesManagerViewModel.cs
@@ -28,6 +28,10 @@ namespace Zametek.Contract.ProjectPlan
 
         ObservableCollection<IManagedActivityViewModel> OrderableActivities { get; }
 
+        int ScrollToActivityId { get; }
+
+        void SelectActivityById(int activityId);
+
         ICommand SetSelectedManagedActivitiesCommand { get; }
 
         ICommand AddManagedActivityCommand { get; }

--- a/src/Zametek.Contract.ProjectPlan/ArrowGraphManagement/GraphEdgeHitRect.cs
+++ b/src/Zametek.Contract.ProjectPlan/ArrowGraphManagement/GraphEdgeHitRect.cs
@@ -1,0 +1,10 @@
+namespace Zametek.Contract.ProjectPlan
+{
+    public record GraphEdgeHitRect(int ActivityId, double LabelX, double LabelY, double LabelWidth, double LabelHeight)
+    {
+        public bool Contains(double px, double py)
+        {
+            return px >= LabelX && px <= LabelX + LabelWidth && py >= LabelY && py <= LabelY + LabelHeight;
+        }
+    }
+}

--- a/src/Zametek.Contract.ProjectPlan/ArrowGraphManagement/IArrowGraphManagerViewModel.cs
+++ b/src/Zametek.Contract.ProjectPlan/ArrowGraphManagement/IArrowGraphManagerViewModel.cs
@@ -18,6 +18,8 @@ namespace Zametek.Contract.ProjectPlan
 
         BaseTheme BaseTheme { get; }
 
+        IReadOnlyList<GraphEdgeHitRect> EdgeHitRects { get; }
+
         ICommand SaveArrowGraphImageFileCommand { get; }
 
         Task SaveArrowGraphImageFileAsync(string? filename);
@@ -25,5 +27,7 @@ namespace Zametek.Contract.ProjectPlan
         void BuildArrowGraphDiagramData();
 
         void BuildArrowGraphDiagramImage();
+
+        void NavigateToActivity(int activityId);
     }
 }

--- a/src/Zametek.Contract.ProjectPlan/ArrowGraphManagement/IArrowGraphSerializer.cs
+++ b/src/Zametek.Contract.ProjectPlan/ArrowGraphManagement/IArrowGraphSerializer.cs
@@ -4,7 +4,7 @@ namespace Zametek.Contract.ProjectPlan
 {
     public interface IArrowGraphSerializer
     {
-        byte[] BuildArrowGraphSvgData(ArrowGraphModel arrowGraph, GraphSettingsModel graphSettings, BaseTheme baseTheme, bool viewNames);
+        (byte[] SvgData, IReadOnlyList<GraphEdgeHitRect> EdgeHitRects) BuildArrowGraphSvgData(ArrowGraphModel arrowGraph, GraphSettingsModel graphSettings, BaseTheme baseTheme, bool viewNames);
 
         byte[] BuildArrowGraphMLData(ArrowGraphModel arrowGraph, GraphSettingsModel graphSettings, bool viewNames);
 

--- a/src/Zametek.Contract.ProjectPlan/GanttChartManagement/IGanttChartManagerViewModel.cs
+++ b/src/Zametek.Contract.ProjectPlan/GanttChartManagement/IGanttChartManagerViewModel.cs
@@ -28,6 +28,8 @@ namespace Zametek.Contract.ProjectPlan
 
         bool ShowSlack { get; set; }
 
+        bool ShowAllConnections { get; set; }
+
         IActivitySelectorViewModel ActivitySelector { get; }
 
         ICommand ResetGanttChartCommand { get; }
@@ -43,5 +45,7 @@ namespace Zametek.Contract.ProjectPlan
         void BuildGanttChartPlotModel();
 
         void SetActivityDuration(int activityId, int newDuration);
+
+        void AddActivityDependency(int fromActivityId, int toActivityId);
     }
 }

--- a/src/Zametek.Contract.ProjectPlan/GanttChartManagement/IGanttChartManagerViewModel.cs
+++ b/src/Zametek.Contract.ProjectPlan/GanttChartManagement/IGanttChartManagerViewModel.cs
@@ -41,5 +41,7 @@ namespace Zametek.Contract.ProjectPlan
         Task SaveGanttChartImageFileAsync(string? filename, int width, int height);
 
         void BuildGanttChartPlotModel();
+
+        void SetActivityDuration(int activityId, int newDuration);
     }
 }

--- a/src/Zametek.Contract.ProjectPlan/IMainViewModel.cs
+++ b/src/Zametek.Contract.ProjectPlan/IMainViewModel.cs
@@ -158,6 +158,8 @@ namespace Zametek.Contract.ProjectPlan
 
         Task ResetLayoutAsync();
 
+        void SelectActivity(int activityId);
+
         Task OpenProjectFileAsync();
 
         Task OpenProjectFileAsync(string? filename);

--- a/src/Zametek.Contract.ProjectPlan/IMainViewModel.cs
+++ b/src/Zametek.Contract.ProjectPlan/IMainViewModel.cs
@@ -26,6 +26,22 @@ namespace Zametek.Contract.ProjectPlan
 
         ITrackingManagerViewModel TrackingManagerViewModel { get; }
 
+        IResourceSettingsManagerViewModel ResourceSettingsManagerViewModel { get; }
+
+        IWorkStreamSettingsManagerViewModel WorkStreamSettingsManagerViewModel { get; }
+
+        IGraphSettingsManagerViewModel GraphSettingsManagerViewModel { get; }
+
+        IHolidaySettingsManagerViewModel HolidaySettingsManagerViewModel { get; }
+
+        IMetricManagerViewModel MetricManagerViewModel { get; }
+
+        IEarnedValueChartManagerViewModel EarnedValueChartManagerViewModel { get; }
+
+        IProjectScenarioManagerViewModel ProjectScenarioManagerViewModel { get; }
+
+        IOutputManagerViewModel OutputManagerViewModel { get; }
+
         bool IsBusy { get; }
 
         bool IsOpening { get; }

--- a/src/Zametek.Contract.ProjectPlan/IMainViewModel.cs
+++ b/src/Zametek.Contract.ProjectPlan/IMainViewModel.cs
@@ -8,6 +8,24 @@ namespace Zametek.Contract.ProjectPlan
     {
         string ProjectTitle { get; }
 
+        ShellView ActiveShellView { get; set; }
+
+        bool IsCommandPaletteOpen { get; set; }
+
+        IActivitiesManagerViewModel ActivitiesManagerViewModel { get; }
+
+        IGanttChartManagerViewModel GanttChartManagerViewModel { get; }
+
+        IResourceChartManagerViewModel ResourceChartManagerViewModel { get; }
+
+        IScenarioChartManagerViewModel ScenarioChartManagerViewModel { get; }
+
+        IArrowGraphManagerViewModel ArrowGraphManagerViewModel { get; }
+
+        IVertexGraphManagerViewModel VertexGraphManagerViewModel { get; }
+
+        ITrackingManagerViewModel TrackingManagerViewModel { get; }
+
         bool IsBusy { get; }
 
         bool IsOpening { get; }

--- a/src/Zametek.Contract.ProjectPlan/ResourceChartManagement/IResourceChartManagerViewModel.cs
+++ b/src/Zametek.Contract.ProjectPlan/ResourceChartManagement/IResourceChartManagerViewModel.cs
@@ -20,9 +20,17 @@ namespace Zametek.Contract.ProjectPlan
 
         bool ShowToday { get; set; }
 
+        bool ShowMilestones { get; set; }
+
         ICommand ResetResourceChartCommand { get; }
 
         ICommand SaveResourceChartImageFileCommand { get; }
+
+        ICommand ChangeAllocationModeCommand { get; }
+
+        ICommand ChangeScheduleModeCommand { get; }
+
+        ICommand ChangeDisplayStyleCommand { get; }
 
         Task SaveResourceChartImageFileAsync(string? filename, int width, int height);
 

--- a/src/Zametek.Contract.ProjectPlan/ScenarioChartManagement/IScenarioChartManagerViewModel.cs
+++ b/src/Zametek.Contract.ProjectPlan/ScenarioChartManagement/IScenarioChartManagerViewModel.cs
@@ -26,6 +26,12 @@ namespace Zametek.Contract.ProjectPlan
 
         ICommand ResetScenarioChartCommand { get; }
 
+        ICommand ChangeTrackedMetricXAxisCommand { get; }
+
+        ICommand ChangeTrackedMetricYAxisCommand { get; }
+
+        ICommand ChangeCurveFittingTypeCommand { get; }
+
         Task SaveScenarioChartImageFileAsync(string? filename, int width, int height);
 
         void BuildScenarioChartPlotModel();

--- a/src/Zametek.Contract.ProjectPlan/VertexGraphManagement/GraphNodeHitRect.cs
+++ b/src/Zametek.Contract.ProjectPlan/VertexGraphManagement/GraphNodeHitRect.cs
@@ -1,0 +1,10 @@
+namespace Zametek.Contract.ProjectPlan
+{
+    public record GraphNodeHitRect(int ActivityId, double X, double Y, double Width, double Height)
+    {
+        public bool Contains(double px, double py)
+        {
+            return px >= X && px <= X + Width && py >= Y && py <= Y + Height;
+        }
+    }
+}

--- a/src/Zametek.Contract.ProjectPlan/VertexGraphManagement/IVertexGraphManagerViewModel.cs
+++ b/src/Zametek.Contract.ProjectPlan/VertexGraphManagement/IVertexGraphManagerViewModel.cs
@@ -18,6 +18,8 @@ namespace Zametek.Contract.ProjectPlan
 
         BaseTheme BaseTheme { get; }
 
+        IReadOnlyList<GraphNodeHitRect> NodeHitRects { get; }
+
         ICommand SaveVertexGraphImageFileCommand { get; }
 
         Task SaveVertexGraphImageFileAsync(string? filename);
@@ -25,5 +27,7 @@ namespace Zametek.Contract.ProjectPlan
         void BuildVertexGraphDiagramData();
 
         void BuildVertexGraphDiagramImage();
+
+        void NavigateToActivity(int activityId);
     }
 }

--- a/src/Zametek.Contract.ProjectPlan/VertexGraphManagement/IVertexGraphSerializer.cs
+++ b/src/Zametek.Contract.ProjectPlan/VertexGraphManagement/IVertexGraphSerializer.cs
@@ -4,7 +4,7 @@ namespace Zametek.Contract.ProjectPlan
 {
     public interface IVertexGraphSerializer
     {
-        byte[] BuildVertexGraphSvgData(VertexGraphModel vertexGraph, GraphSettingsModel graphSettings, BaseTheme baseTheme, bool viewNames);
+        (byte[] SvgData, IReadOnlyList<GraphNodeHitRect> NodeHitRects) BuildVertexGraphSvgData(VertexGraphModel vertexGraph, GraphSettingsModel graphSettings, BaseTheme baseTheme, bool viewNames);
 
         byte[] BuildVertexGraphMLData(VertexGraphModel vertexGraph, GraphSettingsModel graphSettings, bool viewNames);
 

--- a/src/Zametek.Data.ProjectPlan/v0_3_0/Converter.cs
+++ b/src/Zametek.Data.ProjectPlan/v0_3_0/Converter.cs
@@ -56,7 +56,9 @@ namespace Zametek.Data.ProjectPlan.v0_3_0
 
             return new ProjectModel
             {
-                ProjectStart = project.ProjectStart,
+                // v0_2_1 stored ProjectStart as DateTime (no offset). Treat it as UTC when
+                // promoting to DateTimeOffset so the conversion is timezone-independent.
+                ProjectStart = new DateTimeOffset(project.ProjectStart, TimeSpan.Zero),
                 DependentActivities = [.. project.DependentActivities.Select(mapper.FromV0_2_1ToV0_3_0)],
                 ArrowGraphSettings = project.ArrowGraphSettings ?? new v0_1_0.ArrowGraphSettingsModel(),
                 ResourceSettings = project.ResourceSettings ?? new v0_1_0.ResourceSettingsModel(),

--- a/src/Zametek.ProjectPlan/App.axaml
+++ b/src/Zametek.ProjectPlan/App.axaml
@@ -38,26 +38,87 @@
 		<StyleInclude Source="avares://Semi.Avalonia.DataGrid/Index.axaml" />
 
 		<StyleInclude Source="avares://MsBox.Avalonia.Markdown/Controls/MarkdownView.axaml" />
-		
+
 		<StyleInclude Source="avares://Xaml.Behaviors.Interactions.DragAndDrop.DataGrid/Styles.axaml" />
 
+		<!-- === UI Polish styles === -->
+
+		<!-- Typography: consistent base font size -->
 		<Style Selector="TextBox">
 			<Setter Property="FontSize" Value="12"/>
 		</Style>
-		
-		<Style Selector="MenuItem">
+
+		<Style Selector="TextBlock">
 			<Setter Property="FontSize" Value="12"/>
+			<Setter Property="LineHeight" Value="18"/>
 		</Style>
 
+		<Style Selector="SelectableTextBlock">
+			<Setter Property="FontSize" Value="12"/>
+			<Setter Property="LineHeight" Value="18"/>
+		</Style>
+
+		<Style Selector="Label">
+			<Setter Property="FontSize" Value="12"/>
+			<Setter Property="Padding" Value="4,0"/>
+		</Style>
+
+		<Style Selector="MenuItem">
+			<Setter Property="FontSize" Value="12"/>
+			<Setter Property="Padding" Value="8,5"/>
+		</Style>
+
+		<!-- Menu item icons: consistent left-side spacing -->
+		<Style Selector="MenuItem > MenuItem">
+			<Setter Property="Padding" Value="8,4"/>
+		</Style>
+
+		<!-- Separator in menus: subtle and clean -->
+		<Style Selector="Separator">
+			<Setter Property="Margin" Value="0,2"/>
+		</Style>
+
+		<!-- ComboBox: consistent sizing and alignment -->
 		<Style Selector="ComboBox">
 			<Setter Property="VerticalAlignment" Value="Center"/>
 			<Setter Property="VerticalContentAlignment" Value="Center"/>
 			<Setter Property="HorizontalAlignment" Value="Stretch"/>
 			<Setter Property="HorizontalContentAlignment" Value="Left"/>
+			<Setter Property="MinHeight" Value="25"/>
+			<Setter Property="Padding" Value="6,3"/>
 		</Style>
 
+		<!-- Button: consistent padding and visual weight -->
+		<Style Selector="Button">
+			<Setter Property="Padding" Value="8,4"/>
+			<Setter Property="FontSize" Value="12"/>
+		</Style>
+
+		<!-- ToggleSwitch: vertically centered, compact -->
+		<Style Selector="ToggleSwitch">
+			<Setter Property="FontSize" Value="12"/>
+		</Style>
+
+		<!-- DataGrid: clear row height and header font weight -->
+		<Style Selector="DataGridColumnHeader">
+			<Setter Property="FontSize" Value="12"/>
+			<Setter Property="FontWeight" Value="SemiBold"/>
+			<Setter Property="Padding" Value="4,4"/>
+			<Setter Property="MinHeight" Value="28"/>
+		</Style>
+
+		<Style Selector="DataGridCell">
+			<Setter Property="FontSize" Value="12"/>
+		</Style>
+
+		<!-- Dock panel tab strip: slight font weight for legibility -->
 		<Style Selector="idc|RootDockControl">
 			<Setter Property="Margin" Value="0,0,0,7"/>
+		</Style>
+
+		<!-- DatePicker: vertically centered -->
+		<Style Selector="DatePicker">
+			<Setter Property="VerticalAlignment" Value="Center"/>
 		</Style>
 
 		<!--For some reason this isn't working at expected on Windows-->
@@ -68,6 +129,7 @@
 		<!--This is for the header in the About window-->
 		<Style Selector="mbc|MsBoxStandardView TextBox.header">
 			<Setter Property="FontSize" Value="20" />
+			<Setter Property="FontWeight" Value="SemiBold" />
 		</Style>
 
 		<Style Selector="DataValidationErrors">
@@ -86,7 +148,7 @@
 			<sys:Double x:Key="ButtonDefaultFontSize">12</sys:Double>
 			<!--<FontWeight x:Key="ButtonDefaultFontWeight">550</FontWeight>-->
 			<SolidColorBrush x:Key="ButtonDefaultBackground" Opacity="0.25" Color="Gray" />
-			<Thickness x:Key="ButtonDefaultPadding">6 6</Thickness>
+			<Thickness x:Key="ButtonDefaultPadding">8 4</Thickness>
 
 			<!--This needs to be here as empty strings don't work in the English theme-->
 
@@ -96,18 +158,31 @@
 			<SolidColorBrush x:Key="TextBoxDefaultBackground" Color="Transparent" />
 			<SolidColorBrush x:Key="TextBoxPointeroverBackground" Color="Transparent" />
 
+			<!--
+				Polish: slightly refined editable cell palette.
+				Light: warm cream base with cleaner selected/focus states.
+				Dark: cool navy base retained, focus contrast improved.
+			-->
 			<ResourceDictionary.ThemeDictionaries>
 				<ResourceDictionary x:Key="Light">
-					<SolidColorBrush x:Key="EditableCellGridBackgroundBrush">#FFFFFFE0</SolidColorBrush>
-					<SolidColorBrush x:Key="EditableHoverCellGridBackgroundBrush">#FFF0E68C</SolidColorBrush>
-					<SolidColorBrush x:Key="EditableSelectedCellGridBackgroundBrush">#FFBDB76B</SolidColorBrush>
-					<SolidColorBrush x:Key="EditableSelectedCurrentFocusCellGridBackgroundBrush">#FFF0F8FF</SolidColorBrush>
+					<!-- Editable cell: warm cream — clearly editable without being distracting -->
+					<SolidColorBrush x:Key="EditableCellGridBackgroundBrush">#FFFFFBEA</SolidColorBrush>
+					<!-- Hover: slightly more saturated warm tone -->
+					<SolidColorBrush x:Key="EditableHoverCellGridBackgroundBrush">#FFFDE68A</SolidColorBrush>
+					<!-- Selected editable: golden amber, clearly selected -->
+					<SolidColorBrush x:Key="EditableSelectedCellGridBackgroundBrush">#FFCA8A04</SolidColorBrush>
+					<!-- Selected + focused: clean light blue — high contrast focus ring -->
+					<SolidColorBrush x:Key="EditableSelectedCurrentFocusCellGridBackgroundBrush">#FFE0F2FE</SolidColorBrush>
+					<!-- Polish: panel separator / border line -->
+					<SolidColorBrush x:Key="SemiColorBorder">#FFE2E8F0</SolidColorBrush>
 				</ResourceDictionary>
 				<ResourceDictionary x:Key="Dark">
 					<SolidColorBrush x:Key="EditableCellGridBackgroundBrush">#FF00001f</SolidColorBrush>
 					<SolidColorBrush x:Key="EditableHoverCellGridBackgroundBrush">#FF0f1973</SolidColorBrush>
 					<SolidColorBrush x:Key="EditableSelectedCellGridBackgroundBrush">#FF424894</SolidColorBrush>
 					<SolidColorBrush x:Key="EditableSelectedCurrentFocusCellGridBackgroundBrush">#FF0f0700</SolidColorBrush>
+					<!-- Polish: panel separator / border line -->
+					<SolidColorBrush x:Key="SemiColorBorder">#FF334155</SolidColorBrush>
 				</ResourceDictionary>
 			</ResourceDictionary.ThemeDictionaries>
 		</ResourceDictionary>

--- a/src/Zametek.ProjectPlan/App.axaml
+++ b/src/Zametek.ProjectPlan/App.axaml
@@ -41,85 +41,8 @@
 
 		<StyleInclude Source="avares://Xaml.Behaviors.Interactions.DragAndDrop.DataGrid/Styles.axaml" />
 
-		<!-- === UI Polish styles === -->
-
-		<!-- Typography: consistent base font size -->
-		<Style Selector="TextBox">
-			<Setter Property="FontSize" Value="12"/>
-		</Style>
-
-		<Style Selector="TextBlock">
-			<Setter Property="FontSize" Value="12"/>
-			<Setter Property="LineHeight" Value="18"/>
-		</Style>
-
-		<Style Selector="SelectableTextBlock">
-			<Setter Property="FontSize" Value="12"/>
-			<Setter Property="LineHeight" Value="18"/>
-		</Style>
-
-		<Style Selector="Label">
-			<Setter Property="FontSize" Value="12"/>
-			<Setter Property="Padding" Value="4,0"/>
-		</Style>
-
-		<Style Selector="MenuItem">
-			<Setter Property="FontSize" Value="12"/>
-			<Setter Property="Padding" Value="8,5"/>
-		</Style>
-
-		<!-- Menu item icons: consistent left-side spacing -->
-		<Style Selector="MenuItem > MenuItem">
-			<Setter Property="Padding" Value="8,4"/>
-		</Style>
-
-		<!-- Separator in menus: subtle and clean -->
-		<Style Selector="Separator">
-			<Setter Property="Margin" Value="0,2"/>
-		</Style>
-
-		<!-- ComboBox: consistent sizing and alignment -->
-		<Style Selector="ComboBox">
-			<Setter Property="VerticalAlignment" Value="Center"/>
-			<Setter Property="VerticalContentAlignment" Value="Center"/>
-			<Setter Property="HorizontalAlignment" Value="Stretch"/>
-			<Setter Property="HorizontalContentAlignment" Value="Left"/>
-			<Setter Property="MinHeight" Value="25"/>
-			<Setter Property="Padding" Value="6,3"/>
-		</Style>
-
-		<!-- Button: consistent padding and visual weight -->
-		<Style Selector="Button">
-			<Setter Property="Padding" Value="8,4"/>
-			<Setter Property="FontSize" Value="12"/>
-		</Style>
-
-		<!-- ToggleSwitch: vertically centered, compact -->
-		<Style Selector="ToggleSwitch">
-			<Setter Property="FontSize" Value="12"/>
-		</Style>
-
-		<!-- DataGrid: clear row height and header font weight -->
-		<Style Selector="DataGridColumnHeader">
-			<Setter Property="FontSize" Value="12"/>
-			<Setter Property="FontWeight" Value="SemiBold"/>
-			<Setter Property="Padding" Value="4,4"/>
-			<Setter Property="MinHeight" Value="28"/>
-		</Style>
-
-		<Style Selector="DataGridCell">
-			<Setter Property="FontSize" Value="12"/>
-		</Style>
-
-		<!-- Dock panel tab strip: slight font weight for legibility -->
-		<Style Selector="idc|RootDockControl">
-			<Setter Property="Margin" Value="0,0,0,7"/>
-		</Style>
-
-		<!-- DatePicker: vertically centered -->
-		<Style Selector="DatePicker">
-			<Setter Property="VerticalAlignment" Value="Center"/>
-		</Style>
+		<!-- === Zametek Design System === -->
+		<StyleInclude Source="avares://Zametek.View.ProjectPlan/Themes/ZametekTheme.axaml" />
 
 		<!--For some reason this isn't working at expected on Windows-->
 		<Style Selector="mbc|MsBoxStandardView Button">
@@ -139,50 +62,106 @@
 
 	<Application.Resources>
 		<ResourceDictionary>
-			<sys:Double x:Key="DefaultFontSize">12</sys:Double>
+			<sys:Double x:Key="DefaultFontSize">13</sys:Double>
 
-			<sys:Double x:Key="TextBlockFontSize">12</sys:Double>
+			<sys:Double x:Key="TextBlockFontSize">13</sys:Double>
 
-			<sys:Double x:Key="ListBoxItemCheckFontSize">12</sys:Double>
+			<sys:Double x:Key="ListBoxItemCheckFontSize">13</sys:Double>
 
-			<sys:Double x:Key="ButtonDefaultFontSize">12</sys:Double>
+			<sys:Double x:Key="ButtonDefaultFontSize">13</sys:Double>
 			<!--<FontWeight x:Key="ButtonDefaultFontWeight">550</FontWeight>-->
 			<SolidColorBrush x:Key="ButtonDefaultBackground" Opacity="0.25" Color="Gray" />
-			<Thickness x:Key="ButtonDefaultPadding">8 4</Thickness>
+			<Thickness x:Key="ButtonDefaultPadding">12 0</Thickness>
 
 			<!--This needs to be here as empty strings don't work in the English theme-->
-
 			<x:String x:Key="STRING_PAGINATION_PAGE">.</x:String>
 
 			<!--This needs to be here in order to prevent text in NumericIntUpDown being obfuscated in ComboBoxItems-->
 			<SolidColorBrush x:Key="TextBoxDefaultBackground" Color="Transparent" />
 			<SolidColorBrush x:Key="TextBoxPointeroverBackground" Color="Transparent" />
 
-			<!--
-				Polish: slightly refined editable cell palette.
-				Light: warm cream base with cleaner selected/focus states.
-				Dark: cool navy base retained, focus contrast improved.
-			-->
+			<!-- ================================================================
+			     Zametek design tokens — fallback (non-themed) values
+			     ThemeDictionaries below provide Light/Dark variants
+			     ================================================================ -->
+			<SolidColorBrush x:Key="ZBackground"    Color="#F8F9FA"/>
+			<SolidColorBrush x:Key="ZSurface"       Color="#FFFFFF"/>
+			<SolidColorBrush x:Key="ZSurface2"      Color="#F1F3F5"/>
+			<SolidColorBrush x:Key="ZBorder"        Color="#DEE2E6"/>
+			<SolidColorBrush x:Key="ZBorderStrong"  Color="#CED4DA"/>
+			<SolidColorBrush x:Key="ZTextPrimary"   Color="#212529"/>
+			<SolidColorBrush x:Key="ZTextSecondary" Color="#6C757D"/>
+			<SolidColorBrush x:Key="ZTextMuted"     Color="#ADB5BD"/>
+			<SolidColorBrush x:Key="ZAccent"        Color="#1971C2"/>
+			<SolidColorBrush x:Key="ZAccentHover"   Color="#1864AB"/>
+			<SolidColorBrush x:Key="ZAccentLight"   Color="#D0EBFF"/>
+			<SolidColorBrush x:Key="ZAccentSubtle"  Color="#E7F5FF"/>
+			<SolidColorBrush x:Key="ZError"         Color="#E03131"/>
+			<SolidColorBrush x:Key="ZWarning"       Color="#F08C00"/>
+			<SolidColorBrush x:Key="ZSuccess"       Color="#2F9E44"/>
+			<SolidColorBrush x:Key="ZToolbarBg"     Color="#FFFFFF"/>
+			<SolidColorBrush x:Key="ZStatusBar"     Color="#F1F3F5"/>
+			<SolidColorBrush x:Key="ZTabStrip"      Color="#F8F9FA"/>
+
 			<ResourceDictionary.ThemeDictionaries>
 				<ResourceDictionary x:Key="Light">
-					<!-- Editable cell: warm cream — clearly editable without being distracting -->
+					<!-- Zametek design tokens — Light -->
+					<SolidColorBrush x:Key="ZBackground"    Color="#F8F9FA"/>
+					<SolidColorBrush x:Key="ZSurface"       Color="#FFFFFF"/>
+					<SolidColorBrush x:Key="ZSurface2"      Color="#F1F3F5"/>
+					<SolidColorBrush x:Key="ZBorder"        Color="#DEE2E6"/>
+					<SolidColorBrush x:Key="ZBorderStrong"  Color="#CED4DA"/>
+					<SolidColorBrush x:Key="ZTextPrimary"   Color="#212529"/>
+					<SolidColorBrush x:Key="ZTextSecondary" Color="#6C757D"/>
+					<SolidColorBrush x:Key="ZTextMuted"     Color="#ADB5BD"/>
+					<SolidColorBrush x:Key="ZAccent"        Color="#1971C2"/>
+					<SolidColorBrush x:Key="ZAccentHover"   Color="#1864AB"/>
+					<SolidColorBrush x:Key="ZAccentLight"   Color="#D0EBFF"/>
+					<SolidColorBrush x:Key="ZAccentSubtle"  Color="#E7F5FF"/>
+					<SolidColorBrush x:Key="ZError"         Color="#E03131"/>
+					<SolidColorBrush x:Key="ZWarning"       Color="#F08C00"/>
+					<SolidColorBrush x:Key="ZSuccess"       Color="#2F9E44"/>
+					<SolidColorBrush x:Key="ZToolbarBg"     Color="#FFFFFF"/>
+					<SolidColorBrush x:Key="ZStatusBar"     Color="#F1F3F5"/>
+					<SolidColorBrush x:Key="ZTabStrip"      Color="#F8F9FA"/>
+
+					<!-- Editable cell: accent-light palette for editability signal -->
 					<SolidColorBrush x:Key="EditableCellGridBackgroundBrush">#FFFFFBEA</SolidColorBrush>
-					<!-- Hover: slightly more saturated warm tone -->
 					<SolidColorBrush x:Key="EditableHoverCellGridBackgroundBrush">#FFFDE68A</SolidColorBrush>
-					<!-- Selected editable: golden amber, clearly selected -->
 					<SolidColorBrush x:Key="EditableSelectedCellGridBackgroundBrush">#FFCA8A04</SolidColorBrush>
-					<!-- Selected + focused: clean light blue — high contrast focus ring -->
-					<SolidColorBrush x:Key="EditableSelectedCurrentFocusCellGridBackgroundBrush">#FFE0F2FE</SolidColorBrush>
-					<!-- Polish: panel separator / border line -->
-					<SolidColorBrush x:Key="SemiColorBorder">#FFE2E8F0</SolidColorBrush>
+					<SolidColorBrush x:Key="EditableSelectedCurrentFocusCellGridBackgroundBrush">#D0EBFF</SolidColorBrush>
+					<!-- Semi border override — unified with ZBorder -->
+					<SolidColorBrush x:Key="SemiColorBorder">#DEE2E6</SolidColorBrush>
 				</ResourceDictionary>
+
 				<ResourceDictionary x:Key="Dark">
-					<SolidColorBrush x:Key="EditableCellGridBackgroundBrush">#FF00001f</SolidColorBrush>
-					<SolidColorBrush x:Key="EditableHoverCellGridBackgroundBrush">#FF0f1973</SolidColorBrush>
-					<SolidColorBrush x:Key="EditableSelectedCellGridBackgroundBrush">#FF424894</SolidColorBrush>
-					<SolidColorBrush x:Key="EditableSelectedCurrentFocusCellGridBackgroundBrush">#FF0f0700</SolidColorBrush>
-					<!-- Polish: panel separator / border line -->
-					<SolidColorBrush x:Key="SemiColorBorder">#FF334155</SolidColorBrush>
+					<!-- Zametek design tokens — Dark -->
+					<SolidColorBrush x:Key="ZBackground"    Color="#1A1B1E"/>
+					<SolidColorBrush x:Key="ZSurface"       Color="#25262B"/>
+					<SolidColorBrush x:Key="ZSurface2"      Color="#2C2E33"/>
+					<SolidColorBrush x:Key="ZBorder"        Color="#373A40"/>
+					<SolidColorBrush x:Key="ZBorderStrong"  Color="#495057"/>
+					<SolidColorBrush x:Key="ZTextPrimary"   Color="#F8F9FA"/>
+					<SolidColorBrush x:Key="ZTextSecondary" Color="#ADB5BD"/>
+					<SolidColorBrush x:Key="ZTextMuted"     Color="#6C757D"/>
+					<SolidColorBrush x:Key="ZAccent"        Color="#4DABF7"/>
+					<SolidColorBrush x:Key="ZAccentHover"   Color="#74C0FC"/>
+					<SolidColorBrush x:Key="ZAccentLight"   Color="#1C3A5E"/>
+					<SolidColorBrush x:Key="ZAccentSubtle"  Color="#1A2D45"/>
+					<SolidColorBrush x:Key="ZError"         Color="#FF6B6B"/>
+					<SolidColorBrush x:Key="ZWarning"       Color="#FFA94D"/>
+					<SolidColorBrush x:Key="ZSuccess"       Color="#69DB7C"/>
+					<SolidColorBrush x:Key="ZToolbarBg"     Color="#25262B"/>
+					<SolidColorBrush x:Key="ZStatusBar"     Color="#1A1B1E"/>
+					<SolidColorBrush x:Key="ZTabStrip"      Color="#1A1B1E"/>
+
+					<!-- Editable cell: dark navy palette -->
+					<SolidColorBrush x:Key="EditableCellGridBackgroundBrush">#1C3A5E</SolidColorBrush>
+					<SolidColorBrush x:Key="EditableHoverCellGridBackgroundBrush">#1A2D45</SolidColorBrush>
+					<SolidColorBrush x:Key="EditableSelectedCellGridBackgroundBrush">#1864AB</SolidColorBrush>
+					<SolidColorBrush x:Key="EditableSelectedCurrentFocusCellGridBackgroundBrush">#1971C2</SolidColorBrush>
+					<!-- Semi border override -->
+					<SolidColorBrush x:Key="SemiColorBorder">#373A40</SolidColorBrush>
 				</ResourceDictionary>
 			</ResourceDictionary.ThemeDictionaries>
 		</ResourceDictionary>

--- a/src/Zametek.ProjectPlan/App.axaml
+++ b/src/Zametek.ProjectPlan/App.axaml
@@ -80,29 +80,6 @@
 			<SolidColorBrush x:Key="TextBoxDefaultBackground" Color="Transparent" />
 			<SolidColorBrush x:Key="TextBoxPointeroverBackground" Color="Transparent" />
 
-			<!-- ================================================================
-			     Zametek design tokens — fallback (non-themed) values
-			     ThemeDictionaries below provide Light/Dark variants
-			     ================================================================ -->
-			<SolidColorBrush x:Key="ZBackground"    Color="#F8F9FA"/>
-			<SolidColorBrush x:Key="ZSurface"       Color="#FFFFFF"/>
-			<SolidColorBrush x:Key="ZSurface2"      Color="#F1F3F5"/>
-			<SolidColorBrush x:Key="ZBorder"        Color="#DEE2E6"/>
-			<SolidColorBrush x:Key="ZBorderStrong"  Color="#CED4DA"/>
-			<SolidColorBrush x:Key="ZTextPrimary"   Color="#212529"/>
-			<SolidColorBrush x:Key="ZTextSecondary" Color="#6C757D"/>
-			<SolidColorBrush x:Key="ZTextMuted"     Color="#ADB5BD"/>
-			<SolidColorBrush x:Key="ZAccent"        Color="#1971C2"/>
-			<SolidColorBrush x:Key="ZAccentHover"   Color="#1864AB"/>
-			<SolidColorBrush x:Key="ZAccentLight"   Color="#D0EBFF"/>
-			<SolidColorBrush x:Key="ZAccentSubtle"  Color="#E7F5FF"/>
-			<SolidColorBrush x:Key="ZError"         Color="#E03131"/>
-			<SolidColorBrush x:Key="ZWarning"       Color="#F08C00"/>
-			<SolidColorBrush x:Key="ZSuccess"       Color="#2F9E44"/>
-			<SolidColorBrush x:Key="ZToolbarBg"     Color="#FFFFFF"/>
-			<SolidColorBrush x:Key="ZStatusBar"     Color="#F1F3F5"/>
-			<SolidColorBrush x:Key="ZTabStrip"      Color="#F8F9FA"/>
-
 			<ResourceDictionary.ThemeDictionaries>
 				<ResourceDictionary x:Key="Light">
 					<!-- Zametek design tokens — Light -->

--- a/src/Zametek.Resource.ProjectPlan/Labels.Designer.cs
+++ b/src/Zametek.Resource.ProjectPlan/Labels.Designer.cs
@@ -1509,6 +1509,15 @@ namespace Zametek.Resource.ProjectPlan {
                 return ResourceManager.GetString("Label_ShowSlack", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Show All Connections.
+        /// </summary>
+        public static string Label_ShowAllConnections {
+            get {
+                return ResourceManager.GetString("Label_ShowAllConnections", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Show Today.

--- a/src/Zametek.Resource.ProjectPlan/Labels.resx
+++ b/src/Zametek.Resource.ProjectPlan/Labels.resx
@@ -588,6 +588,9 @@
   <data name="Label_ShowSlack" xml:space="preserve">
     <value>Show Slack</value>
   </data>
+  <data name="Label_ShowAllConnections" xml:space="preserve">
+    <value>Show All Connections</value>
+  </data>
   <data name="Label_RootNode" xml:space="preserve">
     <value>Root</value>
   </data>

--- a/src/Zametek.View.ProjectPlan/ActivityManagement/ActivitiesManagerView.axaml
+++ b/src/Zametek.View.ProjectPlan/ActivityManagement/ActivitiesManagerView.axaml
@@ -50,6 +50,19 @@
 
 	<DockPanel Margin="0">
 
+		<!-- Action toolbar: primary activity operations, always visible -->
+		<WrapPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="2,4,2,2">
+			<Button Content="＋ Add Activity"
+					Command="{Binding AddManagedActivityCommand, Mode=OneWay}"
+					Margin="2" Padding="8,3" />
+			<Button Content="Insert"
+					Command="{Binding InsertManagedActivityCommand, Mode=OneWay}"
+					Margin="2" Padding="8,3" />
+			<Button Content="＋ Milestone"
+					Command="{Binding AddMilestoneCommand, Mode=OneWay}"
+					Margin="2" Padding="8,3" />
+		</WrapPanel>
+
 		<!-- Column-group toggle toolbar -->
 		<WrapPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="2,2,2,2">
 			<ToggleButton x:Name="ToggleTiming" Content="Timing" Margin="2" Padding="4,2"

--- a/src/Zametek.View.ProjectPlan/ActivityManagement/ActivitiesManagerView.axaml
+++ b/src/Zametek.View.ProjectPlan/ActivityManagement/ActivitiesManagerView.axaml
@@ -50,6 +50,20 @@
 
 	<DockPanel Margin="0">
 
+		<!-- Column-group toggle toolbar -->
+		<WrapPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="2,2,2,2">
+			<ToggleButton x:Name="ToggleTiming" Content="Timing" Margin="2" Padding="4,2"
+						  IsCheckedChanged="ToggleTiming_IsCheckedChanged" />
+			<ToggleButton x:Name="ToggleSlack" Content="Slack" Margin="2" Padding="4,2"
+						  IsCheckedChanged="ToggleSlack_IsCheckedChanged" />
+			<ToggleButton x:Name="ToggleFlags" Content="Flags" Margin="2" Padding="4,2"
+						  IsCheckedChanged="ToggleFlags_IsCheckedChanged" />
+			<ToggleButton x:Name="ToggleResourcesDetail" Content="Resources Detail" Margin="2" Padding="4,2"
+						  IsCheckedChanged="ToggleResourcesDetail_IsCheckedChanged" />
+			<ToggleButton x:Name="ToggleNotes" Content="Notes" Margin="2" Padding="4,2"
+						  IsCheckedChanged="ToggleNotes_IsCheckedChanged" />
+		</WrapPanel>
+
 		<!-- Set Background to Transparent to ensure the context menu works even when the datagrid is empty -->
 		<!-- https://github.com/AvaloniaUI/Avalonia/discussions/15118 -->
 		<DataGrid Name="ActivitiesGrid"
@@ -65,6 +79,11 @@
 				  Classes="DragAndDrop"
 				  CanUserReorderColumns="True">
 			<DataGrid.Styles>
+				<!-- Alternating row background -->
+				<Style Selector="DataGridRow:nth-child(even)">
+					<Setter Property="Background" Value="{DynamicResource ZSurface}"/>
+				</Style>
+
 				<!-- Make DataGrid a drop target -->
 				<Style Selector="DataGridRow">
 					<Setter Property="(Interaction.Behaviors)">
@@ -77,6 +96,7 @@
 				</Style>
 				<Style Selector="DataGridRow Grid.editable">
 					<Setter Property="Background" Value="{DynamicResource EditableCellGridBackgroundBrush}"/>
+					<Setter Property="Cursor" Value="Hand"/>
 				</Style>
 				<Style Selector="DataGridRow:not(:pointerover) Grid.editable">
 					<Setter Property="Background" Value="{DynamicResource EditableCellGridBackgroundBrush}"/>
@@ -391,10 +411,12 @@
 					</DataGridTemplateColumn.CellEditingTemplate>
 				</DataGridTemplateColumn>
 
-				<DataGridTemplateColumn CanUserResize="True"
+				<DataGridTemplateColumn Tag="ColResourceDependencies"
+										CanUserResize="True"
 										CanUserReorder="True"
 										CanUserSort="True"
 										IsReadOnly="True"
+										IsVisible="False"
 										CustomSortComparer="{StaticResource resourceDependenciesStringSortComparer}"
 										Width="180">
 					<DataGridTemplateColumn.HeaderTemplate>
@@ -418,10 +440,12 @@
 					</DataGridTemplateColumn.CellTemplate>
 				</DataGridTemplateColumn>
 
-				<DataGridTemplateColumn CanUserResize="True"
+				<DataGridTemplateColumn Tag="ColSuccessors"
+									CanUserResize="True"
 									CanUserReorder="True"
 									CanUserSort="True"
 									IsReadOnly="True"
+									IsVisible="False"
 									CustomSortComparer="{StaticResource successorsStringSortComparer}"
 									Width="120">
 					<DataGridTemplateColumn.HeaderTemplate>
@@ -445,10 +469,12 @@
 					</DataGridTemplateColumn.CellTemplate>
 				</DataGridTemplateColumn>
 
-				<DataGridTemplateColumn CanUserResize="True"
+				<DataGridTemplateColumn Tag="ColIsDummy"
+										CanUserResize="True"
 										CanUserReorder="True"
 										CanUserSort="True"
 										IsReadOnly="True"
+										IsVisible="False"
 										CustomSortComparer="{StaticResource isDummySortComparer}"
 										Width="85">
 					<DataGridTemplateColumn.HeaderTemplate>
@@ -474,10 +500,12 @@
 					</DataGridTemplateColumn.CellTemplate>
 				</DataGridTemplateColumn>
 
-				<DataGridTemplateColumn CanUserResize="True"
+				<DataGridTemplateColumn Tag="ColIsIsolated"
+									CanUserResize="True"
 									CanUserReorder="True"
 									CanUserSort="True"
 									IsReadOnly="True"
+									IsVisible="False"
 									CustomSortComparer="{StaticResource isIsolatedSortComparer}"
 									Width="85">
 					<DataGridTemplateColumn.HeaderTemplate>
@@ -503,10 +531,12 @@
 					</DataGridTemplateColumn.CellTemplate>
 				</DataGridTemplateColumn>
 
-				<DataGridTemplateColumn CanUserResize="True"
+				<DataGridTemplateColumn Tag="ColIsCritical"
+										CanUserResize="True"
 										CanUserReorder="True"
 										CanUserSort="True"
 										IsReadOnly="True"
+										IsVisible="False"
 										CustomSortComparer="{StaticResource isCriticalSortComparer}"
 										Width="80">
 					<DataGridTemplateColumn.HeaderTemplate>
@@ -532,10 +562,12 @@
 					</DataGridTemplateColumn.CellTemplate>
 				</DataGridTemplateColumn>
 
-				<DataGridTemplateColumn CanUserResize="True"
+				<DataGridTemplateColumn Tag="ColEarliestStartTime"
+										CanUserResize="True"
 										CanUserReorder="True"
 										CanUserSort="True"
 										IsReadOnly="True"
+										IsVisible="False"
 										CustomSortComparer="{StaticResource earliestStartTimeSortComparer}"
 										Width="80">
 					<DataGridTemplateColumn.HeaderTemplate>
@@ -567,10 +599,12 @@
 					</DataGridTemplateColumn.CellTemplate>
 				</DataGridTemplateColumn>
 
-				<DataGridTemplateColumn CanUserResize="True"
+				<DataGridTemplateColumn Tag="ColLatestStartTime"
+										CanUserResize="True"
 										CanUserReorder="True"
 										CanUserSort="True"
 										IsReadOnly="True"
+										IsVisible="False"
 										CustomSortComparer="{StaticResource latestStartTimeSortComparer}"
 										Width="80">
 					<DataGridTemplateColumn.HeaderTemplate>
@@ -602,10 +636,12 @@
 					</DataGridTemplateColumn.CellTemplate>
 				</DataGridTemplateColumn>
 
-				<DataGridTemplateColumn CanUserResize="True"
+				<DataGridTemplateColumn Tag="ColEarliestFinishTime"
+										CanUserResize="True"
 										CanUserReorder="True"
 										CanUserSort="True"
 										IsReadOnly="True"
+										IsVisible="False"
 										CustomSortComparer="{StaticResource earliestFinishTimeSortComparer}"
 										Width="80">
 					<DataGridTemplateColumn.HeaderTemplate>
@@ -637,10 +673,12 @@
 					</DataGridTemplateColumn.CellTemplate>
 				</DataGridTemplateColumn>
 
-				<DataGridTemplateColumn CanUserResize="True"
+				<DataGridTemplateColumn Tag="ColLatestFinishTime"
+										CanUserResize="True"
 										CanUserReorder="True"
 										CanUserSort="True"
 										IsReadOnly="True"
+										IsVisible="False"
 										CustomSortComparer="{StaticResource latestFinishTimeSortComparer}"
 										Width="80">
 					<DataGridTemplateColumn.HeaderTemplate>
@@ -672,10 +710,12 @@
 					</DataGridTemplateColumn.CellTemplate>
 				</DataGridTemplateColumn>
 
-				<DataGridTemplateColumn CanUserResize="True"
+				<DataGridTemplateColumn Tag="ColTotalSlack"
+										CanUserResize="True"
 										CanUserReorder="True"
 										CanUserSort="True"
 										IsReadOnly="True"
+										IsVisible="False"
 										CustomSortComparer="{StaticResource totalSlackSortComparer}"
 										Width="55">
 					<DataGridTemplateColumn.HeaderTemplate>
@@ -700,10 +740,12 @@
 					</DataGridTemplateColumn.CellTemplate>
 				</DataGridTemplateColumn>
 
-				<DataGridTemplateColumn CanUserResize="True"
+				<DataGridTemplateColumn Tag="ColFreeSlack"
+										CanUserResize="True"
 										CanUserReorder="True"
 										CanUserSort="True"
 										IsReadOnly="True"
+										IsVisible="False"
 										CustomSortComparer="{StaticResource freeSlackSortComparer}"
 										Width="55">
 					<DataGridTemplateColumn.HeaderTemplate>
@@ -728,10 +770,12 @@
 					</DataGridTemplateColumn.CellTemplate>
 				</DataGridTemplateColumn>
 
-				<DataGridTemplateColumn CanUserResize="True"
+				<DataGridTemplateColumn Tag="ColInterferingSlack"
+										CanUserResize="True"
 										CanUserReorder="True"
 										CanUserSort="True"
 										IsReadOnly="True"
+										IsVisible="False"
 										CustomSortComparer="{StaticResource interferingSlackSortComparer}"
 										Width="55">
 					<DataGridTemplateColumn.HeaderTemplate>
@@ -756,9 +800,11 @@
 					</DataGridTemplateColumn.CellTemplate>
 				</DataGridTemplateColumn>
 
-				<DataGridTemplateColumn CanUserResize="True"
+				<DataGridTemplateColumn Tag="ColMinimumFreeSlack"
+										CanUserResize="True"
 										CanUserReorder="True"
 										CanUserSort="True"
+										IsVisible="False"
 										CustomSortComparer="{StaticResource minimumFreeSlackSortComparer}"
 										Width="115">
 					<DataGridTemplateColumn.HeaderTemplate>
@@ -796,9 +842,11 @@
 					</DataGridTemplateColumn.CellEditingTemplate>
 				</DataGridTemplateColumn>
 
-				<DataGridTemplateColumn CanUserResize="True"
+				<DataGridTemplateColumn Tag="ColMinimumEarliestStartTime"
+										CanUserResize="True"
 										CanUserReorder="True"
 										CanUserSort="True"
+										IsVisible="False"
 										CustomSortComparer="{StaticResource minimumEarliestStartTimeSortComparer}"
 										Width="120">
 					<DataGridTemplateColumn.HeaderTemplate>
@@ -855,9 +903,11 @@
 					</DataGridTemplateColumn.CellEditingTemplate>
 				</DataGridTemplateColumn>
 
-				<DataGridTemplateColumn CanUserResize="True"
+				<DataGridTemplateColumn Tag="ColMaximumLatestFinishTime"
+										CanUserResize="True"
 										CanUserReorder="True"
 										CanUserSort="True"
+										IsVisible="False"
 										CustomSortComparer="{StaticResource maximumLatestFinishTimeSortComparer}"
 										Width="120">
 					<DataGridTemplateColumn.HeaderTemplate>
@@ -1021,7 +1071,8 @@
 					</DataGridTemplateColumn.CellEditingTemplate>
 				</DataGridTemplateColumn>
 
-				<DataGridTemplateColumn CanUserResize="True"
+				<DataGridTemplateColumn Tag="ColHasNoCost"
+										CanUserResize="True"
 										CanUserReorder="True"
 										CanUserSort="True"
 										IsReadOnly="True"
@@ -1053,7 +1104,8 @@
 					</DataGridTemplateColumn.CellTemplate>
 				</DataGridTemplateColumn>
 
-				<DataGridTemplateColumn CanUserResize="True"
+				<DataGridTemplateColumn Tag="ColHasNoBilling"
+										CanUserResize="True"
 										CanUserReorder="True"
 										CanUserSort="True"
 										IsReadOnly="True"
@@ -1085,10 +1137,12 @@
 					</DataGridTemplateColumn.CellTemplate>
 				</DataGridTemplateColumn>
 
-				<DataGridTemplateColumn CanUserResize="True"
+				<DataGridTemplateColumn Tag="ColHasNoEffort"
+										CanUserResize="True"
 										CanUserReorder="True"
 										CanUserSort="True"
 										IsReadOnly="True"
+										IsVisible="False"
 										CustomSortComparer="{StaticResource hasNoEffortSortComparer}"
 										Width="115">
 					<DataGridTemplateColumn.HeaderTemplate>
@@ -1116,10 +1170,12 @@
 					</DataGridTemplateColumn.CellTemplate>
 				</DataGridTemplateColumn>
 
-				<DataGridTemplateColumn CanUserResize="True"
+				<DataGridTemplateColumn Tag="ColHasNoRisk"
+										CanUserResize="True"
 										CanUserReorder="True"
 										CanUserSort="True"
 										IsReadOnly="True"
+										IsVisible="False"
 										CustomSortComparer="{StaticResource hasNoRiskSortComparer}"
 										Width="115">
 					<DataGridTemplateColumn.HeaderTemplate>
@@ -1147,9 +1203,11 @@
 					</DataGridTemplateColumn.CellTemplate>
 				</DataGridTemplateColumn>
 
-				<DataGridTemplateColumn CanUserResize="True"
+				<DataGridTemplateColumn Tag="ColTargetResourceOperator"
+										CanUserResize="True"
 										CanUserReorder="True"
 										CanUserSort="True"
+										IsVisible="False"
 										CustomSortComparer="{StaticResource targetResourceOperatorSortComparer}"
 										Width="150">
 					<DataGridTemplateColumn.HeaderTemplate>
@@ -1198,10 +1256,12 @@
 					</DataGridTemplateColumn.CellEditingTemplate>
 				</DataGridTemplateColumn>
 
-				<DataGridTemplateColumn CanUserResize="True"
+				<DataGridTemplateColumn Tag="ColAllocatedToResources"
+										CanUserResize="True"
 										CanUserReorder="True"
 										CanUserSort="True"
 										IsReadOnly="True"
+										IsVisible="False"
 										CustomSortComparer="{StaticResource allocatedToResourcesStringSortComparer}"
 										Width="165">
 					<DataGridTemplateColumn.HeaderTemplate>
@@ -1225,10 +1285,12 @@
 					</DataGridTemplateColumn.CellTemplate>
 				</DataGridTemplateColumn>
 
-				<DataGridTemplateColumn CanUserResize="True"
+				<DataGridTemplateColumn Tag="ColPercentageCompleted"
+										CanUserResize="True"
 										CanUserReorder="True"
 										CanUserSort="True"
 										IsReadOnly="True"
+										IsVisible="False"
 										CustomSortComparer="{StaticResource lastTrackerValueSortComparer}"
 										Width="95">
 					<DataGridTemplateColumn.HeaderTemplate>
@@ -1253,9 +1315,11 @@
 					</DataGridTemplateColumn.CellTemplate>
 				</DataGridTemplateColumn>
 
-				<DataGridTemplateColumn CanUserResize="True"
+				<DataGridTemplateColumn Tag="ColNotes"
+										CanUserResize="True"
 										CanUserReorder="True"
 										CanUserSort="True"
+										IsVisible="False"
 										CustomSortComparer="{StaticResource notesSortComparer}"
 										Width="120">
 					<DataGridTemplateColumn.HeaderTemplate>

--- a/src/Zametek.View.ProjectPlan/ActivityManagement/ActivitiesManagerView.axaml
+++ b/src/Zametek.View.ProjectPlan/ActivityManagement/ActivitiesManagerView.axaml
@@ -48,7 +48,7 @@
 		<local:ManagedActivitySortComparer x:Key="notesSortComparer" SortMemberPath="Notes"/>
 	</UserControl.Resources>
 
-	<DockPanel Margin="7">
+	<DockPanel Margin="0">
 
 		<!-- Set Background to Transparent to ensure the context menu works even when the datagrid is empty -->
 		<!-- https://github.com/AvaloniaUI/Avalonia/discussions/15118 -->
@@ -61,7 +61,7 @@
 				  SelectionMode="Extended"
 				  CanUserResizeColumns="True"
 				  CanUserSortColumns="True"
-				  GridLinesVisibility="All"
+				  GridLinesVisibility="Horizontal"
 				  Classes="DragAndDrop"
 				  CanUserReorderColumns="True">
 			<DataGrid.Styles>

--- a/src/Zametek.View.ProjectPlan/ActivityManagement/ActivitiesManagerView.axaml.cs
+++ b/src/Zametek.View.ProjectPlan/ActivityManagement/ActivitiesManagerView.axaml.cs
@@ -1,8 +1,10 @@
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Xaml.Interactivity;
+using ReactiveUI;
 using System;
 using System.Linq;
+using System.Reactive.Linq;
 using Zametek.Contract.ProjectPlan;
 
 namespace Zametek.View.ProjectPlan
@@ -10,9 +12,12 @@ namespace Zametek.View.ProjectPlan
     public partial class ActivitiesManagerView
         : UserControl
     {
+        private IDisposable? m_ScrollToActivitySub;
+
         public ActivitiesManagerView()
         {
             InitializeComponent();
+            AttachScrollBehavior();
         }
 
         public ActivitiesManagerView(IDataGridManager dataGridManager)
@@ -21,6 +26,38 @@ namespace Zametek.View.ProjectPlan
             InitializeComponent();
             BehaviorCollection behaviors = Interaction.GetBehaviors(ActivitiesGrid);
             behaviors.Add(new DataGridPersistBehavior(dataGridManager));
+            AttachScrollBehavior();
+        }
+
+        private void AttachScrollBehavior()
+        {
+            DataContextChanged += (_, _) =>
+            {
+                m_ScrollToActivitySub?.Dispose();
+                if (DataContext is IActivitiesManagerViewModel vm)
+                {
+                    m_ScrollToActivitySub = vm
+                        .WhenAnyValue(x => x.ScrollToActivityId)
+                        .Skip(1)
+                        .ObserveOn(RxApp.MainThreadScheduler)
+                        .Subscribe(id => ScrollGridToActivity(id));
+                }
+            };
+        }
+
+        private void ScrollGridToActivity(int activityId)
+        {
+            if (DataContext is not IActivitiesManagerViewModel vm)
+            {
+                return;
+            }
+
+            var item = vm.Activities.FirstOrDefault(a => a.Id == activityId);
+            if (item is not null)
+            {
+                ActivitiesGrid.SelectedItem = item;
+                ActivitiesGrid.ScrollIntoView(item, null);
+            }
         }
 
         /// <summary>

--- a/src/Zametek.View.ProjectPlan/ActivityManagement/ActivitiesManagerView.axaml.cs
+++ b/src/Zametek.View.ProjectPlan/ActivityManagement/ActivitiesManagerView.axaml.cs
@@ -1,6 +1,8 @@
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Xaml.Interactivity;
 using System;
+using System.Linq;
 using Zametek.Contract.ProjectPlan;
 
 namespace Zametek.View.ProjectPlan
@@ -19,6 +21,73 @@ namespace Zametek.View.ProjectPlan
             InitializeComponent();
             BehaviorCollection behaviors = Interaction.GetBehaviors(ActivitiesGrid);
             behaviors.Add(new DataGridPersistBehavior(dataGridManager));
+        }
+
+        /// <summary>
+        /// Find a DataGridColumn by its Tag string.
+        /// </summary>
+        private DataGridColumn? FindColumn(string tag) =>
+            ActivitiesGrid.Columns.FirstOrDefault(c => c.Tag?.ToString() == tag);
+
+        private void SetColumnsVisible(bool visible, params string[] tags)
+        {
+            foreach (string tag in tags)
+            {
+                DataGridColumn? col = FindColumn(tag);
+                if (col is not null)
+                {
+                    col.IsVisible = visible;
+                }
+            }
+        }
+
+        private void ToggleTiming_IsCheckedChanged(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            bool show = (sender as ToggleButton)?.IsChecked == true;
+            SetColumnsVisible(show,
+                "ColEarliestStartTime",
+                "ColLatestStartTime",
+                "ColEarliestFinishTime",
+                "ColLatestFinishTime");
+        }
+
+        private void ToggleSlack_IsCheckedChanged(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            bool show = (sender as ToggleButton)?.IsChecked == true;
+            SetColumnsVisible(show,
+                "ColTotalSlack",
+                "ColFreeSlack",
+                "ColInterferingSlack");
+        }
+
+        private void ToggleFlags_IsCheckedChanged(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            bool show = (sender as ToggleButton)?.IsChecked == true;
+            SetColumnsVisible(show,
+                "ColIsDummy",
+                "ColIsIsolated",
+                "ColIsCritical",
+                "ColHasNoEffort",
+                "ColHasNoRisk",
+                "ColHasNoCost",
+                "ColHasNoBilling");
+        }
+
+        private void ToggleResourcesDetail_IsCheckedChanged(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            bool show = (sender as ToggleButton)?.IsChecked == true;
+            SetColumnsVisible(show,
+                "ColResourceDependencies",
+                "ColAllocatedToResources",
+                "ColTargetResourceOperator");
+        }
+
+        private void ToggleNotes_IsCheckedChanged(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            bool show = (sender as ToggleButton)?.IsChecked == true;
+            SetColumnsVisible(show,
+                "ColNotes",
+                "ColPercentageCompleted");
         }
     }
 }

--- a/src/Zametek.View.ProjectPlan/GanttChartManagement/GanttChartManagerView.axaml
+++ b/src/Zametek.View.ProjectPlan/GanttChartManagement/GanttChartManagerView.axaml
@@ -17,7 +17,7 @@
     <converters:EnumToBoolConverter x:Key="enumToBool" />
   </UserControl.Resources>
 
-  <DockPanel Margin="7">
+  <DockPanel>
     <DockPanel>
       <DockPanel DockPanel.Dock="Bottom">
         <Label VerticalContentAlignment="Center"

--- a/src/Zametek.View.ProjectPlan/GanttChartManagement/GanttChartManagerView.axaml
+++ b/src/Zametek.View.ProjectPlan/GanttChartManagement/GanttChartManagerView.axaml
@@ -71,7 +71,11 @@
       <!-- ScottPlot PlotView -->
       <ContentControl x:Name="scottplot"
 							Content="{Binding GanttChartPlotModel, Mode=OneWay}"
-							Bounds="{Binding Path=ImageBounds, Mode=OneWayToSource}">
+							Bounds="{Binding Path=ImageBounds, Mode=OneWayToSource}"
+							HorizontalAlignment="Stretch"
+							VerticalAlignment="Stretch"
+							HorizontalContentAlignment="Stretch"
+							VerticalContentAlignment="Stretch">
         <ContentControl.ContextMenu>
           <ContextMenu>
             <MenuItem Header="{x:Static resources:Labels.Label_ShowGroupLabels}"
@@ -82,6 +86,10 @@
             <MenuItem Header="{x:Static resources:Labels.Label_ShowSlack}"
 								  IsEnabled="{Binding Path=IsAnnotated, Mode=OneWay}"
 								  IsChecked="{Binding Path=ShowSlack, Mode=TwoWay}"
+								  ToggleType="CheckBox" />
+
+            <MenuItem Header="{x:Static resources:Labels.Label_ShowAllConnections}"
+								  IsChecked="{Binding Path=ShowAllConnections, Mode=TwoWay}"
 								  ToggleType="CheckBox" />
 
             <MenuItem Header="{x:Static resources:Labels.Label_ShowProjectFinish}"

--- a/src/Zametek.View.ProjectPlan/GanttChartManagement/GanttChartManagerView.axaml.cs
+++ b/src/Zametek.View.ProjectPlan/GanttChartManagement/GanttChartManagerView.axaml.cs
@@ -20,6 +20,10 @@ namespace Zametek.View.ProjectPlan
         private AnnotatedBar? m_DragBar;
         private VerticalLine? m_DragPreviewLine;
 
+        // State for Ctrl+drag dependency creation.
+        private int m_DepSourceActivityId;
+        private AnnotatedBar? m_DepSourceBar;
+
         public GanttChartManagerView()
         {
             InitializeComponent();
@@ -181,6 +185,85 @@ namespace Zametek.View.ProjectPlan
                 m_DragBar = null;
                 plotModel.Refresh();
 
+                e.Pointer.Capture(null);
+                e.Handled = true;
+            }
+        }
+
+        /// <summary>
+        /// Hit-test: is the pixel position inside any annotated activity bar?
+        /// </summary>
+        private AnnotatedBar? HitTestBar(AvaPlot plotModel, Point plotPosition)
+        {
+            BarPlot? barPlot = plotModel.Plot.GetPlottables<BarPlot>().FirstOrDefault();
+            if (barPlot is null)
+            {
+                return null;
+            }
+
+            Pixel mousePixel = new(plotPosition.X, plotPosition.Y);
+            Coordinates mouseCoord = plotModel.Plot.GetCoordinates(mousePixel);
+
+            foreach (Bar bar in barPlot.Bars)
+            {
+                if (bar is not AnnotatedBar annotatedBar || annotatedBar.ActivityId == 0)
+                {
+                    continue;
+                }
+
+                if (bar.Rect.Contains(mouseCoord))
+                {
+                    return annotatedBar;
+                }
+            }
+
+            return null;
+        }
+
+        protected override void OnCtrlLeftDragStart(AvaPlot plotModel, Point plotPosition, PointerPressedEventArgs e)
+        {
+            AnnotatedBar? hit = HitTestBar(plotModel, plotPosition);
+            if (hit is null)
+            {
+                return;
+            }
+
+            m_DepSourceActivityId = hit.ActivityId;
+            m_DepSourceBar = hit;
+            e.Pointer.Capture(scottplot);
+            e.Handled = true;
+        }
+
+        protected override void OnCtrlLeftDragging(AvaPlot plotModel, Point plotPosition, PointerEventArgs e)
+        {
+            // No live preview for simplicity — cursor change is sufficient feedback.
+            e.Handled = true;
+        }
+
+        protected override void OnCtrlLeftDragCompleted(AvaPlot plotModel, Point plotPosition, PointerReleasedEventArgs e)
+        {
+            try
+            {
+                if (m_DepSourceActivityId == 0)
+                {
+                    return;
+                }
+
+                AnnotatedBar? targetBar = HitTestBar(plotModel, plotPosition);
+                if (targetBar is null || targetBar.ActivityId == m_DepSourceActivityId)
+                {
+                    return;
+                }
+
+                if (DataContext is IGanttChartManagerViewModel vm)
+                {
+                    vm.AddActivityDependency(m_DepSourceActivityId, targetBar.ActivityId);
+                }
+            }
+            finally
+            {
+                m_DepSourceActivityId = 0;
+                m_DepSourceBar = null;
                 e.Pointer.Capture(null);
                 e.Handled = true;
             }

--- a/src/Zametek.View.ProjectPlan/GanttChartManagement/GanttChartManagerView.axaml.cs
+++ b/src/Zametek.View.ProjectPlan/GanttChartManagement/GanttChartManagerView.axaml.cs
@@ -1,12 +1,228 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using ScottPlot;
+using ScottPlot.Avalonia;
+using ScottPlot.Plottables;
+using System.Linq;
+using Zametek.Contract.ProjectPlan;
+using Zametek.ViewModel.ProjectPlan;
+
 namespace Zametek.View.ProjectPlan
 {
     public partial class GanttChartManagerView
         : ScottPlotUserControl
     {
+        // Within this many pixels of the right edge of a bar counts as a resize handle.
+        private const double c_RightEdgeHitPixels = 8.0;
+
+        // State for the active bar resize drag.
+        private AnnotatedBar? m_DragBar;
+        private VerticalLine? m_DragPreviewLine;
+
         public GanttChartManagerView()
         {
             InitializeComponent();
             InitializePlotContainer(scottplot);
+        }
+
+        /// <summary>
+        /// Returns the AvaPlot embedded in the scottplot ContentControl, or null.
+        /// </summary>
+        private AvaPlot? GetPlotModel() =>
+            scottplot.Content as AvaPlot;
+
+        /// <summary>
+        /// Hit-test: is the pixel position within <see cref="c_RightEdgeHitPixels"/> of the right edge
+        /// of any annotated activity bar?
+        /// </summary>
+        private AnnotatedBar? HitTestRightEdge(AvaPlot plotModel, Point plotPosition)
+        {
+            BarPlot? barPlot = plotModel.Plot.GetPlottables<BarPlot>().FirstOrDefault();
+            if (barPlot is null)
+            {
+                return null;
+            }
+
+            Pixel mousePixel = new(plotPosition.X, plotPosition.Y);
+
+            foreach (Bar bar in barPlot.Bars)
+            {
+                if (bar is not AnnotatedBar annotatedBar || annotatedBar.ActivityId == 0)
+                {
+                    continue;
+                }
+
+                // Get the pixel coordinate of the bar's right edge (bar.Value is the right end in data coords).
+                Pixel rightEdgePixel = plotModel.Plot.GetPixel(new Coordinates(annotatedBar.Value, annotatedBar.Position));
+
+                double dx = mousePixel.X - rightEdgePixel.X;
+                double dy = mousePixel.Y - rightEdgePixel.Y;
+                double distX = System.Math.Abs(dx);
+
+                // Only trigger if within the pixel threshold horizontally, and within the bar height vertically.
+                // Bar height in pixels: Size is in data units on the Y axis, convert to pixels.
+                Pixel topPixel = plotModel.Plot.GetPixel(
+                    new Coordinates(annotatedBar.Value, annotatedBar.Position + annotatedBar.Size / 2.0));
+                Pixel bottomPixel = plotModel.Plot.GetPixel(
+                    new Coordinates(annotatedBar.Value, annotatedBar.Position - annotatedBar.Size / 2.0));
+
+                double barPixelHeight = System.Math.Abs(topPixel.Y - bottomPixel.Y);
+                double distY = System.Math.Abs(dy);
+
+                if (distX <= c_RightEdgeHitPixels && distY <= barPixelHeight / 2.0)
+                {
+                    return annotatedBar;
+                }
+            }
+
+            return null;
+        }
+
+        protected override void OnLeftPointerPressed(AvaPlot plotModel, Point plotPosition, PointerPressedEventArgs e)
+        {
+            AnnotatedBar? hit = HitTestRightEdge(plotModel, plotPosition);
+            if (hit is null)
+            {
+                return;
+            }
+
+            m_DragBar = hit;
+
+            // Add a preview vertical line at the current right edge.
+            m_DragPreviewLine = plotModel.Plot.Add.VerticalLine(
+                hit.Value,
+                width: 2,
+                pattern: ScottPlot.LinePattern.Dashed);
+
+            plotModel.Refresh();
+
+            // Capture so we keep receiving events.
+            e.Pointer.Capture(scottplot);
+            e.Handled = true;
+        }
+
+        protected override void OnLeftDragging(AvaPlot plotModel, Point plotPosition, PointerEventArgs e)
+        {
+            if (m_DragBar is null || m_DragPreviewLine is null)
+            {
+                return;
+            }
+
+            Pixel mousePixel = new(plotPosition.X, plotPosition.Y);
+            Coordinates mouseCoord = plotModel.Plot.GetCoordinates(mousePixel);
+
+            // Compute how many days the new right edge represents.
+            int newDuration = ComputeNewDuration(mouseCoord.X, m_DragBar);
+            if (newDuration < 1)
+            {
+                newDuration = 1;
+            }
+
+            // Move preview line to the snapped position.
+            double snappedX = m_DragBar.ValueBase + (mouseCoord.X - m_DragBar.ValueBase);
+            // Snap to nearest integer day by re-deriving x from newDuration.
+            double snappedDataX = DurationToDataX(m_DragBar, newDuration, m_DragBar.ValueBase);
+
+            m_DragPreviewLine.X = snappedDataX;
+            plotModel.Refresh();
+
+            e.Handled = true;
+        }
+
+        protected override void OnLeftPointerReleased(AvaPlot plotModel, Point plotPosition, PointerReleasedEventArgs e)
+        {
+            // Click without drag: discard any pending bar state.
+            if (m_DragPreviewLine is not null)
+            {
+                plotModel.Plot.Remove(m_DragPreviewLine);
+                m_DragPreviewLine = null;
+                plotModel.Refresh();
+            }
+
+            m_DragBar = null;
+        }
+
+        protected override void OnLeftDragCompleted(AvaPlot plotModel, Point plotPosition, PointerReleasedEventArgs e)
+        {
+            if (m_DragBar is null)
+            {
+                return;
+            }
+
+            try
+            {
+                Pixel mousePixel = new(plotPosition.X, plotPosition.Y);
+                Coordinates mouseCoord = plotModel.Plot.GetCoordinates(mousePixel);
+
+                int newDuration = ComputeNewDuration(mouseCoord.X, m_DragBar);
+                if (newDuration < 1)
+                {
+                    newDuration = 1;
+                }
+
+                int activityId = m_DragBar.ActivityId;
+
+                // Commit to ViewModel.
+                if (DataContext is IGanttChartManagerViewModel vm)
+                {
+                    vm.SetActivityDuration(activityId, newDuration);
+                }
+            }
+            finally
+            {
+                // Remove preview line.
+                if (m_DragPreviewLine is not null)
+                {
+                    plotModel.Plot.Remove(m_DragPreviewLine);
+                    m_DragPreviewLine = null;
+                }
+
+                m_DragBar = null;
+                plotModel.Refresh();
+
+                e.Pointer.Capture(null);
+                e.Handled = true;
+            }
+        }
+
+        /// <summary>
+        /// Converts a new right-edge X data coordinate into an integer duration (days),
+        /// using the bar's original data-units-per-day ratio.
+        /// </summary>
+        private static int ComputeNewDuration(double newRightX, AnnotatedBar bar)
+        {
+            if (bar.ActivityDuration <= 0)
+            {
+                return 1;
+            }
+
+            double originalDataWidth = bar.Value - bar.ValueBase;
+            if (System.Math.Abs(originalDataWidth) < double.Epsilon)
+            {
+                return 1;
+            }
+
+            double dataPerDay = originalDataWidth / bar.ActivityDuration;
+            double newDataWidth = newRightX - bar.ValueBase;
+            int newDuration = (int)System.Math.Round(newDataWidth / dataPerDay);
+
+            return newDuration;
+        }
+
+        /// <summary>
+        /// Given a duration (days), compute what the right-edge X data coordinate should be.
+        /// </summary>
+        private static double DurationToDataX(AnnotatedBar bar, int duration, double leftX)
+        {
+            if (bar.ActivityDuration <= 0)
+            {
+                return leftX + duration;
+            }
+
+            double originalDataWidth = bar.Value - bar.ValueBase;
+            double dataPerDay = originalDataWidth / bar.ActivityDuration;
+            return leftX + (duration * dataPerDay);
         }
     }
 }

--- a/src/Zametek.View.ProjectPlan/GanttChartManagement/GanttChartManagerView.axaml.cs
+++ b/src/Zametek.View.ProjectPlan/GanttChartManagement/GanttChartManagerView.axaml.cs
@@ -91,10 +91,11 @@ namespace Zametek.View.ProjectPlan
             {
                 m_DragBar = hit;
                 // Preview line is deferred to first OnLeftDragging call so a plain click leaves no artifact.
-                // Capture to the AvaPlot (not the ContentControl wrapper) so ScottPlot still receives
-                // its own release event via bubbling — capturing to the parent ContentControl bypasses
-                // AvaPlot on release, leaving ScottPlot permanently in "button held" state.
-                e.Pointer.Capture(plotModel);
+                // Capture to the ContentControl so our PointerMoved handler keeps firing for the full drag,
+                // even if the pointer leaves the AvaPlot bounds. ScottPlot never enters pan mode because
+                // PointerPressed is intercepted via Tunnel routing in ScottPlotUserControl before it reaches
+                // AvaPlot — so there is no "sticky pan" state to worry about on release.
+                e.Pointer.Capture(m_PlotContainer);
             }
 
             // Always claim left-click so ScottPlot never enters its own pan mode.
@@ -259,7 +260,7 @@ namespace Zametek.View.ProjectPlan
 
             m_DepSourceActivityId = hit.ActivityId;
             m_DepSourceBar = hit;
-            e.Pointer.Capture(plotModel); // Capture to AvaPlot so ScottPlot still gets its release via bubbling.
+            e.Pointer.Capture(m_PlotContainer);
             e.Handled = true;
             return true;
         }

--- a/src/Zametek.View.ProjectPlan/GanttChartManagement/GanttChartManagerView.axaml.cs
+++ b/src/Zametek.View.ProjectPlan/GanttChartManagement/GanttChartManagerView.axaml.cs
@@ -1,6 +1,7 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
+using AvaloniaCursor = Avalonia.Input.Cursor;
 using ScottPlot;
 using ScottPlot.Avalonia;
 using ScottPlot.Plottables;
@@ -83,34 +84,38 @@ namespace Zametek.View.ProjectPlan
             return null;
         }
 
-        protected override void OnLeftPointerPressed(AvaPlot plotModel, Point plotPosition, PointerPressedEventArgs e)
+        protected override bool OnLeftPointerPressed(AvaPlot plotModel, Point plotPosition, PointerPressedEventArgs e)
         {
             AnnotatedBar? hit = HitTestRightEdge(plotModel, plotPosition);
-            if (hit is null)
+            if (hit is not null)
             {
-                return;
+                m_DragBar = hit;
+                // Preview line is deferred to first OnLeftDragging call so a plain click leaves no artifact.
+                // Capture to the AvaPlot (not the ContentControl wrapper) so ScottPlot still receives
+                // its own release event via bubbling — capturing to the parent ContentControl bypasses
+                // AvaPlot on release, leaving ScottPlot permanently in "button held" state.
+                e.Pointer.Capture(plotModel);
             }
 
-            m_DragBar = hit;
-
-            // Add a preview vertical line at the current right edge.
-            m_DragPreviewLine = plotModel.Plot.Add.VerticalLine(
-                hit.Value,
-                width: 2,
-                pattern: ScottPlot.LinePattern.Dashed);
-
-            plotModel.Refresh();
-
-            // Capture so we keep receiving events.
-            e.Pointer.Capture(scottplot);
+            // Always claim left-click so ScottPlot never enters its own pan mode.
             e.Handled = true;
+            return true;
         }
 
         protected override void OnLeftDragging(AvaPlot plotModel, Point plotPosition, PointerEventArgs e)
         {
-            if (m_DragBar is null || m_DragPreviewLine is null)
+            if (m_DragBar is null)
             {
                 return;
+            }
+
+            // Add the preview line on the first dragging call (not on press, so clicks are clean).
+            if (m_DragPreviewLine is null)
+            {
+                m_DragPreviewLine = plotModel.Plot.Add.VerticalLine(
+                    m_DragBar.Value,
+                    width: 2,
+                    pattern: ScottPlot.LinePattern.Dashed);
             }
 
             Pixel mousePixel = new(plotPosition.X, plotPosition.Y);
@@ -142,6 +147,13 @@ namespace Zametek.View.ProjectPlan
                 plotModel.Plot.Remove(m_DragPreviewLine);
                 m_DragPreviewLine = null;
                 plotModel.Refresh();
+            }
+
+            if (m_DragBar is not null)
+            {
+                // Capture was set in OnLeftPointerPressed — must release it here,
+                // otherwise subsequent clicks (e.g. double-click) are routed incorrectly.
+                e.Pointer.Capture(null);
             }
 
             m_DragBar = null;
@@ -190,6 +202,23 @@ namespace Zametek.View.ProjectPlan
             }
         }
 
+        protected override AvaloniaCursor? GetHoverCursor(AvaPlot plotModel, Point plotPosition)
+        {
+            // Resize handle: near the right edge of any bar.
+            if (HitTestRightEdge(plotModel, plotPosition) is not null)
+            {
+                return new AvaloniaCursor(StandardCursorType.SizeWestEast);
+            }
+
+            // Hand cursor: hovering over the body of any bar (Ctrl+drag to create dependency).
+            if (HitTestBar(plotModel, plotPosition) is not null)
+            {
+                return new AvaloniaCursor(StandardCursorType.Hand);
+            }
+
+            return AvaloniaCursor.Default;
+        }
+
         /// <summary>
         /// Hit-test: is the pixel position inside any annotated activity bar?
         /// </summary>
@@ -220,18 +249,19 @@ namespace Zametek.View.ProjectPlan
             return null;
         }
 
-        protected override void OnCtrlLeftDragStart(AvaPlot plotModel, Point plotPosition, PointerPressedEventArgs e)
+        protected override bool OnCtrlLeftDragStart(AvaPlot plotModel, Point plotPosition, PointerPressedEventArgs e)
         {
             AnnotatedBar? hit = HitTestBar(plotModel, plotPosition);
             if (hit is null)
             {
-                return;
+                return false;
             }
 
             m_DepSourceActivityId = hit.ActivityId;
             m_DepSourceBar = hit;
-            e.Pointer.Capture(scottplot);
+            e.Pointer.Capture(plotModel); // Capture to AvaPlot so ScottPlot still gets its release via bubbling.
             e.Handled = true;
+            return true;
         }
 
         protected override void OnCtrlLeftDragging(AvaPlot plotModel, Point plotPosition, PointerEventArgs e)

--- a/src/Zametek.View.ProjectPlan/GraphManagement/ArrowGraphManagerView.axaml.cs
+++ b/src/Zametek.View.ProjectPlan/GraphManagement/ArrowGraphManagerView.axaml.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using System;
+using Zametek.Contract.ProjectPlan;
 
 namespace Zametek.View.ProjectPlan
 {
@@ -19,6 +20,18 @@ namespace Zametek.View.ProjectPlan
         {
             InitializeComponent();
         }
+
+        // Converts a pointer position (relative to the ScrollViewer) into SVG coordinate space.
+        private Point ToSvgPoint(ScrollViewer scrollViewer, Point pointerInViewer)
+        {
+            double zoom = zoomer.Value;
+            double svgX = (scrollViewer.Offset.X + pointerInViewer.X) / zoom;
+            double svgY = (scrollViewer.Offset.Y + pointerInViewer.Y) / zoom;
+            return new Point(svgX, svgY);
+        }
+
+        private IArrowGraphManagerViewModel? GetViewModel() =>
+            DataContext as IArrowGraphManagerViewModel;
 
         private void ScrollViewer_PointerMoved(object? sender, PointerEventArgs e)
         {
@@ -37,6 +50,25 @@ namespace Zametek.View.ProjectPlan
                         double dY = posNow.Y - m_LastDragPoint.Value.Y;
                         m_LastDragPoint = posNow;
                         scrollViewer.Offset = new Vector(scrollViewer.Offset.X - dX, scrollViewer.Offset.Y - dY);
+                    }
+                }
+                else
+                {
+                    // Change cursor to hand when hovering over an edge label.
+                    IArrowGraphManagerViewModel? vm = GetViewModel();
+                    if (vm is not null)
+                    {
+                        Point svgPt = ToSvgPoint(scrollViewer, posNow);
+                        bool overLabel = false;
+                        foreach (GraphEdgeHitRect rect in vm.EdgeHitRects)
+                        {
+                            if (rect.Contains(svgPt.X, svgPt.Y))
+                            {
+                                overLabel = true;
+                                break;
+                            }
+                        }
+                        scrollViewer.Cursor = new Cursor(overLabel ? StandardCursorType.Hand : StandardCursorType.Arrow);
                     }
                 }
             }
@@ -65,6 +97,22 @@ namespace Zametek.View.ProjectPlan
                 if (pointer.X <= scrollViewer.Viewport.Width
                     && pointer.Y < scrollViewer.Viewport.Height) //make sure we still can use the scrollbars
                 {
+                    // Check if click lands on an edge label hit rect — if so, navigate rather than pan.
+                    IArrowGraphManagerViewModel? vm = GetViewModel();
+                    if (vm is not null)
+                    {
+                        Point svgPt = ToSvgPoint(scrollViewer, pointer);
+                        foreach (GraphEdgeHitRect rect in vm.EdgeHitRects)
+                        {
+                            if (rect.Contains(svgPt.X, svgPt.Y))
+                            {
+                                vm.NavigateToActivity(rect.ActivityId);
+                                e.Handled = true;
+                                return;
+                            }
+                        }
+                    }
+
                     scrollViewer.Cursor = new Cursor(StandardCursorType.SizeAll);
                     m_LastDragPoint = pointer;
                 }

--- a/src/Zametek.View.ProjectPlan/GraphManagement/VertexGraphManagerView.axaml.cs
+++ b/src/Zametek.View.ProjectPlan/GraphManagement/VertexGraphManagerView.axaml.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using System;
+using Zametek.Contract.ProjectPlan;
 
 namespace Zametek.View.ProjectPlan
 {
@@ -19,6 +20,19 @@ namespace Zametek.View.ProjectPlan
         {
             InitializeComponent();
         }
+
+        // Converts a pointer position (relative to the ScrollViewer) into SVG coordinate space.
+        private Point ToSvgPoint(ScrollViewer scrollViewer, Point pointerInViewer)
+        {
+            double zoom = zoomer.Value;
+            // Pointer in viewer = (scrollOffset + pointerInViewer) / zoom gives the unscaled image coordinate.
+            double svgX = (scrollViewer.Offset.X + pointerInViewer.X) / zoom;
+            double svgY = (scrollViewer.Offset.Y + pointerInViewer.Y) / zoom;
+            return new Point(svgX, svgY);
+        }
+
+        private IVertexGraphManagerViewModel? GetViewModel() =>
+            DataContext as IVertexGraphManagerViewModel;
 
         private void ScrollViewer_PointerMoved(object? sender, PointerEventArgs e)
         {
@@ -37,6 +51,25 @@ namespace Zametek.View.ProjectPlan
                         double dY = posNow.Y - m_LastDragPoint.Value.Y;
                         m_LastDragPoint = posNow;
                         scrollViewer.Offset = new Vector(scrollViewer.Offset.X - dX, scrollViewer.Offset.Y - dY);
+                    }
+                }
+                else
+                {
+                    // Change cursor to hand when hovering over a node.
+                    IVertexGraphManagerViewModel? vm = GetViewModel();
+                    if (vm is not null)
+                    {
+                        Point svgPt = ToSvgPoint(scrollViewer, posNow);
+                        bool overNode = false;
+                        foreach (GraphNodeHitRect rect in vm.NodeHitRects)
+                        {
+                            if (rect.Contains(svgPt.X, svgPt.Y))
+                            {
+                                overNode = true;
+                                break;
+                            }
+                        }
+                        scrollViewer.Cursor = new Cursor(overNode ? StandardCursorType.Hand : StandardCursorType.Arrow);
                     }
                 }
             }
@@ -65,6 +98,22 @@ namespace Zametek.View.ProjectPlan
                 if (pointer.X <= scrollViewer.Viewport.Width
                     && pointer.Y < scrollViewer.Viewport.Height) //make sure we still can use the scrollbars
                 {
+                    // Check if click lands on a node hit rect — if so, navigate rather than pan.
+                    IVertexGraphManagerViewModel? vm = GetViewModel();
+                    if (vm is not null)
+                    {
+                        Point svgPt = ToSvgPoint(scrollViewer, pointer);
+                        foreach (GraphNodeHitRect rect in vm.NodeHitRects)
+                        {
+                            if (rect.Contains(svgPt.X, svgPt.Y))
+                            {
+                                vm.NavigateToActivity(rect.ActivityId);
+                                e.Handled = true;
+                                return;
+                            }
+                        }
+                    }
+
                     scrollViewer.Cursor = new Cursor(StandardCursorType.SizeAll);
                     m_LastDragPoint = pointer;
                 }

--- a/src/Zametek.View.ProjectPlan/HomeView.axaml
+++ b/src/Zametek.View.ProjectPlan/HomeView.axaml
@@ -18,6 +18,8 @@
 
     <!-- Left: Activities DataGrid -->
     <ContentControl Grid.Column="0"
+                    HorizontalContentAlignment="Stretch"
+                    VerticalContentAlignment="Stretch"
                     Content="{Binding ActivitiesManagerViewModel, Mode=OneWay}" />
 
     <!-- Splitter -->
@@ -29,6 +31,8 @@
 
     <!-- Right: Gantt Chart -->
     <ContentControl Grid.Column="2"
+                    HorizontalContentAlignment="Stretch"
+                    VerticalContentAlignment="Stretch"
                     Content="{Binding GanttChartManagerViewModel, Mode=OneWay}" />
   </Grid>
 </UserControl>

--- a/src/Zametek.View.ProjectPlan/HomeView.axaml
+++ b/src/Zametek.View.ProjectPlan/HomeView.axaml
@@ -1,0 +1,34 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:local="using:Zametek.View.ProjectPlan"
+             xmlns:vm="using:Zametek.ViewModel.ProjectPlan"
+             x:DataType="vm:MainViewModel"
+             mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="700"
+             x:Class="Zametek.View.ProjectPlan.HomeView">
+
+  <!-- Split: Activities (left 40%) | Gantt (right 60%) -->
+  <Grid>
+    <Grid.ColumnDefinitions>
+      <ColumnDefinition Width="2*" />
+      <ColumnDefinition Width="Auto" />
+      <ColumnDefinition Width="3*" />
+    </Grid.ColumnDefinitions>
+
+    <!-- Left: Activities DataGrid -->
+    <ContentControl Grid.Column="0"
+                    Content="{Binding ActivitiesManagerViewModel, Mode=OneWay}" />
+
+    <!-- Splitter -->
+    <GridSplitter Grid.Column="1"
+                  Width="4"
+                  HorizontalAlignment="Center"
+                  VerticalAlignment="Stretch"
+                  Background="{DynamicResource ZBorder}" />
+
+    <!-- Right: Gantt Chart -->
+    <ContentControl Grid.Column="2"
+                    Content="{Binding GanttChartManagerViewModel, Mode=OneWay}" />
+  </Grid>
+</UserControl>

--- a/src/Zametek.View.ProjectPlan/HomeView.axaml.cs
+++ b/src/Zametek.View.ProjectPlan/HomeView.axaml.cs
@@ -1,0 +1,13 @@
+using Avalonia.Controls;
+
+namespace Zametek.View.ProjectPlan
+{
+    public partial class HomeView
+        : UserControl
+    {
+        public HomeView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/Zametek.View.ProjectPlan/MainView.axaml
+++ b/src/Zametek.View.ProjectPlan/MainView.axaml
@@ -43,7 +43,13 @@
 			<Setter Property="BorderBrush" Value="Transparent"/>
 		</Style>
 		<Style Selector="Border.error">
-			<Setter Property="BorderBrush" Value="Red"/>
+			<Setter Property="BorderBrush" Value="#FFDC2626"/>
+		</Style>
+		<!-- Status bar label: muted caption weight -->
+		<Style Selector="DockPanel Label.status-label">
+			<Setter Property="FontSize" Value="11"/>
+			<Setter Property="Opacity" Value="0.7"/>
+			<Setter Property="VerticalContentAlignment" Value="Center"/>
 		</Style>
 	</Window.Styles>
 
@@ -300,46 +306,52 @@
 					</MenuItem>
 				</Menu>
 
-				<DockPanel DockPanel.Dock="Bottom"
-						   Margin="0">
+				<Border DockPanel.Dock="Bottom"
+						BorderThickness="0,1,0,0"
+						BorderBrush="{DynamicResource SemiColorBorder}"
+						Padding="0,4,0,4">
+					<DockPanel Margin="0">
 
-					<Label DockPanel.Dock="Left"
-						   IsTabStop="False"
-						   Content="{x:Static resources:Labels.Label_ProjectStart}"
-						   VerticalContentAlignment="Center"
-						   Height="25"
-						   Margin="0,0,7,0"/>
-					<DatePicker DockPanel.Dock="Left"
-								SelectedDate="{Binding Path=ProjectStart, Mode=TwoWay}"
-								Margin="0,0,11,0"
-								Padding="3"
-								Focusable="True"
-								DayFormat="d (ddd)"
-								DayVisible="True"
-								MonthVisible="True"
-								YearVisible="True"
-								VerticalAlignment="Center"/>
+						<Label DockPanel.Dock="Left"
+							   IsTabStop="False"
+							   Classes="status-label"
+							   Content="{x:Static resources:Labels.Label_ProjectStart}"
+							   VerticalContentAlignment="Center"
+							   Height="25"
+							   Margin="4,0,4,0"/>
+						<DatePicker DockPanel.Dock="Left"
+									SelectedDate="{Binding Path=ProjectStart, Mode=TwoWay}"
+									Margin="0,0,12,0"
+									Padding="3"
+									Focusable="True"
+									DayFormat="d (ddd)"
+									DayVisible="True"
+									MonthVisible="True"
+									YearVisible="True"
+									VerticalAlignment="Center"/>
 
-					<Label DockPanel.Dock="Left"
-						   IsTabStop="False"
-						   Content="{x:Static resources:Labels.Label_Today}"
-						   VerticalContentAlignment="Center"
-						   Height="25"
-						   Margin="0,0,7,0"/>
+						<Label DockPanel.Dock="Left"
+							   IsTabStop="False"
+							   Classes="status-label"
+							   Content="{x:Static resources:Labels.Label_Today}"
+							   VerticalContentAlignment="Center"
+							   Height="25"
+							   Margin="4,0,4,0"/>
 
-					<DatePicker DockPanel.Dock="Left"
-								SelectedDate="{Binding Path=Today, Mode=TwoWay}"
-								Margin="0,0,11,0"
-								Padding="3"
-								Focusable="True"
-								DayFormat="d (ddd)"
-								DayVisible="True"
-								MonthVisible="True"
-								YearVisible="True"
-								VerticalAlignment="Center"/>
+						<DatePicker DockPanel.Dock="Left"
+									SelectedDate="{Binding Path=Today, Mode=TwoWay}"
+									Margin="0,0,12,0"
+									Padding="3"
+									Focusable="True"
+									DayFormat="d (ddd)"
+									DayVisible="True"
+									MonthVisible="True"
+									YearVisible="True"
+									VerticalAlignment="Center"/>
 
-					<Grid />
-				</DockPanel>
+						<Grid />
+					</DockPanel>
+				</Border>
 
 				<idc:DockControl Layout="{Binding Path=Layout, Mode=OneWay}"
 								 DockProperties.IsDragEnabled="False" />

--- a/src/Zametek.View.ProjectPlan/MainView.axaml
+++ b/src/Zametek.View.ProjectPlan/MainView.axaml
@@ -39,47 +39,50 @@
 	</Window.KeyBindings>
 
 	<Window.Styles>
-		<Style Selector="Border.ok">
-			<Setter Property="BorderBrush" Value="Transparent"/>
+		<!-- Error indicator: thin top accent bar -->
+		<Style Selector="Border.compile-ok">
+			<Setter Property="Background" Value="Transparent"/>
 		</Style>
-		<Style Selector="Border.error">
-			<Setter Property="BorderBrush" Value="#FFDC2626"/>
-		</Style>
-		<!-- Status bar label: muted caption weight -->
-		<Style Selector="DockPanel Label.status-label">
-			<Setter Property="FontSize" Value="11"/>
-			<Setter Property="Opacity" Value="0.7"/>
-			<Setter Property="VerticalContentAlignment" Value="Center"/>
+		<Style Selector="Border.compile-error">
+			<Setter Property="Background" Value="{DynamicResource ZError}"/>
 		</Style>
 	</Window.Styles>
 
 	<u:LoadingContainer IsLoading="{Binding Path=IsBusy, Mode=OneWay}"
 						LoadingMessage="{x:Static resources:Labels.Label_PleaseWait}"
 						Name="LoadingPanel">
-		<Border BorderThickness="3">
-			<Classes.ok>
-				<MultiBinding Converter="{x:Static BoolConverters.And}">
-					<MultiBinding.Bindings>
-						<Binding Path="!HasCompilationErrors" Mode="OneWay"/>
-						<Binding Path="!HasStaleOutputs" Mode="OneWay"/>
-					</MultiBinding.Bindings>
-				</MultiBinding>
-			</Classes.ok>
+		<DockPanel IsEnabled="{Binding Path=!IsBusy, Mode=OneWay}"
+				   Background="{DynamicResource ZBackground}">
 
-			<Classes.error>
-				<MultiBinding Converter="{x:Static BoolConverters.Or}">
-					<MultiBinding.Bindings>
-						<Binding Path="HasCompilationErrors" Mode="OneWay"/>
-						<Binding Path="HasStaleOutputs" Mode="OneWay"/>
-					</MultiBinding.Bindings>
-				</MultiBinding>
-			</Classes.error>
+			<!-- Thin error indicator bar at the very top -->
+			<Border DockPanel.Dock="Top"
+					Height="3">
+				<Classes.compile-ok>
+					<MultiBinding Converter="{x:Static BoolConverters.And}">
+						<MultiBinding.Bindings>
+							<Binding Path="!HasCompilationErrors" Mode="OneWay"/>
+							<Binding Path="!HasStaleOutputs" Mode="OneWay"/>
+						</MultiBinding.Bindings>
+					</MultiBinding>
+				</Classes.compile-ok>
+				<Classes.compile-error>
+					<MultiBinding Converter="{x:Static BoolConverters.Or}">
+						<MultiBinding.Bindings>
+							<Binding Path="HasCompilationErrors" Mode="OneWay"/>
+							<Binding Path="HasStaleOutputs" Mode="OneWay"/>
+						</MultiBinding.Bindings>
+					</MultiBinding>
+				</Classes.compile-error>
+			</Border>
 
-			<DockPanel Margin="7"
-					   IsEnabled="{Binding Path=!IsBusy, Mode=OneWay}">
-				<Menu DockPanel.Dock="Top"
-					  HorizontalAlignment="Left"
-					  Padding="0">
+			<!-- Menu bar with clean bottom border -->
+			<Border DockPanel.Dock="Top"
+					Background="{DynamicResource ZToolbarBg}"
+					BorderThickness="0,0,0,1"
+					BorderBrush="{DynamicResource ZBorder}">
+				<Menu HorizontalAlignment="Left"
+					  Padding="4,0"
+					  Height="36">
 					<MenuItem Header="{x:Static resources:Menus.Menu_File}">
 						<MenuItem Header="{x:Static resources:Menus.Menu_Open}"
 								  Command="{Binding Path=OpenProjectFileCommand, Mode=OneWay}"
@@ -305,57 +308,57 @@
 						</MenuItem>
 					</MenuItem>
 				</Menu>
+			</Border>
 
-				<Border DockPanel.Dock="Bottom"
-						BorderThickness="0,1,0,0"
-						BorderBrush="{DynamicResource SemiColorBorder}"
-						Padding="0,4,0,4">
-					<DockPanel Margin="0">
+			<!-- Status bar: 30px, subtle background, 11px muted labels -->
+			<Border DockPanel.Dock="Bottom"
+					Height="30"
+					Background="{DynamicResource ZStatusBar}"
+					BorderThickness="0,1,0,0"
+					BorderBrush="{DynamicResource ZBorder}">
+				<DockPanel VerticalAlignment="Center"
+						   Margin="8,0">
+					<Label DockPanel.Dock="Left"
+						   IsTabStop="False"
+						   Classes="status-label"
+						   Content="{x:Static resources:Labels.Label_ProjectStart}"
+						   VerticalContentAlignment="Center"
+						   Margin="0,0,4,0"/>
+					<DatePicker DockPanel.Dock="Left"
+								SelectedDate="{Binding Path=ProjectStart, Mode=TwoWay}"
+								Margin="0,0,16,0"
+								Padding="3"
+								Focusable="True"
+								DayFormat="d (ddd)"
+								DayVisible="True"
+								MonthVisible="True"
+								YearVisible="True"
+								VerticalAlignment="Center"/>
 
-						<Label DockPanel.Dock="Left"
-							   IsTabStop="False"
-							   Classes="status-label"
-							   Content="{x:Static resources:Labels.Label_ProjectStart}"
-							   VerticalContentAlignment="Center"
-							   Height="25"
-							   Margin="4,0,4,0"/>
-						<DatePicker DockPanel.Dock="Left"
-									SelectedDate="{Binding Path=ProjectStart, Mode=TwoWay}"
-									Margin="0,0,12,0"
-									Padding="3"
-									Focusable="True"
-									DayFormat="d (ddd)"
-									DayVisible="True"
-									MonthVisible="True"
-									YearVisible="True"
-									VerticalAlignment="Center"/>
+					<Label DockPanel.Dock="Left"
+						   IsTabStop="False"
+						   Classes="status-label"
+						   Content="{x:Static resources:Labels.Label_Today}"
+						   VerticalContentAlignment="Center"
+						   Margin="0,0,4,0"/>
+					<DatePicker DockPanel.Dock="Left"
+								SelectedDate="{Binding Path=Today, Mode=TwoWay}"
+								Margin="0,0,16,0"
+								Padding="3"
+								Focusable="True"
+								DayFormat="d (ddd)"
+								DayVisible="True"
+								MonthVisible="True"
+								YearVisible="True"
+								VerticalAlignment="Center"/>
 
-						<Label DockPanel.Dock="Left"
-							   IsTabStop="False"
-							   Classes="status-label"
-							   Content="{x:Static resources:Labels.Label_Today}"
-							   VerticalContentAlignment="Center"
-							   Height="25"
-							   Margin="4,0,4,0"/>
+					<Grid />
+				</DockPanel>
+			</Border>
 
-						<DatePicker DockPanel.Dock="Left"
-									SelectedDate="{Binding Path=Today, Mode=TwoWay}"
-									Margin="0,0,12,0"
-									Padding="3"
-									Focusable="True"
-									DayFormat="d (ddd)"
-									DayVisible="True"
-									MonthVisible="True"
-									YearVisible="True"
-									VerticalAlignment="Center"/>
-
-						<Grid />
-					</DockPanel>
-				</Border>
-
-				<idc:DockControl Layout="{Binding Path=Layout, Mode=OneWay}"
-								 DockProperties.IsDragEnabled="False" />
-			</DockPanel>
-		</Border>
+			<!-- Dock control fills remaining space, no extra margin -->
+			<idc:DockControl Layout="{Binding Path=Layout, Mode=OneWay}"
+							 DockProperties.IsDragEnabled="False" />
+		</DockPanel>
 	</u:LoadingContainer>
 </Window>

--- a/src/Zametek.View.ProjectPlan/MainView.axaml
+++ b/src/Zametek.View.ProjectPlan/MainView.axaml
@@ -405,24 +405,10 @@
 									VerticalAlignment="Center"
 									Margin="4,0">
 							<Button Classes="toolbar-btn"
-									Content="+ Activity"
-									Command="{Binding Path=ActivitiesManagerViewModel.AddManagedActivityCommand, Mode=OneWay}"
-									ToolTip.Tip="Add Activity" />
-							<Button Classes="toolbar-btn"
-									Content="&#9889; Compile"
+									Content="Compile"
 									Command="{Binding Path=CompileCommand, Mode=OneWay}"
 									IsVisible="{Binding Path=!AutoCompile, Mode=OneWay}"
-									ToolTip.Tip="Compile Project" />
-							<Button Classes="toolbar-btn"
-									ToolTip.Tip="Toggle Dates"
-									Command="{Binding Path=ToggleShowDatesCommand, Mode=OneWay}">
-								<TextBlock Text="&#128197;" FontSize="14" VerticalAlignment="Center"/>
-							</Button>
-							<Button Classes="toolbar-btn"
-									ToolTip.Tip="Toggle Cost"
-									Command="{Binding Path=ToggleHideCostCommand, Mode=OneWay}">
-								<TextBlock Text="&#128176;" FontSize="14" VerticalAlignment="Center"/>
-							</Button>
+									ToolTip.Tip="Compile Project (also in Compile menu)" />
 						</StackPanel>
 
 						<!-- Command palette trigger (right) -->

--- a/src/Zametek.View.ProjectPlan/MainView.axaml
+++ b/src/Zametek.View.ProjectPlan/MainView.axaml
@@ -12,7 +12,10 @@
 		x:DataType="vm:MainViewModel"
         Icon="resm:Zametek.Resource.ProjectPlan.Icons.zpp.ico?assembly=Zametek.Resource.ProjectPlan"
 		xmlns:u="https://irihi.tech/ursa"
-        Title="{Binding Path=ProjectTitle, Mode=OneWay}">
+        Title="{Binding Path=ProjectTitle, Mode=OneWay}"
+        Width="1400" Height="860"
+        MinWidth="900" MinHeight="600"
+        WindowStartupLocation="CenterScreen">
 
 	<Window.KeyBindings>
 		<KeyBinding x:DataType="vm:MainViewModel"
@@ -121,8 +124,12 @@
 
 	<u:LoadingContainer IsLoading="{Binding Path=IsBusy, Mode=OneWay}"
 						LoadingMessage="{x:Static resources:Labels.Label_PleaseWait}"
-						Name="LoadingPanel">
+						Name="LoadingPanel"
+						HorizontalContentAlignment="Stretch"
+						VerticalContentAlignment="Stretch">
 		<Grid IsEnabled="{Binding Path=!IsBusy, Mode=OneWay}"
+			  HorizontalAlignment="Stretch"
+			  VerticalAlignment="Stretch"
 			  Background="{DynamicResource ZBackground}">
 			<DockPanel>
 
@@ -661,6 +668,161 @@
 								</Grid>
 							</Button>
 
+							<!-- Separator between charts and settings panels -->
+							<Separator Margin="4,8" Background="{DynamicResource ZBorder}" Height="1"/>
+
+							<!-- Resource Settings -->
+							<Button Classes="nav-btn"
+									Name="NavResourceSettings"
+									ToolTip.Tip="Resource Settings"
+									Click="NavResourceSettings_Click">
+								<Grid>
+									<Border HorizontalAlignment="Left"
+											Width="3"
+											VerticalAlignment="Stretch"
+											Background="{DynamicResource ZAccent}"
+											IsVisible="{Binding Path=ActiveShellView, Converter={x:Static local:EnumConverters.IsShellViewMatch}, ConverterParameter={x:Static common:ShellView.ResourceSettings}, Mode=OneWay}"
+											CornerRadius="0,2,2,0" />
+									<TextBlock Text="&#128100;"
+											   FontSize="18"
+											   HorizontalAlignment="Center"
+											   VerticalAlignment="Center" />
+								</Grid>
+							</Button>
+
+							<!-- Work Streams -->
+							<Button Classes="nav-btn"
+									Name="NavWorkStreams"
+									ToolTip.Tip="Work Streams"
+									Click="NavWorkStreams_Click">
+								<Grid>
+									<Border HorizontalAlignment="Left"
+											Width="3"
+											VerticalAlignment="Stretch"
+											Background="{DynamicResource ZAccent}"
+											IsVisible="{Binding Path=ActiveShellView, Converter={x:Static local:EnumConverters.IsShellViewMatch}, ConverterParameter={x:Static common:ShellView.WorkStreams}, Mode=OneWay}"
+											CornerRadius="0,2,2,0" />
+									<TextBlock Text="&#8801;"
+											   FontSize="18"
+											   HorizontalAlignment="Center"
+											   VerticalAlignment="Center" />
+								</Grid>
+							</Button>
+
+							<!-- Graph Settings -->
+							<Button Classes="nav-btn"
+									Name="NavGraphSettings"
+									ToolTip.Tip="Graph Settings"
+									Click="NavGraphSettings_Click">
+								<Grid>
+									<Border HorizontalAlignment="Left"
+											Width="3"
+											VerticalAlignment="Stretch"
+											Background="{DynamicResource ZAccent}"
+											IsVisible="{Binding Path=ActiveShellView, Converter={x:Static local:EnumConverters.IsShellViewMatch}, ConverterParameter={x:Static common:ShellView.GraphSettings}, Mode=OneWay}"
+											CornerRadius="0,2,2,0" />
+									<TextBlock Text="&#9998;"
+											   FontSize="18"
+											   HorizontalAlignment="Center"
+											   VerticalAlignment="Center" />
+								</Grid>
+							</Button>
+
+							<!-- Holidays -->
+							<Button Classes="nav-btn"
+									Name="NavHolidays"
+									ToolTip.Tip="Holidays"
+									Click="NavHolidays_Click">
+								<Grid>
+									<Border HorizontalAlignment="Left"
+											Width="3"
+											VerticalAlignment="Stretch"
+											Background="{DynamicResource ZAccent}"
+											IsVisible="{Binding Path=ActiveShellView, Converter={x:Static local:EnumConverters.IsShellViewMatch}, ConverterParameter={x:Static common:ShellView.Holidays}, Mode=OneWay}"
+											CornerRadius="0,2,2,0" />
+									<TextBlock Text="&#128197;"
+											   FontSize="18"
+											   HorizontalAlignment="Center"
+											   VerticalAlignment="Center" />
+								</Grid>
+							</Button>
+
+							<!-- Metrics -->
+							<Button Classes="nav-btn"
+									Name="NavMetrics"
+									ToolTip.Tip="Metrics"
+									Click="NavMetrics_Click">
+								<Grid>
+									<Border HorizontalAlignment="Left"
+											Width="3"
+											VerticalAlignment="Stretch"
+											Background="{DynamicResource ZAccent}"
+											IsVisible="{Binding Path=ActiveShellView, Converter={x:Static local:EnumConverters.IsShellViewMatch}, ConverterParameter={x:Static common:ShellView.Metrics}, Mode=OneWay}"
+											CornerRadius="0,2,2,0" />
+									<TextBlock Text="&#128200;"
+											   FontSize="18"
+											   HorizontalAlignment="Center"
+											   VerticalAlignment="Center" />
+								</Grid>
+							</Button>
+
+							<!-- Earned Value -->
+							<Button Classes="nav-btn"
+									Name="NavEarnedValue"
+									ToolTip.Tip="Earned Value"
+									Click="NavEarnedValue_Click">
+								<Grid>
+									<Border HorizontalAlignment="Left"
+											Width="3"
+											VerticalAlignment="Stretch"
+											Background="{DynamicResource ZAccent}"
+											IsVisible="{Binding Path=ActiveShellView, Converter={x:Static local:EnumConverters.IsShellViewMatch}, ConverterParameter={x:Static common:ShellView.EarnedValue}, Mode=OneWay}"
+											CornerRadius="0,2,2,0" />
+									<TextBlock Text="&#128176;"
+											   FontSize="18"
+											   HorizontalAlignment="Center"
+											   VerticalAlignment="Center" />
+								</Grid>
+							</Button>
+
+							<!-- Project Scenario -->
+							<Button Classes="nav-btn"
+									Name="NavProjectScenario"
+									ToolTip.Tip="Project Scenario"
+									Click="NavProjectScenario_Click">
+								<Grid>
+									<Border HorizontalAlignment="Left"
+											Width="3"
+											VerticalAlignment="Stretch"
+											Background="{DynamicResource ZAccent}"
+											IsVisible="{Binding Path=ActiveShellView, Converter={x:Static local:EnumConverters.IsShellViewMatch}, ConverterParameter={x:Static common:ShellView.ProjectScenario}, Mode=OneWay}"
+											CornerRadius="0,2,2,0" />
+									<TextBlock Text="&#8644;"
+											   FontSize="18"
+											   HorizontalAlignment="Center"
+											   VerticalAlignment="Center" />
+								</Grid>
+							</Button>
+
+							<!-- Output -->
+							<Button Classes="nav-btn"
+									Name="NavOutput"
+									ToolTip.Tip="Output"
+									Click="NavOutput_Click">
+								<Grid>
+									<Border HorizontalAlignment="Left"
+											Width="3"
+											VerticalAlignment="Stretch"
+											Background="{DynamicResource ZAccent}"
+											IsVisible="{Binding Path=ActiveShellView, Converter={x:Static local:EnumConverters.IsShellViewMatch}, ConverterParameter={x:Static common:ShellView.Output}, Mode=OneWay}"
+											CornerRadius="0,2,2,0" />
+									<TextBlock Text="&#128196;"
+											   FontSize="18"
+											   HorizontalAlignment="Center"
+											   VerticalAlignment="Center" />
+								</Grid>
+							</Button>
+
 						</StackPanel>
 					</Border>
 
@@ -675,27 +837,93 @@
 						<!-- Resources chart -->
 						<ContentControl
 							IsVisible="{Binding Path=ActiveShellView, Converter={x:Static local:EnumConverters.IsShellViewMatch}, ConverterParameter={x:Static common:ShellView.Resources}, Mode=OneWay}"
-							Content="{Binding Path=ResourceChartManagerViewModel, Mode=OneWay}" />
+							Content="{Binding Path=ResourceChartManagerViewModel, Mode=OneWay}"
+							HorizontalContentAlignment="Stretch"
+							VerticalContentAlignment="Stretch" />
 
 						<!-- Scenario chart -->
 						<ContentControl
 							IsVisible="{Binding Path=ActiveShellView, Converter={x:Static local:EnumConverters.IsShellViewMatch}, ConverterParameter={x:Static common:ShellView.Scenario}, Mode=OneWay}"
-							Content="{Binding Path=ScenarioChartManagerViewModel, Mode=OneWay}" />
+							Content="{Binding Path=ScenarioChartManagerViewModel, Mode=OneWay}"
+							HorizontalContentAlignment="Stretch"
+							VerticalContentAlignment="Stretch" />
 
 						<!-- Arrow graph -->
 						<ContentControl
 							IsVisible="{Binding Path=ActiveShellView, Converter={x:Static local:EnumConverters.IsShellViewMatch}, ConverterParameter={x:Static common:ShellView.ArrowGraph}, Mode=OneWay}"
-							Content="{Binding Path=ArrowGraphManagerViewModel, Mode=OneWay}" />
+							Content="{Binding Path=ArrowGraphManagerViewModel, Mode=OneWay}"
+							HorizontalContentAlignment="Stretch"
+							VerticalContentAlignment="Stretch" />
 
 						<!-- Vertex graph -->
 						<ContentControl
 							IsVisible="{Binding Path=ActiveShellView, Converter={x:Static local:EnumConverters.IsShellViewMatch}, ConverterParameter={x:Static common:ShellView.VertexGraph}, Mode=OneWay}"
-							Content="{Binding Path=VertexGraphManagerViewModel, Mode=OneWay}" />
+							Content="{Binding Path=VertexGraphManagerViewModel, Mode=OneWay}"
+							HorizontalContentAlignment="Stretch"
+							VerticalContentAlignment="Stretch" />
 
 						<!-- Tracking -->
 						<ContentControl
 							IsVisible="{Binding Path=ActiveShellView, Converter={x:Static local:EnumConverters.IsShellViewMatch}, ConverterParameter={x:Static common:ShellView.Tracking}, Mode=OneWay}"
-							Content="{Binding Path=TrackingManagerViewModel, Mode=OneWay}" />
+							Content="{Binding Path=TrackingManagerViewModel, Mode=OneWay}"
+							HorizontalContentAlignment="Stretch"
+							VerticalContentAlignment="Stretch" />
+
+						<!-- Resource Settings -->
+						<ContentControl
+							IsVisible="{Binding Path=ActiveShellView, Converter={x:Static local:EnumConverters.IsShellViewMatch}, ConverterParameter={x:Static common:ShellView.ResourceSettings}, Mode=OneWay}"
+							Content="{Binding Path=ResourceSettingsManagerViewModel, Mode=OneWay}"
+							HorizontalContentAlignment="Stretch"
+							VerticalContentAlignment="Stretch" />
+
+						<!-- Work Streams -->
+						<ContentControl
+							IsVisible="{Binding Path=ActiveShellView, Converter={x:Static local:EnumConverters.IsShellViewMatch}, ConverterParameter={x:Static common:ShellView.WorkStreams}, Mode=OneWay}"
+							Content="{Binding Path=WorkStreamSettingsManagerViewModel, Mode=OneWay}"
+							HorizontalContentAlignment="Stretch"
+							VerticalContentAlignment="Stretch" />
+
+						<!-- Graph Settings -->
+						<ContentControl
+							IsVisible="{Binding Path=ActiveShellView, Converter={x:Static local:EnumConverters.IsShellViewMatch}, ConverterParameter={x:Static common:ShellView.GraphSettings}, Mode=OneWay}"
+							Content="{Binding Path=GraphSettingsManagerViewModel, Mode=OneWay}"
+							HorizontalContentAlignment="Stretch"
+							VerticalContentAlignment="Stretch" />
+
+						<!-- Holidays -->
+						<ContentControl
+							IsVisible="{Binding Path=ActiveShellView, Converter={x:Static local:EnumConverters.IsShellViewMatch}, ConverterParameter={x:Static common:ShellView.Holidays}, Mode=OneWay}"
+							Content="{Binding Path=HolidaySettingsManagerViewModel, Mode=OneWay}"
+							HorizontalContentAlignment="Stretch"
+							VerticalContentAlignment="Stretch" />
+
+						<!-- Metrics -->
+						<ContentControl
+							IsVisible="{Binding Path=ActiveShellView, Converter={x:Static local:EnumConverters.IsShellViewMatch}, ConverterParameter={x:Static common:ShellView.Metrics}, Mode=OneWay}"
+							Content="{Binding Path=MetricManagerViewModel, Mode=OneWay}"
+							HorizontalContentAlignment="Stretch"
+							VerticalContentAlignment="Stretch" />
+
+						<!-- Earned Value -->
+						<ContentControl
+							IsVisible="{Binding Path=ActiveShellView, Converter={x:Static local:EnumConverters.IsShellViewMatch}, ConverterParameter={x:Static common:ShellView.EarnedValue}, Mode=OneWay}"
+							Content="{Binding Path=EarnedValueChartManagerViewModel, Mode=OneWay}"
+							HorizontalContentAlignment="Stretch"
+							VerticalContentAlignment="Stretch" />
+
+						<!-- Project Scenario -->
+						<ContentControl
+							IsVisible="{Binding Path=ActiveShellView, Converter={x:Static local:EnumConverters.IsShellViewMatch}, ConverterParameter={x:Static common:ShellView.ProjectScenario}, Mode=OneWay}"
+							Content="{Binding Path=ProjectScenarioManagerViewModel, Mode=OneWay}"
+							HorizontalContentAlignment="Stretch"
+							VerticalContentAlignment="Stretch" />
+
+						<!-- Output -->
+						<ContentControl
+							IsVisible="{Binding Path=ActiveShellView, Converter={x:Static local:EnumConverters.IsShellViewMatch}, ConverterParameter={x:Static common:ShellView.Output}, Mode=OneWay}"
+							Content="{Binding Path=OutputManagerViewModel, Mode=OneWay}"
+							HorizontalContentAlignment="Stretch"
+							VerticalContentAlignment="Stretch" />
 
 						<!-- Command Palette Overlay -->
 						<Border Name="PaletteOverlay"

--- a/src/Zametek.View.ProjectPlan/MainView.axaml
+++ b/src/Zametek.View.ProjectPlan/MainView.axaml
@@ -2,11 +2,10 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+        mc:Ignorable="d" d:DesignWidth="1280" d:DesignHeight="800"
         x:Class="Zametek.View.ProjectPlan.MainView"
 		xmlns:resources="using:Zametek.Resource.ProjectPlan"
 		xmlns:controls="using:Avalonia.Controls"
-		xmlns:idc="clr-namespace:Dock.Avalonia.Controls;assembly=Dock.Avalonia"
 		xmlns:vm="using:Zametek.ViewModel.ProjectPlan"
 		xmlns:local="using:Zametek.View.ProjectPlan"
 		xmlns:common="using:Zametek.Common.ProjectPlan"
@@ -14,6 +13,7 @@
         Icon="resm:Zametek.Resource.ProjectPlan.Icons.zpp.ico?assembly=Zametek.Resource.ProjectPlan"
 		xmlns:u="https://irihi.tech/ursa"
         Title="{Binding Path=ProjectTitle, Mode=OneWay}">
+
 	<Window.KeyBindings>
 		<KeyBinding x:DataType="vm:MainViewModel"
 					Command="{Binding Path=OpenProjectFileCommand, Mode=OneWay}"
@@ -39,326 +39,737 @@
 	</Window.KeyBindings>
 
 	<Window.Styles>
-		<!-- Error indicator: thin top accent bar -->
+		<!-- Error indicator styles -->
 		<Style Selector="Border.compile-ok">
 			<Setter Property="Background" Value="Transparent"/>
 		</Style>
 		<Style Selector="Border.compile-error">
 			<Setter Property="Background" Value="{DynamicResource ZError}"/>
 		</Style>
+
+		<!-- Sidebar nav button base -->
+		<Style Selector="Button.nav-btn">
+			<Setter Property="Width" Value="52"/>
+			<Setter Property="Height" Value="48"/>
+			<Setter Property="Background" Value="Transparent"/>
+			<Setter Property="BorderThickness" Value="0"/>
+			<Setter Property="Padding" Value="0"/>
+			<Setter Property="CornerRadius" Value="0"/>
+			<Setter Property="HorizontalContentAlignment" Value="Center"/>
+			<Setter Property="VerticalContentAlignment" Value="Center"/>
+			<Setter Property="Foreground" Value="{DynamicResource ZTextMuted}"/>
+		</Style>
+		<Style Selector="Button.nav-btn:pointerover">
+			<Setter Property="Background" Value="{DynamicResource ZSurface2}"/>
+			<Setter Property="Foreground" Value="{DynamicResource ZTextSecondary}"/>
+		</Style>
+		<Style Selector="Button.nav-btn.nav-active">
+			<Setter Property="Foreground" Value="{DynamicResource ZAccent}"/>
+			<Setter Property="Background" Value="{DynamicResource ZAccentSubtle}"/>
+		</Style>
+
+		<!-- Toolbar action buttons -->
+		<Style Selector="Button.toolbar-btn">
+			<Setter Property="Background" Value="Transparent"/>
+			<Setter Property="BorderThickness" Value="0"/>
+			<Setter Property="Height" Value="28"/>
+			<Setter Property="Padding" Value="8,0"/>
+			<Setter Property="CornerRadius" Value="4"/>
+			<Setter Property="FontSize" Value="12"/>
+			<Setter Property="Foreground" Value="{DynamicResource ZTextSecondary}"/>
+		</Style>
+		<Style Selector="Button.toolbar-btn:pointerover">
+			<Setter Property="Background" Value="{DynamicResource ZSurface2}"/>
+			<Setter Property="Foreground" Value="{DynamicResource ZTextPrimary}"/>
+		</Style>
+
+		<!-- Status label style -->
+		<Style Selector="Label.status-label">
+			<Setter Property="FontSize" Value="11"/>
+			<Setter Property="Foreground" Value="{DynamicResource ZTextSecondary}"/>
+			<Setter Property="Padding" Value="0"/>
+		</Style>
+
+		<!-- Command palette overlay -->
+		<Style Selector="Border.palette-overlay">
+			<Setter Property="Width" Value="480"/>
+			<Setter Property="MaxHeight" Value="420"/>
+			<Setter Property="CornerRadius" Value="8"/>
+			<Setter Property="BoxShadow" Value="0 8 32 0 #40000000"/>
+			<Setter Property="Background" Value="{DynamicResource ZSurface}"/>
+			<Setter Property="BorderBrush" Value="{DynamicResource ZBorder}"/>
+			<Setter Property="BorderThickness" Value="1"/>
+		</Style>
+
+		<!-- Command palette item -->
+		<Style Selector="Button.palette-item">
+			<Setter Property="Background" Value="Transparent"/>
+			<Setter Property="BorderThickness" Value="0"/>
+			<Setter Property="HorizontalAlignment" Value="Stretch"/>
+			<Setter Property="HorizontalContentAlignment" Value="Left"/>
+			<Setter Property="Padding" Value="12,6"/>
+			<Setter Property="CornerRadius" Value="4"/>
+			<Setter Property="Height" Value="36"/>
+			<Setter Property="FontSize" Value="13"/>
+			<Setter Property="Foreground" Value="{DynamicResource ZTextPrimary}"/>
+		</Style>
+		<Style Selector="Button.palette-item:pointerover">
+			<Setter Property="Background" Value="{DynamicResource ZAccentSubtle}"/>
+			<Setter Property="Foreground" Value="{DynamicResource ZAccent}"/>
+		</Style>
 	</Window.Styles>
 
 	<u:LoadingContainer IsLoading="{Binding Path=IsBusy, Mode=OneWay}"
 						LoadingMessage="{x:Static resources:Labels.Label_PleaseWait}"
 						Name="LoadingPanel">
-		<DockPanel IsEnabled="{Binding Path=!IsBusy, Mode=OneWay}"
-				   Background="{DynamicResource ZBackground}">
+		<Grid IsEnabled="{Binding Path=!IsBusy, Mode=OneWay}"
+			  Background="{DynamicResource ZBackground}">
+			<DockPanel>
 
-			<!-- Thin error indicator bar at the very top -->
-			<Border DockPanel.Dock="Top"
-					Height="3">
-				<Classes.compile-ok>
-					<MultiBinding Converter="{x:Static BoolConverters.And}">
-						<MultiBinding.Bindings>
-							<Binding Path="!HasCompilationErrors" Mode="OneWay"/>
-							<Binding Path="!HasStaleOutputs" Mode="OneWay"/>
-						</MultiBinding.Bindings>
-					</MultiBinding>
-				</Classes.compile-ok>
-				<Classes.compile-error>
-					<MultiBinding Converter="{x:Static BoolConverters.Or}">
-						<MultiBinding.Bindings>
-							<Binding Path="HasCompilationErrors" Mode="OneWay"/>
-							<Binding Path="HasStaleOutputs" Mode="OneWay"/>
-						</MultiBinding.Bindings>
-					</MultiBinding>
-				</Classes.compile-error>
-			</Border>
+				<!-- ── Error bar (3px, top) ── -->
+				<Border DockPanel.Dock="Top" Height="3">
+					<Classes.compile-ok>
+						<MultiBinding Converter="{x:Static BoolConverters.And}">
+							<MultiBinding.Bindings>
+								<Binding Path="!HasCompilationErrors" Mode="OneWay"/>
+								<Binding Path="!HasStaleOutputs" Mode="OneWay"/>
+							</MultiBinding.Bindings>
+						</MultiBinding>
+					</Classes.compile-ok>
+					<Classes.compile-error>
+						<MultiBinding Converter="{x:Static BoolConverters.Or}">
+							<MultiBinding.Bindings>
+								<Binding Path="HasCompilationErrors" Mode="OneWay"/>
+								<Binding Path="HasStaleOutputs" Mode="OneWay"/>
+							</MultiBinding.Bindings>
+						</MultiBinding>
+					</Classes.compile-error>
+				</Border>
 
-			<!-- Menu bar with clean bottom border -->
-			<Border DockPanel.Dock="Top"
-					Background="{DynamicResource ZToolbarBg}"
-					BorderThickness="0,0,0,1"
-					BorderBrush="{DynamicResource ZBorder}">
-				<Menu HorizontalAlignment="Left"
-					  Padding="4,0"
-					  Height="36">
-					<MenuItem Header="{x:Static resources:Menus.Menu_File}">
-						<MenuItem Header="{x:Static resources:Menus.Menu_Open}"
-								  Command="{Binding Path=OpenProjectFileCommand, Mode=OneWay}"
-								  InputGesture="Ctrl+O"/>
-						<Separator />
-						<MenuItem Header="{x:Static resources:Menus.Menu_Save}"
-								  Command="{Binding Path=SaveProjectFileCommand, Mode=OneWay}"
-								  InputGesture="Ctrl+S"/>
-						<MenuItem Header="{x:Static resources:Menus.Menu_SaveAs}"
-								  Command="{Binding Path=SaveAsProjectFileCommand, Mode=OneWay}"/>
-						<Separator />
-						<MenuItem Header="{x:Static resources:Menus.Menu_Import}"
-								  Command="{Binding Path=ImportProjectScenarioFileCommand, Mode=OneWay}"/>
-						<MenuItem Header="{x:Static resources:Menus.Menu_Export}"
-								  Command="{Binding Path=ExportProjectScenarioFileCommand, Mode=OneWay}"/>
-						<Separator />
-						<MenuItem Header="{x:Static resources:Menus.Menu_Close}"
-								  Command="{Binding Path=CloseProjectCommand, Mode=OneWay}"/>
-					</MenuItem>
+				<!-- ── Toolbar (40px) ── -->
+				<Border DockPanel.Dock="Top"
+						Height="40"
+						Background="{DynamicResource ZToolbarBg}"
+						BorderBrush="{DynamicResource ZBorder}"
+						BorderThickness="0,0,0,1">
+					<DockPanel VerticalAlignment="Center">
 
-					<MenuItem Header="{x:Static resources:Menus.Menu_Settings}">
-						<MenuItem Header="{x:Static resources:Menus.Menu_ShowDates}"
-								  Command="{Binding Path=ToggleShowDatesCommand, Mode=OneWay}"
-								  InputGesture="Ctrl+D">
-							<MenuItem.Icon>
-								<CheckBox BorderThickness="0"
-										  Theme="{StaticResource SimpleCheckBox}"
-										  IsHitTestVisible="False"
-										  IsChecked="{Binding Path=ShowDates, Mode=OneWay}" />
-							</MenuItem.Icon>
-						</MenuItem>
-						<MenuItem Header="{x:Static resources:Menus.Menu_UseClassicDates}"
-								  Command="{Binding Path=ToggleUseClassicDatesCommand, Mode=OneWay}"
-								  IsEnabled="{Binding Path=ShowDates, Mode=OneWay}"
-								  InputGesture="Ctrl+F">
-							<MenuItem.Icon>
-								<CheckBox BorderThickness="0"
-										  Theme="{StaticResource SimpleCheckBox}"
-										  IsHitTestVisible="False"
-										  IsChecked="{Binding Path=UseClassicDates, Mode=OneWay}" />
-							</MenuItem.Icon>
-						</MenuItem>
-
-						<MenuItem Header="{x:Static resources:Menus.Menu_NonWorkingDaysSettings}">
-							<MenuItem Header="{x:Static resources:Menus.Menu_NonWorkingDaysNone}"
-									  IsChecked="{Binding Path=NonWorkingDayMode, Converter={x:Static local:EnumConverters.IsNonWorkingDayModeMatch}, ConverterParameter={x:Static common:NonWorkingDayMode.None}, Mode=OneWay}"
-									  Command="{Binding Path=ChangeNonWorkingDayModeCommand, Mode=OneWay}"
-								      CommandParameter="{x:Static common:NonWorkingDayMode.None}"
-									  ToggleType="Radio"/>
-							<MenuItem Header="{x:Static resources:Menus.Menu_NonWorkingDaysWeekends}"
-									  IsChecked="{Binding Path=NonWorkingDayMode, Converter={x:Static local:EnumConverters.IsNonWorkingDayModeMatch}, ConverterParameter={x:Static common:NonWorkingDayMode.Weekends}, Mode=OneWay}"
-									  Command="{Binding Path=ChangeNonWorkingDayModeCommand, Mode=OneWay}"
-								      CommandParameter="{x:Static common:NonWorkingDayMode.Weekends}"
-									  ToggleType="Radio"/>
-							<MenuItem Header="{x:Static resources:Menus.Menu_NonWorkingDaysCustomCalendar}"
-									  IsChecked="{Binding Path=NonWorkingDayMode, Converter={x:Static local:EnumConverters.IsNonWorkingDayModeMatch}, ConverterParameter={x:Static common:NonWorkingDayMode.CustomCalendar}, Mode=OneWay}"
-									  Command="{Binding Path=ChangeNonWorkingDayModeCommand, Mode=OneWay}"
-								      CommandParameter="{x:Static common:NonWorkingDayMode.CustomCalendar}"
-									  ToggleType="Radio"/>
-						</MenuItem>
-
-						<MenuItem Header="{x:Static resources:Menus.Menu_HideCost}"
-								  Command="{Binding Path=ToggleHideCostCommand, Mode=OneWay}"
-								  InputGesture="Ctrl+W">
-							<MenuItem.Icon>
-								<CheckBox BorderThickness="0"
-										  Theme="{StaticResource SimpleCheckBox}"
-										  IsHitTestVisible="False"
-										  IsChecked="{Binding Path=HideCost, Mode=OneWay}" />
-							</MenuItem.Icon>
-						</MenuItem>
-						<MenuItem Header="{x:Static resources:Menus.Menu_HideBilling}"
-								  Command="{Binding Path=ToggleHideBillingCommand, Mode=OneWay}"
-								  InputGesture="Ctrl+E">
-							<MenuItem.Icon>
-								<CheckBox BorderThickness="0"
-										  Theme="{StaticResource SimpleCheckBox}"
-										  IsHitTestVisible="False"
-										  IsChecked="{Binding Path=HideBilling, Mode=OneWay}" />
-							</MenuItem.Icon>
-						</MenuItem>
-						<Separator />
-						<MenuItem Header="{x:Static resources:Menus.Menu_DefaultSettings}">
-							<MenuItem Header="{x:Static resources:Menus.Menu_ShowDates}"
-									  Command="{Binding Path=ToggleDefaultShowDatesCommand, Mode=OneWay}">
-								<MenuItem.Icon>
-									<CheckBox BorderThickness="0"
-											  Theme="{StaticResource SimpleCheckBox}"
-											  IsHitTestVisible="False"
-											  IsChecked="{Binding Path=DefaultShowDates, Mode=OneWay}" />
-								</MenuItem.Icon>
-							</MenuItem>
-							<MenuItem Header="{x:Static resources:Menus.Menu_UseClassicDates}"
-									  Command="{Binding Path=ToggleDefaultUseClassicDatesCommand, Mode=OneWay}"
-									  IsEnabled="{Binding Path=DefaultShowDates, Mode=OneWay}">
-								<MenuItem.Icon>
-									<CheckBox BorderThickness="0"
-											  Theme="{StaticResource SimpleCheckBox}"
-											  IsHitTestVisible="False"
-											  IsChecked="{Binding Path=DefaultUseClassicDates, Mode=OneWay}" />
-								</MenuItem.Icon>
+						<!-- Menu bar (left) -->
+						<Menu DockPanel.Dock="Left"
+							  VerticalAlignment="Center"
+							  Padding="4,0"
+							  Height="40">
+							<MenuItem Header="{x:Static resources:Menus.Menu_File}">
+								<MenuItem Header="{x:Static resources:Menus.Menu_Open}"
+										  Command="{Binding Path=OpenProjectFileCommand, Mode=OneWay}"
+										  InputGesture="Ctrl+O"/>
+								<Separator />
+								<MenuItem Header="{x:Static resources:Menus.Menu_Save}"
+										  Command="{Binding Path=SaveProjectFileCommand, Mode=OneWay}"
+										  InputGesture="Ctrl+S"/>
+								<MenuItem Header="{x:Static resources:Menus.Menu_SaveAs}"
+										  Command="{Binding Path=SaveAsProjectFileCommand, Mode=OneWay}"/>
+								<Separator />
+								<MenuItem Header="{x:Static resources:Menus.Menu_Import}"
+										  Command="{Binding Path=ImportProjectScenarioFileCommand, Mode=OneWay}"/>
+								<MenuItem Header="{x:Static resources:Menus.Menu_Export}"
+										  Command="{Binding Path=ExportProjectScenarioFileCommand, Mode=OneWay}"/>
+								<Separator />
+								<MenuItem Header="{x:Static resources:Menus.Menu_Close}"
+										  Command="{Binding Path=CloseProjectCommand, Mode=OneWay}"/>
 							</MenuItem>
 
-							<MenuItem Header="{x:Static resources:Menus.Menu_NonWorkingDaysSettings}">
-								<MenuItem Header="{x:Static resources:Menus.Menu_NonWorkingDaysNone}"
-										  IsChecked="{Binding Path=DefaultNonWorkingDayMode, Converter={x:Static local:EnumConverters.IsNonWorkingDayModeMatch}, ConverterParameter={x:Static common:NonWorkingDayMode.None}, Mode=OneWay}"
-										  Command="{Binding Path=ChangeDefaultNonWorkingDayModeCommand, Mode=OneWay}"
-										  CommandParameter="{x:Static common:NonWorkingDayMode.None}"
-										  ToggleType="Radio"/>
-								<MenuItem Header="{x:Static resources:Menus.Menu_NonWorkingDaysWeekends}"
-										  IsChecked="{Binding Path=DefaultNonWorkingDayMode, Converter={x:Static local:EnumConverters.IsNonWorkingDayModeMatch}, ConverterParameter={x:Static common:NonWorkingDayMode.Weekends}, Mode=OneWay}"
-										  Command="{Binding Path=ChangeDefaultNonWorkingDayModeCommand, Mode=OneWay}"
-										  CommandParameter="{x:Static common:NonWorkingDayMode.Weekends}"
-										  ToggleType="Radio"/>
-								<MenuItem Header="{x:Static resources:Menus.Menu_NonWorkingDaysCustomCalendar}"
-										  IsChecked="{Binding Path=DefaultNonWorkingDayMode, Converter={x:Static local:EnumConverters.IsNonWorkingDayModeMatch}, ConverterParameter={x:Static common:NonWorkingDayMode.CustomCalendar}, Mode=OneWay}"
-										  Command="{Binding Path=ChangeDefaultNonWorkingDayModeCommand, Mode=OneWay}"
-										  CommandParameter="{x:Static common:NonWorkingDayMode.CustomCalendar}"
-										  ToggleType="Radio"/>
+							<MenuItem Header="{x:Static resources:Menus.Menu_Settings}">
+								<MenuItem Header="{x:Static resources:Menus.Menu_ShowDates}"
+										  Command="{Binding Path=ToggleShowDatesCommand, Mode=OneWay}"
+										  InputGesture="Ctrl+D">
+									<MenuItem.Icon>
+										<CheckBox BorderThickness="0"
+												  Theme="{StaticResource SimpleCheckBox}"
+												  IsHitTestVisible="False"
+												  IsChecked="{Binding Path=ShowDates, Mode=OneWay}" />
+									</MenuItem.Icon>
+								</MenuItem>
+								<MenuItem Header="{x:Static resources:Menus.Menu_UseClassicDates}"
+										  Command="{Binding Path=ToggleUseClassicDatesCommand, Mode=OneWay}"
+										  IsEnabled="{Binding Path=ShowDates, Mode=OneWay}"
+										  InputGesture="Ctrl+F">
+									<MenuItem.Icon>
+										<CheckBox BorderThickness="0"
+												  Theme="{StaticResource SimpleCheckBox}"
+												  IsHitTestVisible="False"
+												  IsChecked="{Binding Path=UseClassicDates, Mode=OneWay}" />
+									</MenuItem.Icon>
+								</MenuItem>
+
+								<MenuItem Header="{x:Static resources:Menus.Menu_NonWorkingDaysSettings}">
+									<MenuItem Header="{x:Static resources:Menus.Menu_NonWorkingDaysNone}"
+											  IsChecked="{Binding Path=NonWorkingDayMode, Converter={x:Static local:EnumConverters.IsNonWorkingDayModeMatch}, ConverterParameter={x:Static common:NonWorkingDayMode.None}, Mode=OneWay}"
+											  Command="{Binding Path=ChangeNonWorkingDayModeCommand, Mode=OneWay}"
+										      CommandParameter="{x:Static common:NonWorkingDayMode.None}"
+											  ToggleType="Radio"/>
+									<MenuItem Header="{x:Static resources:Menus.Menu_NonWorkingDaysWeekends}"
+											  IsChecked="{Binding Path=NonWorkingDayMode, Converter={x:Static local:EnumConverters.IsNonWorkingDayModeMatch}, ConverterParameter={x:Static common:NonWorkingDayMode.Weekends}, Mode=OneWay}"
+											  Command="{Binding Path=ChangeNonWorkingDayModeCommand, Mode=OneWay}"
+										      CommandParameter="{x:Static common:NonWorkingDayMode.Weekends}"
+											  ToggleType="Radio"/>
+									<MenuItem Header="{x:Static resources:Menus.Menu_NonWorkingDaysCustomCalendar}"
+											  IsChecked="{Binding Path=NonWorkingDayMode, Converter={x:Static local:EnumConverters.IsNonWorkingDayModeMatch}, ConverterParameter={x:Static common:NonWorkingDayMode.CustomCalendar}, Mode=OneWay}"
+											  Command="{Binding Path=ChangeNonWorkingDayModeCommand, Mode=OneWay}"
+										      CommandParameter="{x:Static common:NonWorkingDayMode.CustomCalendar}"
+											  ToggleType="Radio"/>
+								</MenuItem>
+
+								<MenuItem Header="{x:Static resources:Menus.Menu_HideCost}"
+										  Command="{Binding Path=ToggleHideCostCommand, Mode=OneWay}"
+										  InputGesture="Ctrl+W">
+									<MenuItem.Icon>
+										<CheckBox BorderThickness="0"
+												  Theme="{StaticResource SimpleCheckBox}"
+												  IsHitTestVisible="False"
+												  IsChecked="{Binding Path=HideCost, Mode=OneWay}" />
+									</MenuItem.Icon>
+								</MenuItem>
+								<MenuItem Header="{x:Static resources:Menus.Menu_HideBilling}"
+										  Command="{Binding Path=ToggleHideBillingCommand, Mode=OneWay}"
+										  InputGesture="Ctrl+E">
+									<MenuItem.Icon>
+										<CheckBox BorderThickness="0"
+												  Theme="{StaticResource SimpleCheckBox}"
+												  IsHitTestVisible="False"
+												  IsChecked="{Binding Path=HideBilling, Mode=OneWay}" />
+									</MenuItem.Icon>
+								</MenuItem>
+								<Separator />
+								<MenuItem Header="{x:Static resources:Menus.Menu_DefaultSettings}">
+									<MenuItem Header="{x:Static resources:Menus.Menu_ShowDates}"
+											  Command="{Binding Path=ToggleDefaultShowDatesCommand, Mode=OneWay}">
+										<MenuItem.Icon>
+											<CheckBox BorderThickness="0"
+													  Theme="{StaticResource SimpleCheckBox}"
+													  IsHitTestVisible="False"
+													  IsChecked="{Binding Path=DefaultShowDates, Mode=OneWay}" />
+										</MenuItem.Icon>
+									</MenuItem>
+									<MenuItem Header="{x:Static resources:Menus.Menu_UseClassicDates}"
+											  Command="{Binding Path=ToggleDefaultUseClassicDatesCommand, Mode=OneWay}"
+											  IsEnabled="{Binding Path=DefaultShowDates, Mode=OneWay}">
+										<MenuItem.Icon>
+											<CheckBox BorderThickness="0"
+													  Theme="{StaticResource SimpleCheckBox}"
+													  IsHitTestVisible="False"
+													  IsChecked="{Binding Path=DefaultUseClassicDates, Mode=OneWay}" />
+										</MenuItem.Icon>
+									</MenuItem>
+
+									<MenuItem Header="{x:Static resources:Menus.Menu_NonWorkingDaysSettings}">
+										<MenuItem Header="{x:Static resources:Menus.Menu_NonWorkingDaysNone}"
+												  IsChecked="{Binding Path=DefaultNonWorkingDayMode, Converter={x:Static local:EnumConverters.IsNonWorkingDayModeMatch}, ConverterParameter={x:Static common:NonWorkingDayMode.None}, Mode=OneWay}"
+												  Command="{Binding Path=ChangeDefaultNonWorkingDayModeCommand, Mode=OneWay}"
+												  CommandParameter="{x:Static common:NonWorkingDayMode.None}"
+												  ToggleType="Radio"/>
+										<MenuItem Header="{x:Static resources:Menus.Menu_NonWorkingDaysWeekends}"
+												  IsChecked="{Binding Path=DefaultNonWorkingDayMode, Converter={x:Static local:EnumConverters.IsNonWorkingDayModeMatch}, ConverterParameter={x:Static common:NonWorkingDayMode.Weekends}, Mode=OneWay}"
+												  Command="{Binding Path=ChangeDefaultNonWorkingDayModeCommand, Mode=OneWay}"
+												  CommandParameter="{x:Static common:NonWorkingDayMode.Weekends}"
+												  ToggleType="Radio"/>
+										<MenuItem Header="{x:Static resources:Menus.Menu_NonWorkingDaysCustomCalendar}"
+												  IsChecked="{Binding Path=DefaultNonWorkingDayMode, Converter={x:Static local:EnumConverters.IsNonWorkingDayModeMatch}, ConverterParameter={x:Static common:NonWorkingDayMode.CustomCalendar}, Mode=OneWay}"
+												  Command="{Binding Path=ChangeDefaultNonWorkingDayModeCommand, Mode=OneWay}"
+												  CommandParameter="{x:Static common:NonWorkingDayMode.CustomCalendar}"
+												  ToggleType="Radio"/>
+									</MenuItem>
+
+									<MenuItem Header="{x:Static resources:Menus.Menu_HideCost}"
+											  Command="{Binding Path=ToggleDefaultHideCostCommand, Mode=OneWay}">
+										<MenuItem.Icon>
+											<CheckBox BorderThickness="0"
+													  Theme="{StaticResource SimpleCheckBox}"
+													  IsHitTestVisible="False"
+													  IsChecked="{Binding Path=DefaultHideCost, Mode=OneWay}" />
+										</MenuItem.Icon>
+									</MenuItem>
+									<MenuItem Header="{x:Static resources:Menus.Menu_HideBilling}"
+											  Command="{Binding Path=ToggleDefaultHideBillingCommand, Mode=OneWay}">
+										<MenuItem.Icon>
+											<CheckBox BorderThickness="0"
+													  Theme="{StaticResource SimpleCheckBox}"
+													  IsHitTestVisible="False"
+													  IsChecked="{Binding Path=DefaultHideBilling, Mode=OneWay}" />
+										</MenuItem.Icon>
+									</MenuItem>
+								</MenuItem>
+								<Separator />
+								<MenuItem Header="{x:Static resources:Menus.Menu_Themes}">
+									<MenuItem Header="{x:Static resources:Themes.Theme_Default}"
+											  IsChecked="{Binding Path=SelectedTheme, Converter={x:Static local:StringConverters.IsMatch}, ConverterParameter={x:Static resources:Themes.Theme_Default}, Mode=OneWay}"
+											  Command="{Binding Path=ChangeThemeCommand, Mode=OneWay}"
+										      CommandParameter="{x:Static resources:Themes.Theme_Default}"
+											  ToggleType="Radio" />
+									<MenuItem Header="{x:Static resources:Themes.Theme_Light}"
+											  IsChecked="{Binding Path=SelectedTheme, Converter={x:Static local:StringConverters.IsMatch}, ConverterParameter={x:Static resources:Themes.Theme_Light}, Mode=OneWay}"
+											  Command="{Binding Path=ChangeThemeCommand, Mode=OneWay}"
+										      CommandParameter="{x:Static resources:Themes.Theme_Light}"
+											  ToggleType="Radio" />
+									<MenuItem Header="{x:Static resources:Themes.Theme_Dark}"
+											  IsChecked="{Binding Path=SelectedTheme, Converter={x:Static local:StringConverters.IsMatch}, ConverterParameter={x:Static resources:Themes.Theme_Dark}, Mode=OneWay}"
+											  Command="{Binding Path=ChangeThemeCommand, Mode=OneWay}"
+										      CommandParameter="{x:Static resources:Themes.Theme_Dark}"
+											  ToggleType="Radio" />
+									<MenuItem Header="{x:Static resources:Themes.Theme_Aquatic}"
+											  IsChecked="{Binding Path=SelectedTheme, Converter={x:Static local:StringConverters.IsMatch}, ConverterParameter={x:Static resources:Themes.Theme_Aquatic}, Mode=OneWay}"
+											  Command="{Binding Path=ChangeThemeCommand, Mode=OneWay}"
+										      CommandParameter="{x:Static resources:Themes.Theme_Aquatic}"
+											  ToggleType="Radio" />
+									<MenuItem Header="{x:Static resources:Themes.Theme_Desert}"
+											  IsChecked="{Binding Path=SelectedTheme, Converter={x:Static local:StringConverters.IsMatch}, ConverterParameter={x:Static resources:Themes.Theme_Desert}, Mode=OneWay}"
+											  Command="{Binding Path=ChangeThemeCommand, Mode=OneWay}"
+										      CommandParameter="{x:Static resources:Themes.Theme_Desert}"
+											  ToggleType="Radio" />
+									<MenuItem Header="{x:Static resources:Themes.Theme_Dusk}"
+											  IsChecked="{Binding Path=SelectedTheme, Converter={x:Static local:StringConverters.IsMatch}, ConverterParameter={x:Static resources:Themes.Theme_Dusk}, Mode=OneWay}"
+											  Command="{Binding Path=ChangeThemeCommand, Mode=OneWay}"
+										      CommandParameter="{x:Static resources:Themes.Theme_Dusk}"
+											  ToggleType="Radio" />
+									<MenuItem Header="{x:Static resources:Themes.Theme_NightSky}"
+											  IsChecked="{Binding Path=SelectedTheme, Converter={x:Static local:StringConverters.IsMatch}, ConverterParameter={x:Static resources:Themes.Theme_NightSky}, Mode=OneWay}"
+											  Command="{Binding Path=ChangeThemeCommand, Mode=OneWay}"
+										      CommandParameter="{x:Static resources:Themes.Theme_NightSky}"
+											  ToggleType="Radio" />
+								</MenuItem>
+
+								<MenuItem Header="{x:Static resources:Menus.Menu_SaveLayout}"
+										  Command="{Binding Path=SaveLayoutCommand, Mode=OneWay}"
+										  InputGesture="Ctrl+L"/>
+
+								<MenuItem Header="{x:Static resources:Menus.Menu_ResetLayout}"
+										  Command="{Binding Path=ResetLayoutCommand, Mode=OneWay}" />
 							</MenuItem>
 
-							<MenuItem Header="{x:Static resources:Menus.Menu_HideCost}"
-									  Command="{Binding Path=ToggleDefaultHideCostCommand, Mode=OneWay}">
-								<MenuItem.Icon>
-									<CheckBox BorderThickness="0"
-											  Theme="{StaticResource SimpleCheckBox}"
-											  IsHitTestVisible="False"
-											  IsChecked="{Binding Path=DefaultHideCost, Mode=OneWay}" />
-								</MenuItem.Icon>
+							<MenuItem Header="{x:Static resources:Menus.Menu_Compile}">
+								<MenuItem Header="{x:Static resources:Menus.Menu_Compile}"
+										  Command="{Binding Path=CompileCommand, Mode=OneWay}"/>
+								<MenuItem Header="{x:Static resources:Menus.Menu_AutoCompile}"
+										  Command="{Binding Path=ToggleAutoCompileCommand, Mode=OneWay}">
+									<MenuItem.Icon>
+										<CheckBox BorderThickness="0"
+												  Theme="{StaticResource SimpleCheckBox}"
+												  IsHitTestVisible="False"
+												  IsChecked="{Binding Path=AutoCompile, Mode=OneWay}" />
+									</MenuItem.Icon>
+								</MenuItem>
+								<MenuItem Header="{x:Static resources:Menus.Menu_TransitiveReduction}"
+										  Command="{Binding Path=TransitiveReductionCommand, Mode=OneWay}"/>
 							</MenuItem>
-							<MenuItem Header="{x:Static resources:Menus.Menu_HideBilling}"
-									  Command="{Binding Path=ToggleDefaultHideBillingCommand, Mode=OneWay}">
-								<MenuItem.Icon>
-									<CheckBox BorderThickness="0"
-											  Theme="{StaticResource SimpleCheckBox}"
-											  IsHitTestVisible="False"
-											  IsChecked="{Binding Path=DefaultHideBilling, Mode=OneWay}" />
-								</MenuItem.Icon>
+
+							<MenuItem Header="{x:Static resources:Menus.Menu_Help}">
+								<MenuItem Header="{x:Static resources:Menus.Menu_Documentation}"
+										  Command="{Binding Path=OpenDocumentationCommand, Mode=OneWay}"/>
+								<Separator />
+								<MenuItem Header="{x:Static resources:Menus.Menu_ReportIssue}"
+										  Command="{Binding Path=OpenReportIssueCommand, Mode=OneWay}"/>
+								<Separator />
+								<MenuItem Header="{x:Static resources:Menus.Menu_Donate}"
+										  Command="{Binding Path=OpenDonateCommand, Mode=OneWay}"/>
+								<MenuItem Header="{x:Static resources:Menus.Menu_ViewLicense}"
+										  Command="{Binding Path=OpenViewLicenseCommand, Mode=OneWay}"/>
+								<Separator />
+								<MenuItem Command="{Binding Path=OpenAboutCommand, Mode=OneWay}">
+									<MenuItem.Header>
+										<TextBlock>
+											<Run Text="{x:Static resources:Menus.Menu_About}"></Run>
+											<Run Text="{x:Static resources:Labels.Label_AppName}"></Run>
+										</TextBlock>
+									</MenuItem.Header>
+								</MenuItem>
 							</MenuItem>
-						</MenuItem>
-						<Separator />
-						<MenuItem Header="{x:Static resources:Menus.Menu_Themes}">
-							<MenuItem Header="{x:Static resources:Themes.Theme_Default}"
-									  IsChecked="{Binding Path=SelectedTheme, Converter={x:Static local:StringConverters.IsMatch}, ConverterParameter={x:Static resources:Themes.Theme_Default}, Mode=OneWay}"
-									  Command="{Binding Path=ChangeThemeCommand, Mode=OneWay}"
-								      CommandParameter="{x:Static resources:Themes.Theme_Default}"
-									  ToggleType="Radio" />
-							<MenuItem Header="{x:Static resources:Themes.Theme_Light}"
-									  IsChecked="{Binding Path=SelectedTheme, Converter={x:Static local:StringConverters.IsMatch}, ConverterParameter={x:Static resources:Themes.Theme_Light}, Mode=OneWay}"
-									  Command="{Binding Path=ChangeThemeCommand, Mode=OneWay}"
-								      CommandParameter="{x:Static resources:Themes.Theme_Light}"
-									  ToggleType="Radio" />
-							<MenuItem Header="{x:Static resources:Themes.Theme_Dark}"
-									  IsChecked="{Binding Path=SelectedTheme, Converter={x:Static local:StringConverters.IsMatch}, ConverterParameter={x:Static resources:Themes.Theme_Dark}, Mode=OneWay}"
-									  Command="{Binding Path=ChangeThemeCommand, Mode=OneWay}"
-								      CommandParameter="{x:Static resources:Themes.Theme_Dark}"
-									  ToggleType="Radio" />
-							<MenuItem Header="{x:Static resources:Themes.Theme_Aquatic}"
-									  IsChecked="{Binding Path=SelectedTheme, Converter={x:Static local:StringConverters.IsMatch}, ConverterParameter={x:Static resources:Themes.Theme_Aquatic}, Mode=OneWay}"
-									  Command="{Binding Path=ChangeThemeCommand, Mode=OneWay}"
-								      CommandParameter="{x:Static resources:Themes.Theme_Aquatic}"
-									  ToggleType="Radio" />
-							<MenuItem Header="{x:Static resources:Themes.Theme_Desert}"
-									  IsChecked="{Binding Path=SelectedTheme, Converter={x:Static local:StringConverters.IsMatch}, ConverterParameter={x:Static resources:Themes.Theme_Desert}, Mode=OneWay}"
-									  Command="{Binding Path=ChangeThemeCommand, Mode=OneWay}"
-								      CommandParameter="{x:Static resources:Themes.Theme_Desert}"
-									  ToggleType="Radio" />
-							<MenuItem Header="{x:Static resources:Themes.Theme_Dusk}"
-									  IsChecked="{Binding Path=SelectedTheme, Converter={x:Static local:StringConverters.IsMatch}, ConverterParameter={x:Static resources:Themes.Theme_Dusk}, Mode=OneWay}"
-									  Command="{Binding Path=ChangeThemeCommand, Mode=OneWay}"
-								      CommandParameter="{x:Static resources:Themes.Theme_Dusk}"
-									  ToggleType="Radio" />
-							<MenuItem Header="{x:Static resources:Themes.Theme_NightSky}"
-									  IsChecked="{Binding Path=SelectedTheme, Converter={x:Static local:StringConverters.IsMatch}, ConverterParameter={x:Static resources:Themes.Theme_NightSky}, Mode=OneWay}"
-									  Command="{Binding Path=ChangeThemeCommand, Mode=OneWay}"
-								      CommandParameter="{x:Static resources:Themes.Theme_NightSky}"
-									  ToggleType="Radio" />
-						</MenuItem>
+						</Menu>
 
-						<MenuItem Header="{x:Static resources:Menus.Menu_SaveLayout}"
-								  Command="{Binding Path=SaveLayoutCommand, Mode=OneWay}"
-								  InputGesture="Ctrl+L"/>
+						<!-- Divider -->
+						<Separator DockPanel.Dock="Left"
+								   Width="1"
+								   Margin="2,8"
+								   Background="{DynamicResource ZBorder}" />
 
-						<MenuItem Header="{x:Static resources:Menus.Menu_ResetLayout}"
-								  Command="{Binding Path=ResetLayoutCommand, Mode=OneWay}" />
-					</MenuItem>
+						<!-- Action buttons (left-center) -->
+						<StackPanel DockPanel.Dock="Left"
+									Orientation="Horizontal"
+									Spacing="2"
+									VerticalAlignment="Center"
+									Margin="4,0">
+							<Button Classes="toolbar-btn"
+									Content="+ Activity"
+									Command="{Binding Path=ActivitiesManagerViewModel.AddManagedActivityCommand, Mode=OneWay}"
+									ToolTip.Tip="Add Activity" />
+							<Button Classes="toolbar-btn"
+									Content="&#9889; Compile"
+									Command="{Binding Path=CompileCommand, Mode=OneWay}"
+									IsVisible="{Binding Path=!AutoCompile, Mode=OneWay}"
+									ToolTip.Tip="Compile Project" />
+							<Button Classes="toolbar-btn"
+									ToolTip.Tip="Toggle Dates"
+									Command="{Binding Path=ToggleShowDatesCommand, Mode=OneWay}">
+								<TextBlock Text="&#128197;" FontSize="14" VerticalAlignment="Center"/>
+							</Button>
+							<Button Classes="toolbar-btn"
+									ToolTip.Tip="Toggle Cost"
+									Command="{Binding Path=ToggleHideCostCommand, Mode=OneWay}">
+								<TextBlock Text="&#128176;" FontSize="14" VerticalAlignment="Center"/>
+							</Button>
+						</StackPanel>
 
-					<MenuItem Header="{x:Static resources:Menus.Menu_Compile}">
-						<MenuItem Header="{x:Static resources:Menus.Menu_Compile}"
-								  Command="{Binding Path=CompileCommand, Mode=OneWay}"/>
-						<MenuItem Header="{x:Static resources:Menus.Menu_AutoCompile}"
-								  Command="{Binding Path=ToggleAutoCompileCommand, Mode=OneWay}">
-							<MenuItem.Icon>
-								<CheckBox BorderThickness="0"
-										  Theme="{StaticResource SimpleCheckBox}"
-										  IsHitTestVisible="False"
-										  IsChecked="{Binding Path=AutoCompile, Mode=OneWay}" />
-							</MenuItem.Icon>
-						</MenuItem>
-						<MenuItem Header="{x:Static resources:Menus.Menu_TransitiveReduction}"
-								  Command="{Binding Path=TransitiveReductionCommand, Mode=OneWay}"/>
-					</MenuItem>
-					
-					<MenuItem Header="{x:Static resources:Menus.Menu_Help}">
-						<MenuItem Header="{x:Static resources:Menus.Menu_Documentation}"
-								  Command="{Binding Path=OpenDocumentationCommand, Mode=OneWay}"/>
-						<Separator />
-						<MenuItem Header="{x:Static resources:Menus.Menu_ReportIssue}"
-								  Command="{Binding Path=OpenReportIssueCommand, Mode=OneWay}"/>
-						<Separator />
-						<MenuItem Header="{x:Static resources:Menus.Menu_Donate}"
-								  Command="{Binding Path=OpenDonateCommand, Mode=OneWay}"/>
-						<MenuItem Header="{x:Static resources:Menus.Menu_ViewLicense}"
-								  Command="{Binding Path=OpenViewLicenseCommand, Mode=OneWay}"/>
-						<Separator />
-						<MenuItem Command="{Binding Path=OpenAboutCommand, Mode=OneWay}">
-							<MenuItem.Header>
-								<TextBlock>
-									<Run Text="{x:Static resources:Menus.Menu_About}"></Run>
-									<Run Text="{x:Static resources:Labels.Label_AppName}"></Run>
-								</TextBlock>
-							</MenuItem.Header>
-						</MenuItem>
-					</MenuItem>
-				</Menu>
-			</Border>
+						<!-- Command palette trigger (right) -->
+						<Border DockPanel.Dock="Right"
+								Margin="8,6"
+								VerticalAlignment="Center"
+								Width="200"
+								Background="{DynamicResource ZSurface2}"
+								CornerRadius="4"
+								BorderBrush="{DynamicResource ZBorder}"
+								BorderThickness="1"
+								Cursor="Hand"
+								Name="CommandPaletteTrigger">
+							<TextBlock Text="&#8984;K  Search commands..."
+									   FontSize="11"
+									   Foreground="{DynamicResource ZTextMuted}"
+									   VerticalAlignment="Center"
+									   Margin="8,0" />
+						</Border>
 
-			<!-- Status bar: 30px, subtle background, 11px muted labels -->
-			<Border DockPanel.Dock="Bottom"
-					Height="30"
-					Background="{DynamicResource ZStatusBar}"
-					BorderThickness="0,1,0,0"
-					BorderBrush="{DynamicResource ZBorder}">
-				<DockPanel VerticalAlignment="Center"
-						   Margin="8,0">
-					<Label DockPanel.Dock="Left"
-						   IsTabStop="False"
-						   Classes="status-label"
-						   Content="{x:Static resources:Labels.Label_ProjectStart}"
-						   VerticalContentAlignment="Center"
-						   Margin="0,0,4,0"/>
-					<DatePicker DockPanel.Dock="Left"
-								SelectedDate="{Binding Path=ProjectStart, Mode=TwoWay}"
-								Margin="0,0,16,0"
-								Padding="3"
-								Focusable="True"
-								DayFormat="d (ddd)"
-								DayVisible="True"
-								MonthVisible="True"
-								YearVisible="True"
-								VerticalAlignment="Center"/>
+						<!-- Spacer -->
+						<Grid DockPanel.Dock="Right" />
+					</DockPanel>
+				</Border>
 
-					<Label DockPanel.Dock="Left"
-						   IsTabStop="False"
-						   Classes="status-label"
-						   Content="{x:Static resources:Labels.Label_Today}"
-						   VerticalContentAlignment="Center"
-						   Margin="0,0,4,0"/>
-					<DatePicker DockPanel.Dock="Left"
-								SelectedDate="{Binding Path=Today, Mode=TwoWay}"
-								Margin="0,0,16,0"
-								Padding="3"
-								Focusable="True"
-								DayFormat="d (ddd)"
-								DayVisible="True"
-								MonthVisible="True"
-								YearVisible="True"
-								VerticalAlignment="Center"/>
+				<!-- ── Stats bar (28px) ── -->
+				<Border DockPanel.Dock="Top"
+						Height="28"
+						Background="{DynamicResource ZSurface2}"
+						BorderBrush="{DynamicResource ZBorder}"
+						BorderThickness="0,0,0,1">
+					<StackPanel Orientation="Horizontal"
+								VerticalAlignment="Center"
+								Margin="60,0,8,0"
+								Spacing="0">
+						<TextBlock Text="Project:"
+								   FontSize="11"
+								   Foreground="{DynamicResource ZTextSecondary}"
+								   VerticalAlignment="Center"
+								   Margin="0,0,4,0" />
+						<TextBlock Text="{Binding Path=ProjectTitle, Mode=OneWay}"
+								   FontSize="11"
+								   Foreground="{DynamicResource ZTextPrimary}"
+								   VerticalAlignment="Center"
+								   MaxWidth="240"
+								   TextTrimming="CharacterEllipsis" />
+						<Separator Width="1" Height="14" Margin="12,0" Background="{DynamicResource ZBorder}" />
+						<TextBlock Text="Errors"
+								   FontSize="11"
+								   Foreground="{DynamicResource ZError}"
+								   VerticalAlignment="Center"
+								   IsVisible="{Binding Path=HasCompilationErrors, Mode=OneWay}" />
+						<TextBlock Text="Stale"
+								   FontSize="11"
+								   Foreground="{DynamicResource ZTextMuted}"
+								   VerticalAlignment="Center"
+								   IsVisible="{Binding Path=HasStaleOutputs, Mode=OneWay}" />
+						<TextBlock Text="OK"
+								   FontSize="11"
+								   Foreground="{DynamicResource ZAccent}"
+								   VerticalAlignment="Center">
+							<TextBlock.IsVisible>
+								<MultiBinding Converter="{x:Static BoolConverters.And}">
+									<Binding Path="!HasCompilationErrors" Mode="OneWay"/>
+									<Binding Path="!HasStaleOutputs" Mode="OneWay"/>
+								</MultiBinding>
+							</TextBlock.IsVisible>
+						</TextBlock>
+					</StackPanel>
+				</Border>
 
-					<Grid />
-				</DockPanel>
-			</Border>
+				<!-- ── Status bar (30px, bottom) ── -->
+				<Border DockPanel.Dock="Bottom"
+						Height="30"
+						Background="{DynamicResource ZStatusBar}"
+						BorderThickness="0,1,0,0"
+						BorderBrush="{DynamicResource ZBorder}">
+					<DockPanel VerticalAlignment="Center" Margin="8,0">
+						<Label DockPanel.Dock="Left"
+							   IsTabStop="False"
+							   Classes="status-label"
+							   Content="{x:Static resources:Labels.Label_ProjectStart}"
+							   VerticalContentAlignment="Center"
+							   Margin="0,0,4,0"/>
+						<DatePicker DockPanel.Dock="Left"
+									SelectedDate="{Binding Path=ProjectStart, Mode=TwoWay}"
+									Margin="0,0,16,0"
+									Padding="3"
+									Focusable="True"
+									DayFormat="d (ddd)"
+									DayVisible="True"
+									MonthVisible="True"
+									YearVisible="True"
+									VerticalAlignment="Center"/>
 
-			<!-- Dock control fills remaining space, no extra margin -->
-			<idc:DockControl Layout="{Binding Path=Layout, Mode=OneWay}"
-							 DockProperties.IsDragEnabled="False" />
-		</DockPanel>
+						<Label DockPanel.Dock="Left"
+							   IsTabStop="False"
+							   Classes="status-label"
+							   Content="{x:Static resources:Labels.Label_Today}"
+							   VerticalContentAlignment="Center"
+							   Margin="0,0,4,0"/>
+						<DatePicker DockPanel.Dock="Left"
+									SelectedDate="{Binding Path=Today, Mode=TwoWay}"
+									Margin="0,0,16,0"
+									Padding="3"
+									Focusable="True"
+									DayFormat="d (ddd)"
+									DayVisible="True"
+									MonthVisible="True"
+									YearVisible="True"
+									VerticalAlignment="Center"/>
+
+						<Grid />
+					</DockPanel>
+				</Border>
+
+				<!-- ── Main body: sidebar + content ── -->
+				<Grid>
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="52" />
+						<ColumnDefinition Width="*" />
+					</Grid.ColumnDefinitions>
+
+					<!-- Left sidebar (52px) -->
+					<Border Grid.Column="0"
+							Background="{DynamicResource ZSurface}"
+							BorderBrush="{DynamicResource ZBorder}"
+							BorderThickness="0,0,1,0">
+						<StackPanel Orientation="Vertical">
+
+							<!-- Activities + Gantt (home) -->
+							<Button Classes="nav-btn"
+									Name="NavActivitiesGantt"
+									ToolTip.Tip="Activities + Gantt"
+									Click="NavActivitiesGantt_Click">
+								<Grid>
+									<!-- Active accent bar -->
+									<Border HorizontalAlignment="Left"
+											Width="3"
+											VerticalAlignment="Stretch"
+											Background="{DynamicResource ZAccent}"
+											IsVisible="{Binding Path=ActiveShellView, Converter={x:Static local:EnumConverters.IsShellViewMatch}, ConverterParameter={x:Static common:ShellView.ActivitiesGantt}, Mode=OneWay}"
+											CornerRadius="0,2,2,0" />
+									<TextBlock Text="&#9776;"
+											   FontSize="18"
+											   HorizontalAlignment="Center"
+											   VerticalAlignment="Center" />
+								</Grid>
+							</Button>
+
+							<!-- Resources -->
+							<Button Classes="nav-btn"
+									Name="NavResources"
+									ToolTip.Tip="Resources"
+									Click="NavResources_Click">
+								<Grid>
+									<Border HorizontalAlignment="Left"
+											Width="3"
+											VerticalAlignment="Stretch"
+											Background="{DynamicResource ZAccent}"
+											IsVisible="{Binding Path=ActiveShellView, Converter={x:Static local:EnumConverters.IsShellViewMatch}, ConverterParameter={x:Static common:ShellView.Resources}, Mode=OneWay}"
+											CornerRadius="0,2,2,0" />
+									<TextBlock Text="&#128202;"
+											   FontSize="18"
+											   HorizontalAlignment="Center"
+											   VerticalAlignment="Center" />
+								</Grid>
+							</Button>
+
+							<!-- Scenario -->
+							<Button Classes="nav-btn"
+									Name="NavScenario"
+									ToolTip.Tip="Scenario"
+									Click="NavScenario_Click">
+								<Grid>
+									<Border HorizontalAlignment="Left"
+											Width="3"
+											VerticalAlignment="Stretch"
+											Background="{DynamicResource ZAccent}"
+											IsVisible="{Binding Path=ActiveShellView, Converter={x:Static local:EnumConverters.IsShellViewMatch}, ConverterParameter={x:Static common:ShellView.Scenario}, Mode=OneWay}"
+											CornerRadius="0,2,2,0" />
+									<TextBlock Text="&#128200;"
+											   FontSize="18"
+											   HorizontalAlignment="Center"
+											   VerticalAlignment="Center" />
+								</Grid>
+							</Button>
+
+							<!-- Arrow Graph -->
+							<Button Classes="nav-btn"
+									Name="NavArrowGraph"
+									ToolTip.Tip="Arrow Graph"
+									Click="NavArrowGraph_Click">
+								<Grid>
+									<Border HorizontalAlignment="Left"
+											Width="3"
+											VerticalAlignment="Stretch"
+											Background="{DynamicResource ZAccent}"
+											IsVisible="{Binding Path=ActiveShellView, Converter={x:Static local:EnumConverters.IsShellViewMatch}, ConverterParameter={x:Static common:ShellView.ArrowGraph}, Mode=OneWay}"
+											CornerRadius="0,2,2,0" />
+									<TextBlock Text="&#8594;"
+											   FontSize="20"
+											   HorizontalAlignment="Center"
+											   VerticalAlignment="Center" />
+								</Grid>
+							</Button>
+
+							<!-- Vertex Graph -->
+							<Button Classes="nav-btn"
+									Name="NavVertexGraph"
+									ToolTip.Tip="Vertex Graph"
+									Click="NavVertexGraph_Click">
+								<Grid>
+									<Border HorizontalAlignment="Left"
+											Width="3"
+											VerticalAlignment="Stretch"
+											Background="{DynamicResource ZAccent}"
+											IsVisible="{Binding Path=ActiveShellView, Converter={x:Static local:EnumConverters.IsShellViewMatch}, ConverterParameter={x:Static common:ShellView.VertexGraph}, Mode=OneWay}"
+											CornerRadius="0,2,2,0" />
+									<TextBlock Text="&#9711;"
+											   FontSize="18"
+											   HorizontalAlignment="Center"
+											   VerticalAlignment="Center" />
+								</Grid>
+							</Button>
+
+							<!-- Tracking -->
+							<Button Classes="nav-btn"
+									Name="NavTracking"
+									ToolTip.Tip="Tracking"
+									Click="NavTracking_Click">
+								<Grid>
+									<Border HorizontalAlignment="Left"
+											Width="3"
+											VerticalAlignment="Stretch"
+											Background="{DynamicResource ZAccent}"
+											IsVisible="{Binding Path=ActiveShellView, Converter={x:Static local:EnumConverters.IsShellViewMatch}, ConverterParameter={x:Static common:ShellView.Tracking}, Mode=OneWay}"
+											CornerRadius="0,2,2,0" />
+									<TextBlock Text="&#10003;"
+											   FontSize="18"
+											   HorizontalAlignment="Center"
+											   VerticalAlignment="Center" />
+								</Grid>
+							</Button>
+
+						</StackPanel>
+					</Border>
+
+					<!-- Main content area -->
+					<Grid Grid.Column="1">
+
+						<!-- Home: Activities + Gantt split view -->
+						<local:HomeView
+							IsVisible="{Binding Path=ActiveShellView, Converter={x:Static local:EnumConverters.IsShellViewMatch}, ConverterParameter={x:Static common:ShellView.ActivitiesGantt}, Mode=OneWay}"
+							DataContext="{Binding}" />
+
+						<!-- Resources chart -->
+						<ContentControl
+							IsVisible="{Binding Path=ActiveShellView, Converter={x:Static local:EnumConverters.IsShellViewMatch}, ConverterParameter={x:Static common:ShellView.Resources}, Mode=OneWay}"
+							Content="{Binding Path=ResourceChartManagerViewModel, Mode=OneWay}" />
+
+						<!-- Scenario chart -->
+						<ContentControl
+							IsVisible="{Binding Path=ActiveShellView, Converter={x:Static local:EnumConverters.IsShellViewMatch}, ConverterParameter={x:Static common:ShellView.Scenario}, Mode=OneWay}"
+							Content="{Binding Path=ScenarioChartManagerViewModel, Mode=OneWay}" />
+
+						<!-- Arrow graph -->
+						<ContentControl
+							IsVisible="{Binding Path=ActiveShellView, Converter={x:Static local:EnumConverters.IsShellViewMatch}, ConverterParameter={x:Static common:ShellView.ArrowGraph}, Mode=OneWay}"
+							Content="{Binding Path=ArrowGraphManagerViewModel, Mode=OneWay}" />
+
+						<!-- Vertex graph -->
+						<ContentControl
+							IsVisible="{Binding Path=ActiveShellView, Converter={x:Static local:EnumConverters.IsShellViewMatch}, ConverterParameter={x:Static common:ShellView.VertexGraph}, Mode=OneWay}"
+							Content="{Binding Path=VertexGraphManagerViewModel, Mode=OneWay}" />
+
+						<!-- Tracking -->
+						<ContentControl
+							IsVisible="{Binding Path=ActiveShellView, Converter={x:Static local:EnumConverters.IsShellViewMatch}, ConverterParameter={x:Static common:ShellView.Tracking}, Mode=OneWay}"
+							Content="{Binding Path=TrackingManagerViewModel, Mode=OneWay}" />
+
+						<!-- Command Palette Overlay -->
+						<Border Name="PaletteOverlay"
+								IsVisible="{Binding Path=IsCommandPaletteOpen, Mode=OneWay}"
+								ZIndex="100"
+								HorizontalAlignment="Center"
+								VerticalAlignment="Top"
+								Margin="0,40,0,0"
+								Classes="palette-overlay">
+							<DockPanel>
+								<!-- Search box -->
+								<Border DockPanel.Dock="Top"
+										BorderBrush="{DynamicResource ZBorder}"
+										BorderThickness="0,0,0,1"
+										Padding="12,8">
+									<DockPanel>
+										<TextBlock DockPanel.Dock="Left"
+												   Text="&#128269;"
+												   FontSize="14"
+												   VerticalAlignment="Center"
+												   Margin="0,0,8,0"
+												   Foreground="{DynamicResource ZTextMuted}" />
+										<TextBox Name="PaletteSearchBox"
+												 Watermark="Search commands..."
+												 BorderThickness="0"
+												 Background="Transparent"
+												 FontSize="13"
+												 Padding="0"
+												 VerticalAlignment="Center"
+												 MinHeight="0"
+												 Height="24"
+												 TextChanged="PaletteSearch_TextChanged"
+												 KeyDown="PaletteSearch_KeyDown" />
+									</DockPanel>
+								</Border>
+
+								<!-- Command list -->
+								<ScrollViewer DockPanel.Dock="Top"
+											  MaxHeight="340"
+											  VerticalScrollBarVisibility="Auto">
+									<ItemsControl Name="PaletteItemsControl"
+												  Margin="4">
+										<ItemsControl.ItemTemplate>
+											<DataTemplate x:DataType="local:PaletteCommand">
+												<Button Classes="palette-item"
+														Command="{Binding ExecuteCommand}"
+														CommandParameter="{Binding}">
+													<Grid>
+														<Grid.ColumnDefinitions>
+															<ColumnDefinition Width="*" />
+															<ColumnDefinition Width="Auto" />
+														</Grid.ColumnDefinitions>
+														<TextBlock Grid.Column="0"
+																   Text="{Binding Label}"
+																   VerticalAlignment="Center" />
+														<TextBlock Grid.Column="1"
+																   Text="{Binding Gesture}"
+																   FontSize="11"
+																   Foreground="{DynamicResource ZTextMuted}"
+																   VerticalAlignment="Center"
+																   Margin="8,0,0,0" />
+													</Grid>
+												</Button>
+											</DataTemplate>
+										</ItemsControl.ItemTemplate>
+									</ItemsControl>
+								</ScrollViewer>
+							</DockPanel>
+						</Border>
+
+					</Grid>
+				</Grid>
+
+			</DockPanel>
+		</Grid>
 	</u:LoadingContainer>
 </Window>

--- a/src/Zametek.View.ProjectPlan/MainView.axaml.cs
+++ b/src/Zametek.View.ProjectPlan/MainView.axaml.cs
@@ -104,6 +104,14 @@ namespace Zametek.View.ProjectPlan
                 new PaletteCommand("Switch to Arrow Graph", "", new RelayCommand(() => m_ViewModel.ActiveShellView = ShellView.ArrowGraph), ClosePalette),
                 new PaletteCommand("Switch to Vertex Graph", "", new RelayCommand(() => m_ViewModel.ActiveShellView = ShellView.VertexGraph), ClosePalette),
                 new PaletteCommand("Switch to Tracking", "", new RelayCommand(() => m_ViewModel.ActiveShellView = ShellView.Tracking), ClosePalette),
+                new PaletteCommand("Switch to Resource Settings", "", new RelayCommand(() => m_ViewModel.ActiveShellView = ShellView.ResourceSettings), ClosePalette),
+                new PaletteCommand("Switch to Work Streams", "", new RelayCommand(() => m_ViewModel.ActiveShellView = ShellView.WorkStreams), ClosePalette),
+                new PaletteCommand("Switch to Graph Settings", "", new RelayCommand(() => m_ViewModel.ActiveShellView = ShellView.GraphSettings), ClosePalette),
+                new PaletteCommand("Switch to Holidays", "", new RelayCommand(() => m_ViewModel.ActiveShellView = ShellView.Holidays), ClosePalette),
+                new PaletteCommand("Switch to Metrics", "", new RelayCommand(() => m_ViewModel.ActiveShellView = ShellView.Metrics), ClosePalette),
+                new PaletteCommand("Switch to Earned Value", "", new RelayCommand(() => m_ViewModel.ActiveShellView = ShellView.EarnedValue), ClosePalette),
+                new PaletteCommand("Switch to Project Scenario", "", new RelayCommand(() => m_ViewModel.ActiveShellView = ShellView.ProjectScenario), ClosePalette),
+                new PaletteCommand("Switch to Output", "", new RelayCommand(() => m_ViewModel.ActiveShellView = ShellView.Output), ClosePalette),
                 new PaletteCommand("Add Activity", "", m_ViewModel.ActivitiesManagerViewModel.AddManagedActivityCommand, ClosePalette),
                 new PaletteCommand("Documentation", "", m_ViewModel.OpenDocumentationCommand, ClosePalette),
                 new PaletteCommand("Report Issue", "", m_ViewModel.OpenReportIssueCommand, ClosePalette),
@@ -281,6 +289,46 @@ namespace Zametek.View.ProjectPlan
         private void NavTracking_Click(object? sender, RoutedEventArgs e)
         {
             if (m_ViewModel is not null) m_ViewModel.ActiveShellView = ShellView.Tracking;
+        }
+
+        private void NavResourceSettings_Click(object? sender, RoutedEventArgs e)
+        {
+            if (m_ViewModel is not null) m_ViewModel.ActiveShellView = ShellView.ResourceSettings;
+        }
+
+        private void NavWorkStreams_Click(object? sender, RoutedEventArgs e)
+        {
+            if (m_ViewModel is not null) m_ViewModel.ActiveShellView = ShellView.WorkStreams;
+        }
+
+        private void NavGraphSettings_Click(object? sender, RoutedEventArgs e)
+        {
+            if (m_ViewModel is not null) m_ViewModel.ActiveShellView = ShellView.GraphSettings;
+        }
+
+        private void NavHolidays_Click(object? sender, RoutedEventArgs e)
+        {
+            if (m_ViewModel is not null) m_ViewModel.ActiveShellView = ShellView.Holidays;
+        }
+
+        private void NavMetrics_Click(object? sender, RoutedEventArgs e)
+        {
+            if (m_ViewModel is not null) m_ViewModel.ActiveShellView = ShellView.Metrics;
+        }
+
+        private void NavEarnedValue_Click(object? sender, RoutedEventArgs e)
+        {
+            if (m_ViewModel is not null) m_ViewModel.ActiveShellView = ShellView.EarnedValue;
+        }
+
+        private void NavProjectScenario_Click(object? sender, RoutedEventArgs e)
+        {
+            if (m_ViewModel is not null) m_ViewModel.ActiveShellView = ShellView.ProjectScenario;
+        }
+
+        private void NavOutput_Click(object? sender, RoutedEventArgs e)
+        {
+            if (m_ViewModel is not null) m_ViewModel.ActiveShellView = ShellView.Output;
         }
 
         // ── Palette handlers ──

--- a/src/Zametek.View.ProjectPlan/MainView.axaml.cs
+++ b/src/Zametek.View.ProjectPlan/MainView.axaml.cs
@@ -6,7 +6,10 @@ using Avalonia.Interactivity;
 using Avalonia.Styling;
 using ReactiveUI;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reactive.Linq;
+using System.Windows.Input;
 using Ursa.Controls;
 using Zametek.Common.ProjectPlan;
 using Zametek.Contract.ProjectPlan;
@@ -14,6 +17,27 @@ using Zametek.Utility;
 
 namespace Zametek.View.ProjectPlan
 {
+    public class PaletteCommand
+    {
+        public string Label { get; }
+        public string Gesture { get; }
+        public ICommand UnderlyingCommand { get; }
+        public ICommand ExecuteCommand { get; }
+
+        public PaletteCommand(string label, string gesture, ICommand command, Action? onExecuted = null)
+        {
+            Label = label;
+            Gesture = gesture;
+            UnderlyingCommand = command;
+            ExecuteCommand = new RelayCommand(() =>
+            {
+                if (command.CanExecute(null))
+                    command.Execute(null);
+                onExecuted?.Invoke();
+            });
+        }
+    }
+
     public partial class MainView
         : Window
     {
@@ -24,17 +48,102 @@ namespace Zametek.View.ProjectPlan
         private WindowToastManager? m_ToastManager;
         const int c_MaxToastItems = 3;
 
+        private List<PaletteCommand> m_AllPaletteCommands = [];
+        private List<PaletteCommand> m_FilteredPaletteCommands = [];
+
         public MainView()
         {
             InitializeComponent();
             Loaded += MainView_Loaded;
             Unloaded += MainView_Unloaded;
             InitialTheme = string.Empty;
+
+            // Ctrl+K — open command palette
+            KeyBindings.Add(new KeyBinding
+            {
+                Gesture = new KeyGesture(Key.K, KeyModifiers.Control),
+                Command = new RelayCommand(() =>
+                {
+                    if (m_ViewModel is not null)
+                    {
+                        m_ViewModel.IsCommandPaletteOpen = !m_ViewModel.IsCommandPaletteOpen;
+                        if (m_ViewModel.IsCommandPaletteOpen)
+                        {
+                            OpenPalette();
+                        }
+                    }
+                })
+            });
         }
 
         // This has to be set here because of how the ThemeToggleButton loads.
         // Even when TwoWay binding is in place, it still forces an initial value of 'Light'.
         public string InitialTheme { get; set; }
+
+        private void BuildPaletteCommands()
+        {
+            if (m_ViewModel is null) return;
+
+            m_AllPaletteCommands =
+            [
+                new PaletteCommand("Open Project", "Ctrl+O", m_ViewModel.OpenProjectFileCommand, ClosePalette),
+                new PaletteCommand("Save Project", "Ctrl+S", m_ViewModel.SaveProjectFileCommand, ClosePalette),
+                new PaletteCommand("Save Project As", "", m_ViewModel.SaveAsProjectFileCommand, ClosePalette),
+                new PaletteCommand("Import Scenario", "", m_ViewModel.ImportProjectScenarioFileCommand, ClosePalette),
+                new PaletteCommand("Export Scenario", "", m_ViewModel.ExportProjectScenarioFileCommand, ClosePalette),
+                new PaletteCommand("Close Project", "", m_ViewModel.CloseProjectCommand, ClosePalette),
+                new PaletteCommand("Compile", "", m_ViewModel.CompileCommand, ClosePalette),
+                new PaletteCommand("Transitive Reduction", "", m_ViewModel.TransitiveReductionCommand, ClosePalette),
+                new PaletteCommand("Toggle Dates", "Ctrl+D", m_ViewModel.ToggleShowDatesCommand, ClosePalette),
+                new PaletteCommand("Toggle Cost", "Ctrl+W", m_ViewModel.ToggleHideCostCommand, ClosePalette),
+                new PaletteCommand("Toggle Billing", "Ctrl+E", m_ViewModel.ToggleHideBillingCommand, ClosePalette),
+                new PaletteCommand("Toggle Auto-Compile", "", m_ViewModel.ToggleAutoCompileCommand, ClosePalette),
+                new PaletteCommand("Switch to Activities + Gantt", "", new RelayCommand(() => m_ViewModel.ActiveShellView = ShellView.ActivitiesGantt), ClosePalette),
+                new PaletteCommand("Switch to Resources", "", new RelayCommand(() => m_ViewModel.ActiveShellView = ShellView.Resources), ClosePalette),
+                new PaletteCommand("Switch to Scenario", "", new RelayCommand(() => m_ViewModel.ActiveShellView = ShellView.Scenario), ClosePalette),
+                new PaletteCommand("Switch to Arrow Graph", "", new RelayCommand(() => m_ViewModel.ActiveShellView = ShellView.ArrowGraph), ClosePalette),
+                new PaletteCommand("Switch to Vertex Graph", "", new RelayCommand(() => m_ViewModel.ActiveShellView = ShellView.VertexGraph), ClosePalette),
+                new PaletteCommand("Switch to Tracking", "", new RelayCommand(() => m_ViewModel.ActiveShellView = ShellView.Tracking), ClosePalette),
+                new PaletteCommand("Add Activity", "", m_ViewModel.ActivitiesManagerViewModel.AddManagedActivityCommand, ClosePalette),
+                new PaletteCommand("Documentation", "", m_ViewModel.OpenDocumentationCommand, ClosePalette),
+                new PaletteCommand("Report Issue", "", m_ViewModel.OpenReportIssueCommand, ClosePalette),
+                new PaletteCommand("About", "", m_ViewModel.OpenAboutCommand, ClosePalette),
+            ];
+
+            m_FilteredPaletteCommands = [.. m_AllPaletteCommands];
+        }
+
+        private void OpenPalette()
+        {
+            FilterPalette(string.Empty);
+            PaletteSearchBox?.Focus();
+            if (PaletteSearchBox is not null)
+                PaletteSearchBox.Text = string.Empty;
+        }
+
+        private void FilterPalette(string? query)
+        {
+            if (string.IsNullOrWhiteSpace(query))
+            {
+                m_FilteredPaletteCommands = [.. m_AllPaletteCommands];
+            }
+            else
+            {
+                string lower = query.ToLowerInvariant();
+                m_FilteredPaletteCommands = m_AllPaletteCommands
+                    .Where(c => c.Label.Contains(lower, StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+            }
+
+            if (PaletteItemsControl is not null)
+                PaletteItemsControl.ItemsSource = m_FilteredPaletteCommands;
+        }
+
+        private void ClosePalette()
+        {
+            if (m_ViewModel is not null)
+                m_ViewModel.IsCommandPaletteOpen = false;
+        }
 
         // https://github.com/irihitech/Ursa.Avalonia/blob/main/demo/Ursa.Demo/Pages/ToastDemo.axaml.cs
         private void MainView_Loaded(
@@ -75,6 +184,18 @@ namespace Zametek.View.ProjectPlan
                     .Subscribe(ShowCompilationError);
 
                 m_ViewModel.SelectedTheme = InitialTheme;
+
+                BuildPaletteCommands();
+
+                // Wire up command palette trigger click
+                if (CommandPaletteTrigger is not null)
+                {
+                    CommandPaletteTrigger.PointerPressed += (_, _) =>
+                    {
+                        m_ViewModel.IsCommandPaletteOpen = true;
+                        OpenPalette();
+                    };
+                }
             }
         }
 
@@ -129,5 +250,89 @@ namespace Zametek.View.ProjectPlan
                     classes: [inheritedThemeVariant.ToString() ?? Resource.ProjectPlan.Themes.Theme_Default]);
             }
         }
+
+        // ── Nav button click handlers ──
+
+        private void NavActivitiesGantt_Click(object? sender, RoutedEventArgs e)
+        {
+            if (m_ViewModel is not null) m_ViewModel.ActiveShellView = ShellView.ActivitiesGantt;
+        }
+
+        private void NavResources_Click(object? sender, RoutedEventArgs e)
+        {
+            if (m_ViewModel is not null) m_ViewModel.ActiveShellView = ShellView.Resources;
+        }
+
+        private void NavScenario_Click(object? sender, RoutedEventArgs e)
+        {
+            if (m_ViewModel is not null) m_ViewModel.ActiveShellView = ShellView.Scenario;
+        }
+
+        private void NavArrowGraph_Click(object? sender, RoutedEventArgs e)
+        {
+            if (m_ViewModel is not null) m_ViewModel.ActiveShellView = ShellView.ArrowGraph;
+        }
+
+        private void NavVertexGraph_Click(object? sender, RoutedEventArgs e)
+        {
+            if (m_ViewModel is not null) m_ViewModel.ActiveShellView = ShellView.VertexGraph;
+        }
+
+        private void NavTracking_Click(object? sender, RoutedEventArgs e)
+        {
+            if (m_ViewModel is not null) m_ViewModel.ActiveShellView = ShellView.Tracking;
+        }
+
+        // ── Palette handlers ──
+
+        private void PaletteSearch_TextChanged(object? sender, TextChangedEventArgs e)
+        {
+            FilterPalette((sender as TextBox)?.Text);
+        }
+
+        private void PaletteSearch_KeyDown(object? sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape)
+            {
+                ClosePalette();
+                e.Handled = true;
+            }
+        }
+
+        // Clicking outside the palette closes it
+        protected override void OnPointerPressed(PointerPressedEventArgs e)
+        {
+            base.OnPointerPressed(e);
+            if (m_ViewModel?.IsCommandPaletteOpen == true)
+            {
+                // Check if click is inside the palette border
+                var paletteVisual = this.FindControl<Border>("PaletteOverlay");
+                if (paletteVisual is not null)
+                {
+                    var pt = e.GetPosition(paletteVisual);
+                    var bounds = paletteVisual.Bounds;
+                    if (pt.X < 0 || pt.Y < 0 || pt.X > bounds.Width || pt.Y > bounds.Height)
+                    {
+                        ClosePalette();
+                    }
+                }
+            }
+        }
+    }
+
+    /// <summary>Minimal relay command for palette items that have no ViewModel backing.</summary>
+    internal sealed class RelayCommand : ICommand
+    {
+        private readonly Action m_Execute;
+
+        public RelayCommand(Action execute) => m_Execute = execute;
+
+#pragma warning disable CS0067
+        public event EventHandler? CanExecuteChanged;
+#pragma warning restore CS0067
+
+        public bool CanExecute(object? parameter) => true;
+
+        public void Execute(object? parameter) => m_Execute();
     }
 }

--- a/src/Zametek.View.ProjectPlan/MetricManagement/MetricManagerView.axaml
+++ b/src/Zametek.View.ProjectPlan/MetricManagement/MetricManagerView.axaml
@@ -11,11 +11,28 @@
 	<UserControl.Resources>
 	</UserControl.Resources>
 
+	<UserControl.Styles>
+		<!-- Metric label: muted caption -->
+		<Style Selector="SelectableTextBlock.metric-label">
+			<Setter Property="FontSize" Value="11"/>
+			<Setter Property="Opacity" Value="0.65"/>
+			<Setter Property="VerticalAlignment" Value="Center"/>
+			<Setter Property="HorizontalAlignment" Value="Right"/>
+		</Style>
+		<!-- Metric value: prominent -->
+		<Style Selector="SelectableTextBlock.metric-value">
+			<Setter Property="FontSize" Value="12"/>
+			<Setter Property="FontWeight" Value="SemiBold"/>
+			<Setter Property="VerticalAlignment" Value="Center"/>
+			<Setter Property="Margin" Value="8,0,0,0"/>
+		</Style>
+	</UserControl.Styles>
+
 	<ScrollViewer VerticalScrollBarVisibility="Auto"
 				  HorizontalScrollBarVisibility="Disabled">
-		<WrapPanel Margin="7"
+		<WrapPanel Margin="4"
 				   Orientation="Horizontal">
-			<Grid Margin="7">
+			<Grid Margin="8">
 				<Grid.ColumnDefinitions>
 					<ColumnDefinition Width="135"/>
 					<ColumnDefinition Width="100"/>
@@ -34,7 +51,7 @@
 				<SelectableTextBlock Grid.Column="1" Grid.Row="0"
 									 VerticalAlignment="Center"
 									 Margin="7,0,0,0"
-									 FontWeight="Bold"
+									 FontWeight="SemiBold"
 									 Text="{Binding Path=ActivityRisk, Mode=OneWay, StringFormat=\{0:N2\}}"/>
 
 				<SelectableTextBlock Grid.Column="0" Grid.Row="1"
@@ -44,7 +61,7 @@
 				<SelectableTextBlock Grid.Column="1" Grid.Row="1"
 						             VerticalAlignment="Center"
 						             Margin="7,0,0,0"
-						             FontWeight="Bold"
+						             FontWeight="SemiBold"
 						             Text="{Binding Path=ActivityRiskWithStdDevCorrection, Mode=OneWay, StringFormat=\{0:N2\}}"/>
 
 				<SelectableTextBlock Grid.Column="0" Grid.Row="2"
@@ -54,7 +71,7 @@
 				<SelectableTextBlock Grid.Column="1" Grid.Row="2"
 						             VerticalAlignment="Center"
 						             Margin="7,0,0,0"
-						             FontWeight="Bold"
+						             FontWeight="SemiBold"
 						             Text="{Binding Path=CriticalityRisk, Mode=OneWay, StringFormat=\{0:N2\}}"/>
 
 				<SelectableTextBlock Grid.Column="0" Grid.Row="3"
@@ -64,11 +81,11 @@
 				<SelectableTextBlock Grid.Column="1" Grid.Row="3"
 						             VerticalAlignment="Center"
 						             Margin="7,0,0,0"
-						             FontWeight="Bold"
+						             FontWeight="SemiBold"
 						             Text="{Binding Path=FibonacciRisk, Mode=OneWay, StringFormat=\{0:N2\}}"/>
 			</Grid>
 
-			<Grid Margin="7">
+			<Grid Margin="8">
 				<Grid.ColumnDefinitions>
 					<ColumnDefinition Width="135"/>
 					<ColumnDefinition Width="100"/>
@@ -87,7 +104,7 @@
 				<SelectableTextBlock Grid.Column="1" Grid.Row="0"
 						             VerticalAlignment="Center"
 						             Margin="7,0,0,0"
-						             FontWeight="Bold"
+						             FontWeight="SemiBold"
 						             Text="{Binding Path=NetworkCyclomaticComplexity, Mode=OneWay, StringFormat=\{0:N0\}}"/>
 
 				<SelectableTextBlock Grid.Column="0" Grid.Row="1"
@@ -97,7 +114,7 @@
 				<SelectableTextBlock Grid.Column="1" Grid.Row="1"
 						             VerticalAlignment="Center"
 						             Margin="7,0,0,0"
-						             FontWeight="Bold"
+						             FontWeight="SemiBold"
 						             Text="{Binding Path=GeometricActivityRisk, Mode=OneWay, StringFormat=\{0:N2\}}"/>
 
 				<SelectableTextBlock Grid.Column="0" Grid.Row="2"
@@ -107,7 +124,7 @@
 				<SelectableTextBlock Grid.Column="1" Grid.Row="2"
 						             VerticalAlignment="Center"
 						             Margin="7,0,0,0"
-						             FontWeight="Bold"
+						             FontWeight="SemiBold"
 						             Text="{Binding Path=GeometricCriticalityRisk, Mode=OneWay, StringFormat=\{0:N2\}}"/>
 
 				<SelectableTextBlock Grid.Column="0" Grid.Row="3"
@@ -117,11 +134,11 @@
 				<SelectableTextBlock Grid.Column="1" Grid.Row="3"
 						             VerticalAlignment="Center"
 						             Margin="7,0,0,0"
-						             FontWeight="Bold"
+						             FontWeight="SemiBold"
 						             Text="{Binding Path=GeometricFibonacciRisk, Mode=OneWay, StringFormat=\{0:N2\}}"/>
 			</Grid>
 
-			<Grid Margin="7">
+			<Grid Margin="8">
 				<Grid.ColumnDefinitions>
 					<ColumnDefinition Width="135"/>
 					<ColumnDefinition Width="100"/>
@@ -140,7 +157,7 @@
 				<SelectableTextBlock Grid.Column="1" Grid.Row="0"
 						             VerticalAlignment="Center"
 						             Margin="7,0,0,0"
-						             FontWeight="Bold"
+						             FontWeight="SemiBold"
 						             Text="{Binding Path=ActivityEffort, Mode=OneWay, StringFormat=\{0:N0\}}"/>
 
 				<SelectableTextBlock Grid.Column="0" Grid.Row="1"
@@ -150,7 +167,7 @@
 				<SelectableTextBlock Grid.Column="1" Grid.Row="1"
 						             VerticalAlignment="Center"
 						             Margin="7,0,0,0"
-						             FontWeight="Bold"
+						             FontWeight="SemiBold"
 						             Text="{Binding Path=NetworkDurationManMonths, Mode=OneWay, StringFormat=\{0:N1\}}"/>
 
 				<SelectableTextBlock Grid.Column="0" Grid.Row="2"
@@ -160,7 +177,7 @@
 				<SelectableTextBlock Grid.Column="1" Grid.Row="2"
 						             VerticalAlignment="Center"
 						             Margin="7,0,0,0"
-						             FontWeight="Bold"
+						             FontWeight="SemiBold"
 						             Text="{Binding Path=ProjectFinish, Mode=OneWay}"/>
 
 				<SelectableTextBlock Grid.Column="0" Grid.Row="3"
@@ -170,11 +187,11 @@
 				<SelectableTextBlock Grid.Column="1" Grid.Row="3"
 						             VerticalAlignment="Center"
 						             Margin="7,0,0,0"
-						             FontWeight="Bold"
+						             FontWeight="SemiBold"
 						             Text="{Binding Path=EffortEfficiency, Mode=OneWay, StringFormat=\{0:P1\}}"/>
 			</Grid>
 
-			<Grid Margin="7">
+			<Grid Margin="8">
 				<Grid.ColumnDefinitions>
 					<ColumnDefinition Width="135"/>
 					<ColumnDefinition Width="100"/>
@@ -193,7 +210,7 @@
 				<SelectableTextBlock Grid.Column="1" Grid.Row="0"
 						             VerticalAlignment="Center"
 						             Margin="7,0,0,0"
-						             FontWeight="Bold"
+						             FontWeight="SemiBold"
 						             Text="{Binding Path=DirectEffort, Mode=OneWay, StringFormat=\{0:N0\}}"/>
 
 				<SelectableTextBlock Grid.Column="0" Grid.Row="1"
@@ -203,7 +220,7 @@
 				<SelectableTextBlock Grid.Column="1" Grid.Row="1"
 						             VerticalAlignment="Center"
 						             Margin="7,0,0,0"
-						             FontWeight="Bold"
+						             FontWeight="SemiBold"
 						             Text="{Binding Path=IndirectEffort, Mode=OneWay, StringFormat=\{0:N0\}}"/>
 
 				<SelectableTextBlock Grid.Column="0" Grid.Row="2"
@@ -213,7 +230,7 @@
 				<SelectableTextBlock Grid.Column="1" Grid.Row="2"
 						             VerticalAlignment="Center"
 						             Margin="7,0,0,0"
-						             FontWeight="Bold"
+						             FontWeight="SemiBold"
 						             Text="{Binding Path=OtherEffort, Mode=OneWay, StringFormat=\{0:N0\}}"/>
 
 				<SelectableTextBlock Grid.Column="0" Grid.Row="3"
@@ -223,11 +240,11 @@
 				<SelectableTextBlock Grid.Column="1" Grid.Row="3"
 						             VerticalAlignment="Center"
 						             Margin="7,0,0,0"
-						             FontWeight="Bold"
+						             FontWeight="SemiBold"
 						             Text="{Binding Path=TotalEffort, Mode=OneWay, StringFormat=\{0:N0\}}"/>
 			</Grid>
 
-			<Grid Margin="7"
+			<Grid Margin="8"
 				  IsVisible="{Binding Path=!HideCost, Mode=OneWay}">
 				<Grid.ColumnDefinitions>
 					<ColumnDefinition Width="135"/>
@@ -247,7 +264,7 @@
 				<SelectableTextBlock Grid.Column="1" Grid.Row="0"
 						             VerticalAlignment="Center"
 						             Margin="7,0,0,0"
-						             FontWeight="Bold"
+						             FontWeight="SemiBold"
 						             Text="{Binding Path=DirectCost, Mode=OneWay, StringFormat=\{0:N2\}}"/>
 
 				<SelectableTextBlock Grid.Column="0" Grid.Row="1"
@@ -257,7 +274,7 @@
 				<SelectableTextBlock Grid.Column="1" Grid.Row="1"
 						             VerticalAlignment="Center"
 						             Margin="7,0,0,0"
-						             FontWeight="Bold"
+						             FontWeight="SemiBold"
 						             Text="{Binding Path=IndirectCost, Mode=OneWay, StringFormat=\{0:N2\}}"/>
 
 				<SelectableTextBlock Grid.Column="0" Grid.Row="2"
@@ -267,7 +284,7 @@
 				<SelectableTextBlock Grid.Column="1" Grid.Row="2"
 						             VerticalAlignment="Center"
 						             Margin="7,0,0,0"
-						             FontWeight="Bold"
+						             FontWeight="SemiBold"
 						             Text="{Binding Path=OtherCost, Mode=OneWay, StringFormat=\{0:N2\}}"/>
 
 				<SelectableTextBlock Grid.Column="0" Grid.Row="3"
@@ -277,11 +294,11 @@
 				<SelectableTextBlock Grid.Column="1" Grid.Row="3"
 						             VerticalAlignment="Center"
 						             Margin="7,0,0,0"
-						             FontWeight="Bold"
+						             FontWeight="SemiBold"
 						             Text="{Binding Path=TotalCost, Mode=OneWay, StringFormat=\{0:N2\}}"/>
 			</Grid>
 
-			<Grid Margin="7"
+			<Grid Margin="8"
 				  IsVisible="{Binding Path=!HideBilling, Mode=OneWay}">
 				<Grid.ColumnDefinitions>
 					<ColumnDefinition Width="135"/>
@@ -301,7 +318,7 @@
 				<SelectableTextBlock Grid.Column="1" Grid.Row="0"
 						             VerticalAlignment="Center"
 						             Margin="7,0,0,0"
-						             FontWeight="Bold"
+						             FontWeight="SemiBold"
 						             Text="{Binding Path=DirectBilling, Mode=OneWay, StringFormat=\{0:N2\}}"/>
 
 				<SelectableTextBlock Grid.Column="0" Grid.Row="1"
@@ -311,7 +328,7 @@
 				<SelectableTextBlock Grid.Column="1" Grid.Row="1"
 						             VerticalAlignment="Center"
 						             Margin="7,0,0,0"
-						             FontWeight="Bold"
+						             FontWeight="SemiBold"
 						             Text="{Binding Path=IndirectBilling, Mode=OneWay, StringFormat=\{0:N2\}}"/>
 
 				<SelectableTextBlock Grid.Column="0" Grid.Row="2"
@@ -321,7 +338,7 @@
 				<SelectableTextBlock Grid.Column="1" Grid.Row="2"
 						             VerticalAlignment="Center"
 						             Margin="7,0,0,0"
-						             FontWeight="Bold"
+						             FontWeight="SemiBold"
 						             Text="{Binding Path=OtherBilling, Mode=OneWay, StringFormat=\{0:N2\}}"/>
 
 				<SelectableTextBlock Grid.Column="0" Grid.Row="3"
@@ -331,11 +348,11 @@
 				<SelectableTextBlock Grid.Column="1" Grid.Row="3"
 						             VerticalAlignment="Center"
 						             Margin="7,0,0,0"
-						             FontWeight="Bold"
+						             FontWeight="SemiBold"
 						             Text="{Binding Path=TotalBilling, Mode=OneWay, StringFormat=\{0:N2\}}"/>
 			</Grid>
 
-			<Grid Margin="7"
+			<Grid Margin="8"
 				  IsVisible="{Binding Path=!HideMargin, Mode=OneWay}">
 				<Grid.ColumnDefinitions>
 					<ColumnDefinition Width="135"/>
@@ -355,7 +372,7 @@
 				<SelectableTextBlock Grid.Column="1" Grid.Row="0"
 						             VerticalAlignment="Center"
 						             Margin="7,0,0,0"
-						             FontWeight="Bold">
+						             FontWeight="SemiBold">
 					<SelectableTextBlock.Text>
 						<MultiBinding StringFormat="{}{0:N2}{1}">
 							<Binding Path="DirectMarginAbsolute" Mode="OneWay" />
@@ -371,7 +388,7 @@
 				<SelectableTextBlock Grid.Column="1" Grid.Row="1"
 						             VerticalAlignment="Center"
 						             Margin="7,0,0,0"
-						             FontWeight="Bold">
+						             FontWeight="SemiBold">
 					<SelectableTextBlock.Text>
 						<MultiBinding StringFormat="{}{0:N2}{1}">
 							<Binding Path="IndirectMarginAbsolute" Mode="OneWay" />
@@ -387,7 +404,7 @@
 				<SelectableTextBlock Grid.Column="1" Grid.Row="2"
 						             VerticalAlignment="Center"
 						             Margin="7,0,0,0"
-						             FontWeight="Bold">
+						             FontWeight="SemiBold">
 					<SelectableTextBlock.Text>
 						<MultiBinding StringFormat="{}{0:N2}{1}">
 							<Binding Path="OtherMarginAbsolute" Mode="OneWay" />
@@ -403,7 +420,7 @@
 				<SelectableTextBlock Grid.Column="1" Grid.Row="3"
 						             VerticalAlignment="Center"
 						             Margin="7,0,0,0"
-						             FontWeight="Bold">
+						             FontWeight="SemiBold">
 					<SelectableTextBlock.Text>
 						<MultiBinding StringFormat="{}{0:N2}{1}">
 							<Binding Path="TotalMarginAbsolute" Mode="OneWay" />

--- a/src/Zametek.View.ProjectPlan/Miscellaneous/ConfirmationDialog.axaml
+++ b/src/Zametek.View.ProjectPlan/Miscellaneous/ConfirmationDialog.axaml
@@ -1,0 +1,35 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="Zametek.View.ProjectPlan.ConfirmationDialog"
+        Title=""
+        Width="360"
+        SizeToContent="Height"
+        CanResize="False"
+        ShowInTaskbar="False"
+        WindowStartupLocation="CenterOwner">
+
+    <StackPanel Margin="24,20,24,16" Spacing="16">
+
+        <!-- Message -->
+        <TextBlock x:Name="MessageText"
+                   TextWrapping="Wrap"
+                   FontSize="13"
+                   LineHeight="20" />
+
+        <!-- Buttons -->
+        <StackPanel Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    Spacing="8">
+            <Button x:Name="NoButton"
+                    Content="No"
+                    Width="80"
+                    Click="NoButton_Click" />
+            <Button x:Name="YesButton"
+                    Content="Yes"
+                    Width="80"
+                    Classes="accent"
+                    Click="YesButton_Click" />
+        </StackPanel>
+
+    </StackPanel>
+</Window>

--- a/src/Zametek.View.ProjectPlan/Miscellaneous/ConfirmationDialog.axaml.cs
+++ b/src/Zametek.View.ProjectPlan/Miscellaneous/ConfirmationDialog.axaml.cs
@@ -1,0 +1,35 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+
+namespace Zametek.View.ProjectPlan
+{
+    public partial class ConfirmationDialog : Window
+    {
+        public bool Result { get; private set; }
+
+        // Parameterless ctor required by the Avalonia XAML runtime loader.
+        public ConfirmationDialog()
+        {
+            InitializeComponent();
+        }
+
+        public ConfirmationDialog(string title, string message)
+        {
+            InitializeComponent();
+            Title = title;
+            MessageText.Text = message;
+        }
+
+        private void YesButton_Click(object? sender, RoutedEventArgs e)
+        {
+            Result = true;
+            Close();
+        }
+
+        private void NoButton_Click(object? sender, RoutedEventArgs e)
+        {
+            Result = false;
+            Close();
+        }
+    }
+}

--- a/src/Zametek.View.ProjectPlan/Miscellaneous/DialogService.cs
+++ b/src/Zametek.View.ProjectPlan/Miscellaneous/DialogService.cs
@@ -32,6 +32,34 @@ namespace Zametek.View.ProjectPlan
 
         #region Private Methods
 
+        /// <summary>
+        /// Builds a FilePickerFileType from a FileFilter, ensuring AppleUniformTypeIdentifiers
+        /// are set so macOS doesn't grey out files with unregistered extensions (e.g. .zpp).
+        /// </summary>
+        private static FilePickerFileType BuildFilePickerFileType(FileFilter filter)
+        {
+            // Extract bare extensions from patterns like "*.zpp" → "zpp"
+            var extensions = filter.Patterns
+                .Where(p => p.StartsWith("*.") && p.Length > 2)
+                .Select(p => p[2..])
+                .ToList();
+
+            // On macOS, Avalonia maps AppleUniformTypeIdentifiers to NSOpenPanel allowedContentTypes.
+            // Without this, files with unrecognised extensions are greyed out.
+            // "public.data" is a catch-all UTI that allows any binary data file to be selected.
+            // "public.item" is even broader (includes directories), so we prefer public.data.
+            string[] appleUtis = extensions.Count > 0
+                ? ["public.data"]
+                : ["public.item"];
+
+            return new FilePickerFileType(filter.Name)
+            {
+                Patterns = filter.Patterns,
+                AppleUniformTypeIdentifiers = appleUtis,
+                MimeTypes = ["application/octet-stream"]
+            };
+        }
+
         private async Task<ButtonResult> ShowMessageBoxAsync(MessageBoxStandardParams standardParams)
         {
             return await Dispatcher.UIThread.InvokeAsync(() =>
@@ -250,7 +278,7 @@ namespace Zametek.View.ProjectPlan
                 return null;
             }
 
-            List<FilePickerFileType> filters = [.. fileFilters.Cast<FileFilter>().Select(m_Mapper.ToFilePickerFileType)];
+            List<FilePickerFileType> filters = [.. fileFilters.Cast<FileFilter>().Select(BuildFilePickerFileType)];
 
             var options = new FilePickerOpenOptions
             {
@@ -284,7 +312,7 @@ namespace Zametek.View.ProjectPlan
                 return null;
             }
 
-            List<FilePickerFileType> filters = [.. fileFilters.Cast<FileFilter>().Select(m_Mapper.ToFilePickerFileType)];
+            List<FilePickerFileType> filters = [.. fileFilters.Cast<FileFilter>().Select(BuildFilePickerFileType)];
 
             var options = new FilePickerSaveOptions
             {

--- a/src/Zametek.View.ProjectPlan/Miscellaneous/DialogService.cs
+++ b/src/Zametek.View.ProjectPlan/Miscellaneous/DialogService.cs
@@ -253,18 +253,22 @@ namespace Zametek.View.ProjectPlan
             string message,
             bool markdown = false)
         {
-            ButtonResult result = await ShowMessageBoxAsync(new MessageBoxStandardParams
+            return await Dispatcher.UIThread.InvokeAsync(async () =>
             {
-                WindowStartupLocation = WindowStartupLocation.CenterOwner,
-                SizeToContent = SizeToContent.WidthAndHeight,
-                ContentTitle = title,
-                ContentHeader = header,
-                ContentMessage = message,
-                ButtonDefinitions = ButtonEnum.YesNo,
-                Icon = Icon.Info,
-                Markdown = markdown
+                if (m_Parent is null)
+                {
+                    return false;
+                }
+
+                // Combine header + message into one string for the custom dialog.
+                string body = string.IsNullOrWhiteSpace(header)
+                    ? message
+                    : $"{header}\n\n{message}";
+
+                var dialog = new ConfirmationDialog(title, body);
+                await dialog.ShowDialog(m_Parent);
+                return dialog.Result;
             });
-            return result == ButtonResult.Yes;
         }
 
         public async Task<string?> ShowOpenFileDialogAsync(

--- a/src/Zametek.View.ProjectPlan/Miscellaneous/EnumConverters.cs
+++ b/src/Zametek.View.ProjectPlan/Miscellaneous/EnumConverters.cs
@@ -13,5 +13,8 @@ namespace Zametek.View.ProjectPlan
 
         public static readonly IValueConverter IsNotRecurrenceFrequencyMatch =
             new FuncValueConverter<RecurrenceFrequency, RecurrenceFrequency, bool>((x, y) => x != y);
+
+        public static readonly IValueConverter IsShellViewMatch =
+            new FuncValueConverter<ShellView, ShellView, bool>((x, y) => x == y);
     }
 }

--- a/src/Zametek.View.ProjectPlan/ProjectScenarioManagement/AddNodeTagView.axaml
+++ b/src/Zametek.View.ProjectPlan/ProjectScenarioManagement/AddNodeTagView.axaml
@@ -28,7 +28,7 @@
 		
 		<TextBox Grid.Row="0" Grid.Column="1"
 				 Text="{Binding Path=Tag, Mode=TwoWay}"
-				 BorderBrush="Gray"
+				 BorderBrush="{DynamicResource ZBorder}"
 				 BorderThickness="1"/>
 	</Grid>
 </UserControl>

--- a/src/Zametek.View.ProjectPlan/ProjectScenarioManagement/NodeNameView.axaml
+++ b/src/Zametek.View.ProjectPlan/ProjectScenarioManagement/NodeNameView.axaml
@@ -28,7 +28,7 @@
 		
 		<TextBox Grid.Row="0" Grid.Column="1"
 				 Text="{Binding Path=Name, Mode=TwoWay}"
-				 BorderBrush="Gray"
+				 BorderBrush="{DynamicResource ZBorder}"
 				 BorderThickness="1"/>
 	</Grid>
 </UserControl>

--- a/src/Zametek.View.ProjectPlan/ResourceChartManagement/ResourceChartManagerView.axaml
+++ b/src/Zametek.View.ProjectPlan/ResourceChartManagement/ResourceChartManagerView.axaml
@@ -16,19 +16,24 @@
 	</UserControl.Resources>
 
 	<DockPanel Margin="7">
-		<ScrollViewer DockPanel.Dock="Right"
-					  VerticalScrollBarVisibility="Auto"
+		<Border DockPanel.Dock="Right"
+				BorderThickness="1,0,0,0"
+				BorderBrush="{DynamicResource SemiColorBorder}">
+		<ScrollViewer VerticalScrollBarVisibility="Auto"
 					  HorizontalScrollBarVisibility="Disabled">
-			<DockPanel MinWidth="120"
-					   Margin="11,0,0,0">
+			<DockPanel MinWidth="128"
+					   Margin="12,8,8,8">
 
 				<DockPanel DockPanel.Dock="Top">
 					<Label VerticalContentAlignment="Center"
 						   HorizontalContentAlignment="Left"
-						   Height="25"
+						   Height="22"
 						   DockPanel.Dock="Top"
 						   IsTabStop="False"
-						   Margin="0,0,0,3"
+						   FontSize="11"
+						   FontWeight="SemiBold"
+						   Opacity="0.65"
+						   Margin="0,0,0,2"
 						   Content="{x:Static resources:Labels.Label_AllocationMode}"/>
 
 					<ComboBox ItemsSource="{Binding Source={local:EnumBindingSource {x:Type common:AllocationMode}}}"
@@ -37,7 +42,7 @@
 							  BorderThickness="1"
 							  DockPanel.Dock="Top"
 							  IsTabStop="False"
-							  Margin="0,0,0,11"
+							  Margin="0,0,0,12"
 							  Height="25">
 						<ComboBox.ItemTemplate>
 							<DataTemplate>
@@ -55,10 +60,13 @@
 				<DockPanel DockPanel.Dock="Top">
 					<Label VerticalContentAlignment="Center"
 						   HorizontalContentAlignment="Left"
-						   Height="25"
+						   Height="22"
 						   DockPanel.Dock="Top"
 						   IsTabStop="False"
-						   Margin="0,0,0,3"
+						   FontSize="11"
+						   FontWeight="SemiBold"
+						   Opacity="0.65"
+						   Margin="0,0,0,2"
 						   Content="{x:Static resources:Labels.Label_ScheduleMode}"/>
 
 					<ComboBox ItemsSource="{Binding Source={local:EnumBindingSource {x:Type common:ScheduleMode}}}"
@@ -67,7 +75,7 @@
 							  BorderThickness="1"
 							  DockPanel.Dock="Top"
 							  IsTabStop="False"
-							  Margin="0,0,0,11"
+							  Margin="0,0,0,12"
 							  Height="25">
 						<ComboBox.ItemTemplate>
 							<DataTemplate>
@@ -84,10 +92,13 @@
 				<DockPanel DockPanel.Dock="Top">
 					<Label VerticalContentAlignment="Center"
 						   HorizontalContentAlignment="Left"
-						   Height="25"
+						   Height="22"
 						   DockPanel.Dock="Top"
 						   IsTabStop="False"
-						   Margin="0,0,0,3"
+						   FontSize="11"
+						   FontWeight="SemiBold"
+						   Opacity="0.65"
+						   Margin="0,0,0,2"
 						   Content="{x:Static resources:Labels.Label_DisplayStyle}"/>
 
 					<ComboBox ItemsSource="{Binding Source={local:EnumBindingSource {x:Type common:DisplayStyle}}}"
@@ -96,7 +107,7 @@
 							  BorderThickness="1"
 							  DockPanel.Dock="Top"
 							  IsTabStop="False"
-							  Margin="0,0,0,11"
+							  Margin="0,0,0,12"
 							  Height="25">
 						<ComboBox.ItemTemplate>
 							<DataTemplate>
@@ -113,19 +124,22 @@
 				<DockPanel DockPanel.Dock="Top">
 					<Label VerticalContentAlignment="Center"
 						   HorizontalContentAlignment="Left"
-						   Height="25"
+						   Height="22"
 						   DockPanel.Dock="Top"
 						   IsTabStop="False"
-						   Margin="0,0,0,3"
+						   FontSize="11"
+						   FontWeight="SemiBold"
+						   Opacity="0.65"
+						   Margin="0,0,0,2"
 						   Content="{x:Static resources:Labels.Label_ShowToday}"/>
 
 					<ToggleSwitch DockPanel.Dock="Top"
 								  IsTabStop="False"
-								  Margin="0,0,0,11"
+								  Margin="0,0,0,12"
 								  VerticalAlignment="Center"
 								  VerticalContentAlignment="Center"
-								  HorizontalAlignment="Center"
-								  HorizontalContentAlignment="Center"
+								  HorizontalAlignment="Left"
+								  HorizontalContentAlignment="Left"
 								  OffContent="{x:Static resources:Labels.Label_No}"
 								  OnContent="{x:Static resources:Labels.Label_Yes}"
 								  IsChecked="{Binding Path=ShowToday, Mode=TwoWay}"/>
@@ -134,19 +148,22 @@
 				<DockPanel DockPanel.Dock="Top">
 					<Label VerticalContentAlignment="Center"
 						   HorizontalContentAlignment="Left"
-						   Height="25"
+						   Height="22"
 						   DockPanel.Dock="Top"
 						   IsTabStop="False"
-						   Margin="0,0,0,3"
+						   FontSize="11"
+						   FontWeight="SemiBold"
+						   Opacity="0.65"
+						   Margin="0,0,0,2"
 						   Content="{x:Static resources:Labels.Label_ShowMilestones}"/>
 
 					<ToggleSwitch DockPanel.Dock="Top"
 								  IsTabStop="False"
-								  Margin="0,0,0,11"
+								  Margin="0,0,0,12"
 								  VerticalAlignment="Center"
 								  VerticalContentAlignment="Center"
-								  HorizontalAlignment="Center"
-								  HorizontalContentAlignment="Center"
+								  HorizontalAlignment="Left"
+								  HorizontalContentAlignment="Left"
 								  OffContent="{x:Static resources:Labels.Label_No}"
 								  OnContent="{x:Static resources:Labels.Label_Yes}"
 								  IsChecked="{Binding Path=ShowMilestones, Mode=TwoWay}"/>
@@ -155,6 +172,7 @@
 				<Grid/>
 			</DockPanel>
 		</ScrollViewer>
+		</Border>
 
 		<DockPanel>
 			<!-- ScottPlot PlotView -->

--- a/src/Zametek.View.ProjectPlan/ResourceChartManagement/ResourceChartManagerView.axaml
+++ b/src/Zametek.View.ProjectPlan/ResourceChartManagement/ResourceChartManagerView.axaml
@@ -15,170 +15,120 @@
 		<converters:EnumToBoolConverter x:Key="enumToBool" />
 	</UserControl.Resources>
 
-	<DockPanel Margin="7">
+	<DockPanel>
 		<Border DockPanel.Dock="Right"
+				Background="{DynamicResource ZSurface}"
 				BorderThickness="1,0,0,0"
-				BorderBrush="{DynamicResource SemiColorBorder}">
+				BorderBrush="{DynamicResource ZBorder}">
 		<ScrollViewer VerticalScrollBarVisibility="Auto"
 					  HorizontalScrollBarVisibility="Disabled">
-			<DockPanel MinWidth="128"
-					   Margin="12,8,8,8">
+			<StackPanel MinWidth="148"
+						Margin="12,12,8,12"
+						Spacing="0">
 
-				<DockPanel DockPanel.Dock="Top">
-					<Label VerticalContentAlignment="Center"
-						   HorizontalContentAlignment="Left"
-						   Height="22"
-						   DockPanel.Dock="Top"
-						   IsTabStop="False"
-						   FontSize="11"
-						   FontWeight="SemiBold"
-						   Opacity="0.65"
-						   Margin="0,0,0,2"
-						   Content="{x:Static resources:Labels.Label_AllocationMode}"/>
+				<!-- Allocation Mode -->
+				<Label VerticalContentAlignment="Center"
+					   HorizontalContentAlignment="Left"
+					   IsTabStop="False"
+					   Classes="section-header"
+					   Content="{x:Static resources:Labels.Label_AllocationMode}"/>
+				<ComboBox ItemsSource="{Binding Source={local:EnumBindingSource {x:Type common:AllocationMode}}}"
+						  SelectedItem="{Binding Path=AllocationMode, Mode=TwoWay}"
+						  IsTabStop="False"
+						  Margin="0,0,0,12">
+					<ComboBox.ItemTemplate>
+						<DataTemplate>
+							<TextBlock VerticalAlignment="Center"
+									   TextAlignment="Left"
+									   Margin="0"
+									   Padding="3"
+									   Classes="displayOnly"
+									   Text="{Binding Converter={x:Static local:StringConverters.AllocationModeValue}, Mode=OneWay}"/>
+						</DataTemplate>
+					</ComboBox.ItemTemplate>
+				</ComboBox>
 
-					<ComboBox ItemsSource="{Binding Source={local:EnumBindingSource {x:Type common:AllocationMode}}}"
-							  SelectedItem="{Binding Path=AllocationMode, Mode=TwoWay}"
-							  BorderBrush="Gray"
-							  BorderThickness="1"
-							  DockPanel.Dock="Top"
-							  IsTabStop="False"
+				<!-- Schedule Mode -->
+				<Label VerticalContentAlignment="Center"
+					   HorizontalContentAlignment="Left"
+					   IsTabStop="False"
+					   Classes="section-header"
+					   Content="{x:Static resources:Labels.Label_ScheduleMode}"/>
+				<ComboBox ItemsSource="{Binding Source={local:EnumBindingSource {x:Type common:ScheduleMode}}}"
+						  SelectedItem="{Binding Path=ScheduleMode, Mode=TwoWay}"
+						  IsTabStop="False"
+						  Margin="0,0,0,12">
+					<ComboBox.ItemTemplate>
+						<DataTemplate>
+							<TextBlock VerticalAlignment="Center"
+									   TextAlignment="Left"
+									   Margin="0"
+									   Padding="3"
+									   Text="{Binding Converter={x:Static local:StringConverters.ScheduleModeValue}, Mode=OneWay}"/>
+						</DataTemplate>
+					</ComboBox.ItemTemplate>
+				</ComboBox>
+
+				<!-- Display Style -->
+				<Label VerticalContentAlignment="Center"
+					   HorizontalContentAlignment="Left"
+					   IsTabStop="False"
+					   Classes="section-header"
+					   Content="{x:Static resources:Labels.Label_DisplayStyle}"/>
+				<ComboBox ItemsSource="{Binding Source={local:EnumBindingSource {x:Type common:DisplayStyle}}}"
+						  SelectedItem="{Binding Path=DisplayStyle, Mode=TwoWay}"
+						  IsTabStop="False"
+						  Margin="0,0,0,12">
+					<ComboBox.ItemTemplate>
+						<DataTemplate>
+							<TextBlock VerticalAlignment="Center"
+									   TextAlignment="Left"
+									   Margin="0"
+									   Padding="3"
+									   Text="{Binding Converter={x:Static local:StringConverters.DisplayStyleValue}, Mode=OneWay}"/>
+						</DataTemplate>
+					</ComboBox.ItemTemplate>
+				</ComboBox>
+
+				<!-- Show Today -->
+				<Label VerticalContentAlignment="Center"
+					   HorizontalContentAlignment="Left"
+					   IsTabStop="False"
+					   Classes="section-header"
+					   Content="{x:Static resources:Labels.Label_ShowToday}"/>
+				<ToggleSwitch IsTabStop="False"
 							  Margin="0,0,0,12"
-							  Height="25">
-						<ComboBox.ItemTemplate>
-							<DataTemplate>
-								<TextBlock VerticalAlignment="Center"
-										   TextAlignment="Left"
-										   Margin="0"
-										   Padding="3"
-										   Classes="displayOnly"
-										   Text="{Binding Converter={x:Static local:StringConverters.AllocationModeValue}, Mode=OneWay}"/>
-							</DataTemplate>
-						</ComboBox.ItemTemplate>
-					</ComboBox>
-				</DockPanel>
+							  VerticalAlignment="Center"
+							  VerticalContentAlignment="Center"
+							  HorizontalAlignment="Left"
+							  HorizontalContentAlignment="Left"
+							  OffContent="{x:Static resources:Labels.Label_No}"
+							  OnContent="{x:Static resources:Labels.Label_Yes}"
+							  IsChecked="{Binding Path=ShowToday, Mode=TwoWay}"/>
 
-				<DockPanel DockPanel.Dock="Top">
-					<Label VerticalContentAlignment="Center"
-						   HorizontalContentAlignment="Left"
-						   Height="22"
-						   DockPanel.Dock="Top"
-						   IsTabStop="False"
-						   FontSize="11"
-						   FontWeight="SemiBold"
-						   Opacity="0.65"
-						   Margin="0,0,0,2"
-						   Content="{x:Static resources:Labels.Label_ScheduleMode}"/>
-
-					<ComboBox ItemsSource="{Binding Source={local:EnumBindingSource {x:Type common:ScheduleMode}}}"
-							  SelectedItem="{Binding Path=ScheduleMode, Mode=TwoWay}"
-							  BorderBrush="Gray"
-							  BorderThickness="1"
-							  DockPanel.Dock="Top"
-							  IsTabStop="False"
+				<!-- Show Milestones -->
+				<Label VerticalContentAlignment="Center"
+					   HorizontalContentAlignment="Left"
+					   IsTabStop="False"
+					   Classes="section-header"
+					   Content="{x:Static resources:Labels.Label_ShowMilestones}"/>
+				<ToggleSwitch IsTabStop="False"
 							  Margin="0,0,0,12"
-							  Height="25">
-						<ComboBox.ItemTemplate>
-							<DataTemplate>
-								<TextBlock VerticalAlignment="Center"
-										   TextAlignment="Left"
-										   Margin="0"
-										   Padding="3"
-										   Text="{Binding Converter={x:Static local:StringConverters.ScheduleModeValue}, Mode=OneWay}"/>
-							</DataTemplate>
-						</ComboBox.ItemTemplate>
-					</ComboBox>
-				</DockPanel>
+							  VerticalAlignment="Center"
+							  VerticalContentAlignment="Center"
+							  HorizontalAlignment="Left"
+							  HorizontalContentAlignment="Left"
+							  OffContent="{x:Static resources:Labels.Label_No}"
+							  OnContent="{x:Static resources:Labels.Label_Yes}"
+							  IsChecked="{Binding Path=ShowMilestones, Mode=TwoWay}"/>
 
-				<DockPanel DockPanel.Dock="Top">
-					<Label VerticalContentAlignment="Center"
-						   HorizontalContentAlignment="Left"
-						   Height="22"
-						   DockPanel.Dock="Top"
-						   IsTabStop="False"
-						   FontSize="11"
-						   FontWeight="SemiBold"
-						   Opacity="0.65"
-						   Margin="0,0,0,2"
-						   Content="{x:Static resources:Labels.Label_DisplayStyle}"/>
-
-					<ComboBox ItemsSource="{Binding Source={local:EnumBindingSource {x:Type common:DisplayStyle}}}"
-							  SelectedItem="{Binding Path=DisplayStyle, Mode=TwoWay}"
-							  BorderBrush="Gray"
-							  BorderThickness="1"
-							  DockPanel.Dock="Top"
-							  IsTabStop="False"
-							  Margin="0,0,0,12"
-							  Height="25">
-						<ComboBox.ItemTemplate>
-							<DataTemplate>
-								<TextBlock VerticalAlignment="Center"
-										   TextAlignment="Left"
-										   Margin="0"
-										   Padding="3"
-										   Text="{Binding Converter={x:Static local:StringConverters.DisplayStyleValue}, Mode=OneWay}"/>
-							</DataTemplate>
-						</ComboBox.ItemTemplate>
-					</ComboBox>
-				</DockPanel>
-
-				<DockPanel DockPanel.Dock="Top">
-					<Label VerticalContentAlignment="Center"
-						   HorizontalContentAlignment="Left"
-						   Height="22"
-						   DockPanel.Dock="Top"
-						   IsTabStop="False"
-						   FontSize="11"
-						   FontWeight="SemiBold"
-						   Opacity="0.65"
-						   Margin="0,0,0,2"
-						   Content="{x:Static resources:Labels.Label_ShowToday}"/>
-
-					<ToggleSwitch DockPanel.Dock="Top"
-								  IsTabStop="False"
-								  Margin="0,0,0,12"
-								  VerticalAlignment="Center"
-								  VerticalContentAlignment="Center"
-								  HorizontalAlignment="Left"
-								  HorizontalContentAlignment="Left"
-								  OffContent="{x:Static resources:Labels.Label_No}"
-								  OnContent="{x:Static resources:Labels.Label_Yes}"
-								  IsChecked="{Binding Path=ShowToday, Mode=TwoWay}"/>
-				</DockPanel>
-
-				<DockPanel DockPanel.Dock="Top">
-					<Label VerticalContentAlignment="Center"
-						   HorizontalContentAlignment="Left"
-						   Height="22"
-						   DockPanel.Dock="Top"
-						   IsTabStop="False"
-						   FontSize="11"
-						   FontWeight="SemiBold"
-						   Opacity="0.65"
-						   Margin="0,0,0,2"
-						   Content="{x:Static resources:Labels.Label_ShowMilestones}"/>
-
-					<ToggleSwitch DockPanel.Dock="Top"
-								  IsTabStop="False"
-								  Margin="0,0,0,12"
-								  VerticalAlignment="Center"
-								  VerticalContentAlignment="Center"
-								  HorizontalAlignment="Left"
-								  HorizontalContentAlignment="Left"
-								  OffContent="{x:Static resources:Labels.Label_No}"
-								  OnContent="{x:Static resources:Labels.Label_Yes}"
-								  IsChecked="{Binding Path=ShowMilestones, Mode=TwoWay}"/>
-				</DockPanel>
-
-				<Grid/>
-			</DockPanel>
+			</StackPanel>
 		</ScrollViewer>
 		</Border>
 
-		<DockPanel>
-			<!-- ScottPlot PlotView -->
-			<ContentControl x:Name="scottplot"
-							Content="{Binding ResourceChartPlotModel, Mode=OneWay}"
-							Bounds="{Binding Path=ImageBounds, Mode=OneWayToSource}">
+		<ContentControl x:Name="scottplot"
+						Content="{Binding ResourceChartPlotModel, Mode=OneWay}"
+						Bounds="{Binding Path=ImageBounds, Mode=OneWayToSource}">
 				<ContentControl.ContextMenu>
 					<ContextMenu>
 						<MenuItem Header="{x:Static resources:Labels.Label_ShowToday}"
@@ -264,7 +214,6 @@
 								  Command="{Binding Path=ResetResourceChartCommand, Mode=OneWay}" />
 					</ContextMenu>
 				</ContentControl.ContextMenu>
-			</ContentControl>
-		</DockPanel>
+		</ContentControl>
 	</DockPanel>
 </UserControl>

--- a/src/Zametek.View.ProjectPlan/ResourceChartManagement/ResourceChartManagerView.axaml
+++ b/src/Zametek.View.ProjectPlan/ResourceChartManagement/ResourceChartManagerView.axaml
@@ -7,15 +7,17 @@
 			       xmlns:scottplot="clr-namespace:ScottPlot.Avalonia;assembly=ScottPlot.Avalonia"
 			       xmlns:vm="using:Zametek.ViewModel.ProjectPlan"
 			       xmlns:common="using:Zametek.Common.ProjectPlan"
+			       xmlns:converters="using:Avalonia.Controls.Converters"
 			       x:DataType="vm:ResourceChartManagerViewModel"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="Zametek.View.ProjectPlan.ResourceChartManagerView">
 	<UserControl.Resources>
+		<converters:EnumToBoolConverter x:Key="enumToBool" />
 	</UserControl.Resources>
 
 	<DockPanel Margin="7">
 		<ScrollViewer DockPanel.Dock="Right"
-					  VerticalScrollBarVisibility="Hidden"
+					  VerticalScrollBarVisibility="Auto"
 					  HorizontalScrollBarVisibility="Disabled">
 			<DockPanel MinWidth="120"
 					   Margin="11,0,0,0">
@@ -128,7 +130,7 @@
 								  OnContent="{x:Static resources:Labels.Label_Yes}"
 								  IsChecked="{Binding Path=ShowToday, Mode=TwoWay}"/>
 				</DockPanel>
-				
+
 				<DockPanel DockPanel.Dock="Top">
 					<Label VerticalContentAlignment="Center"
 						   HorizontalContentAlignment="Left"
@@ -161,11 +163,87 @@
 							Bounds="{Binding Path=ImageBounds, Mode=OneWayToSource}">
 				<ContentControl.ContextMenu>
 					<ContextMenu>
+						<MenuItem Header="{x:Static resources:Labels.Label_ShowToday}"
+								  IsChecked="{Binding Path=ShowToday, Mode=TwoWay}"
+								  ToggleType="CheckBox" />
+
+						<MenuItem Header="{x:Static resources:Labels.Label_ShowMilestones}"
+								  IsChecked="{Binding Path=ShowMilestones, Mode=TwoWay}"
+								  ToggleType="CheckBox" />
+
+						<Separator />
+
+						<MenuItem Header="{x:Static resources:Labels.Label_AllocationMode}">
+							<MenuItem Header="{x:Static resources:Enums.Enum_AllocationMode_Activity}"
+									  IsChecked="{Binding Path=AllocationMode, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:AllocationMode.Activity}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeAllocationModeCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:AllocationMode.Activity}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_AllocationMode_Cost}"
+									  IsChecked="{Binding Path=AllocationMode, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:AllocationMode.Cost}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeAllocationModeCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:AllocationMode.Cost}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_AllocationMode_Billing}"
+									  IsChecked="{Binding Path=AllocationMode, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:AllocationMode.Billing}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeAllocationModeCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:AllocationMode.Billing}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_AllocationMode_Effort}"
+									  IsChecked="{Binding Path=AllocationMode, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:AllocationMode.Effort}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeAllocationModeCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:AllocationMode.Effort}"
+									  ToggleType="Radio" />
+						</MenuItem>
+
+						<Separator />
+
+						<MenuItem Header="{x:Static resources:Labels.Label_ScheduleMode}">
+							<MenuItem Header="{x:Static resources:Enums.Enum_ScheduleMode_Combined}"
+									  IsChecked="{Binding Path=ScheduleMode, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:ScheduleMode.Combined}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeScheduleModeCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:ScheduleMode.Combined}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_ScheduleMode_Scheduled}"
+									  IsChecked="{Binding Path=ScheduleMode, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:ScheduleMode.Scheduled}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeScheduleModeCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:ScheduleMode.Scheduled}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_ScheduleMode_Unscheduled}"
+									  IsChecked="{Binding Path=ScheduleMode, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:ScheduleMode.Unscheduled}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeScheduleModeCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:ScheduleMode.Unscheduled}"
+									  ToggleType="Radio" />
+						</MenuItem>
+
+						<Separator />
+
+						<MenuItem Header="{x:Static resources:Labels.Label_DisplayStyle}">
+							<MenuItem Header="{x:Static resources:Enums.Enum_DisplayStyle_Slanted}"
+									  IsChecked="{Binding Path=DisplayStyle, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:DisplayStyle.Slanted}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeDisplayStyleCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:DisplayStyle.Slanted}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_DisplayStyle_Block}"
+									  IsChecked="{Binding Path=DisplayStyle, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:DisplayStyle.Block}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeDisplayStyleCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:DisplayStyle.Block}"
+									  ToggleType="Radio" />
+						</MenuItem>
+
+						<Separator />
+
 						<MenuItem Header="{x:Static resources:Menus.Menu_SaveAs}"
-                      Command="{Binding Path=SaveResourceChartImageFileCommand, Mode=OneWay}" />
+								  Command="{Binding Path=SaveResourceChartImageFileCommand, Mode=OneWay}" />
 
 						<MenuItem Header="{x:Static resources:Menus.Menu_Reset}"
-								      Command="{Binding Path=ResetResourceChartCommand, Mode=OneWay}" />
+								  Command="{Binding Path=ResetResourceChartCommand, Mode=OneWay}" />
 					</ContextMenu>
 				</ContentControl.ContextMenu>
 			</ContentControl>

--- a/src/Zametek.View.ProjectPlan/ResourceSettingsManagement/ResourceSettingsManagerView.axaml
+++ b/src/Zametek.View.ProjectPlan/ResourceSettingsManagement/ResourceSettingsManagerView.axaml
@@ -69,47 +69,56 @@
       </Style>
     </DockPanel.Styles>
 
-		<ScrollViewer DockPanel.Dock="Right"
-					  VerticalScrollBarVisibility="Hidden"
+		<Border DockPanel.Dock="Right"
+				BorderThickness="1,0,0,0"
+				BorderBrush="{DynamicResource SemiColorBorder}">
+		<ScrollViewer VerticalScrollBarVisibility="Hidden"
 					  HorizontalScrollBarVisibility="Disabled">
-			<DockPanel Margin="11,0,0,0">
+			<DockPanel Margin="12,8,8,8">
 				<Label DockPanel.Dock="Top"
 					   IsTabStop="False"
 					   VerticalAlignment="Center"
 					   VerticalContentAlignment="Center"
+					   FontSize="11"
+					   FontWeight="SemiBold"
+					   Opacity="0.65"
 					   Content="{x:Static resources:Labels.Label_DefaultUnitCost}"
-					   Height="25"
-					   Margin="0,0,0,0"/>
+					   Height="22"
+					   Margin="0,0,0,2"/>
 
 				<u:NumericDoubleUpDown DockPanel.Dock="Top"
-									   Height="25" Width="75"
+									   Height="25" Width="80"
 									   Value="{Binding Path=DefaultUnitCost, Mode=TwoWay, UpdateSourceTrigger=LostFocus}"
 									   VerticalAlignment="Center"
 									   ShowButtonSpinner="False"
-									   Margin="0,0,0,11"
-									   Padding="0"
+									   Margin="0,0,0,12"
+									   Padding="4,0"
 									   Minimum="0"/>
 
 				<Label DockPanel.Dock="Top"
 					   IsTabStop="False"
 					   VerticalAlignment="Center"
 					   VerticalContentAlignment="Center"
+					   FontSize="11"
+					   FontWeight="SemiBold"
+					   Opacity="0.65"
 					   Content="{x:Static resources:Labels.Label_DefaultUnitBilling}"
-					   Height="25"
-					   Margin="0,0,0,0"/>
+					   Height="22"
+					   Margin="0,0,0,2"/>
 
 				<u:NumericDoubleUpDown DockPanel.Dock="Top"
-									   Height="25" Width="75"
+									   Height="25" Width="80"
 									   Value="{Binding Path=DefaultUnitBilling, Mode=TwoWay, UpdateSourceTrigger=LostFocus}"
 									   VerticalAlignment="Center"
 									   ShowButtonSpinner="False"
-									   Margin="0,0,0,11"
-									   Padding="0"
+									   Margin="0,0,0,12"
+									   Padding="4,0"
 									   Minimum="0"/>
 
 				<Grid/>
 			</DockPanel>
 		</ScrollViewer>
+		</Border>
 
     <!-- Set Background to Transparent to ensure the context menu works even when the datagrid is empty -->
     <!-- https://github.com/AvaloniaUI/Avalonia/discussions/15118 -->

--- a/src/Zametek.View.ProjectPlan/ScenarioChartManagement/ScenarioChartManagerView.axaml
+++ b/src/Zametek.View.ProjectPlan/ScenarioChartManagement/ScenarioChartManagerView.axaml
@@ -7,15 +7,17 @@
 			 xmlns:scottplot="clr-namespace:ScottPlot.Avalonia;assembly=ScottPlot.Avalonia"
 			 xmlns:vm="using:Zametek.ViewModel.ProjectPlan"
 			 xmlns:common="using:Zametek.Common.ProjectPlan"
+			 xmlns:converters="using:Avalonia.Controls.Converters"
 			 x:DataType="vm:ScenarioChartManagerViewModel"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="Zametek.View.ProjectPlan.ScenarioChartManagerView">
 	<UserControl.Resources>
+		<converters:EnumToBoolConverter x:Key="enumToBool" />
 	</UserControl.Resources>
 
 	<DockPanel Margin="7">
 		<ScrollViewer DockPanel.Dock="Right"
-					  VerticalScrollBarVisibility="Hidden"
+					  VerticalScrollBarVisibility="Auto"
 					  HorizontalScrollBarVisibility="Disabled">
 			<DockPanel Width="205"
 					   Margin="11,0,0,0">
@@ -128,7 +130,7 @@
 								  OnContent="{x:Static resources:Labels.Label_Yes}"
 								  IsChecked="{Binding Path=ShowNames, Mode=TwoWay}"/>
 				</DockPanel>
-				
+
 				<DockPanel DockPanel.Dock="Top">
 					<ScrollViewer VerticalScrollBarVisibility="Auto"
 								  HorizontalScrollBarVisibility="Disabled">
@@ -139,7 +141,7 @@
 											 VerticalAlignment="Stretch"/>
 					</ScrollViewer>
 				</DockPanel>
-				
+
 				<Grid/>
 			</DockPanel>
 		</ScrollViewer>
@@ -151,6 +153,468 @@
 							Bounds="{Binding Path=ImageBounds, Mode=OneWayToSource}">
 				<ContentControl.ContextMenu>
 					<ContextMenu>
+						<MenuItem Header="{x:Static resources:Labels.Label_ShowNames}"
+								  IsChecked="{Binding Path=ShowNames, Mode=TwoWay}"
+								  ToggleType="CheckBox" />
+
+						<Separator />
+
+						<MenuItem Header="{x:Static resources:Labels.Label_TrackedMetricXAxis}">
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_None}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.None}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.None}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_RisksCriticality}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.RisksCriticality}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.RisksCriticality}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_RisksFibonacci}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.RisksFibonacci}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.RisksFibonacci}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_RisksActivity}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.RisksActivity}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.RisksActivity}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_RisksActivityStdDevCorrection}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.RisksActivityStdDevCorrection}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.RisksActivityStdDevCorrection}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_RisksGeometricCriticality}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.RisksGeometricCriticality}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.RisksGeometricCriticality}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_RisksGeometricFibonacci}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.RisksGeometricFibonacci}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.RisksGeometricFibonacci}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_RisksGeometricActivity}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.RisksGeometricActivity}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.RisksGeometricActivity}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_CostsDirect}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.CostsDirect}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.CostsDirect}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_CostsIndirect}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.CostsIndirect}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.CostsIndirect}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_CostsOther}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.CostsOther}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.CostsOther}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_CostsTotal}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.CostsTotal}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.CostsTotal}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_BillingsDirect}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.BillingsDirect}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.BillingsDirect}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_BillingsIndirect}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.BillingsIndirect}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.BillingsIndirect}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_BillingsOther}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.BillingsOther}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.BillingsOther}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_BillingsTotal}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.BillingsTotal}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.BillingsTotal}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_MarginsDirect}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.MarginsDirect}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.MarginsDirect}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_MarginsDirectAbsolute}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.MarginsDirectAbsolute}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.MarginsDirectAbsolute}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_MarginsIndirect}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.MarginsIndirect}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.MarginsIndirect}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_MarginsIndirectAbsolute}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.MarginsIndirectAbsolute}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.MarginsIndirectAbsolute}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_MarginsOther}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.MarginsOther}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.MarginsOther}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_MarginsOtherAbsolute}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.MarginsOtherAbsolute}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.MarginsOtherAbsolute}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_MarginsTotal}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.MarginsTotal}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.MarginsTotal}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_MarginsTotalAbsolute}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.MarginsTotalAbsolute}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.MarginsTotalAbsolute}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_EffortsDirect}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.EffortsDirect}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.EffortsDirect}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_EffortsIndirect}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.EffortsIndirect}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.EffortsIndirect}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_EffortsOther}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.EffortsOther}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.EffortsOther}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_EffortsTotal}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.EffortsTotal}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.EffortsTotal}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_EffortsActivity}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.EffortsActivity}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.EffortsActivity}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_EffortsEfficiency}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.EffortsEfficiency}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.EffortsEfficiency}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_NetworkCyclomaticComplexity}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.NetworkCyclomaticComplexity}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.NetworkCyclomaticComplexity}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_NetworkDuration}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.NetworkDuration}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.NetworkDuration}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_NetworkDurationManMonths}"
+									  IsChecked="{Binding Path=TrackedMetricXAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.NetworkDurationManMonths}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricXAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.NetworkDurationManMonths}"
+									  ToggleType="Radio" />
+						</MenuItem>
+
+						<Separator />
+
+						<MenuItem Header="{x:Static resources:Labels.Label_TrackedMetricYAxis}">
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_None}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.None}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.None}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_RisksCriticality}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.RisksCriticality}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.RisksCriticality}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_RisksFibonacci}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.RisksFibonacci}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.RisksFibonacci}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_RisksActivity}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.RisksActivity}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.RisksActivity}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_RisksActivityStdDevCorrection}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.RisksActivityStdDevCorrection}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.RisksActivityStdDevCorrection}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_RisksGeometricCriticality}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.RisksGeometricCriticality}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.RisksGeometricCriticality}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_RisksGeometricFibonacci}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.RisksGeometricFibonacci}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.RisksGeometricFibonacci}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_RisksGeometricActivity}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.RisksGeometricActivity}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.RisksGeometricActivity}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_CostsDirect}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.CostsDirect}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.CostsDirect}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_CostsIndirect}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.CostsIndirect}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.CostsIndirect}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_CostsOther}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.CostsOther}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.CostsOther}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_CostsTotal}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.CostsTotal}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.CostsTotal}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_BillingsDirect}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.BillingsDirect}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.BillingsDirect}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_BillingsIndirect}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.BillingsIndirect}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.BillingsIndirect}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_BillingsOther}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.BillingsOther}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.BillingsOther}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_BillingsTotal}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.BillingsTotal}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.BillingsTotal}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_MarginsDirect}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.MarginsDirect}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.MarginsDirect}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_MarginsDirectAbsolute}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.MarginsDirectAbsolute}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.MarginsDirectAbsolute}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_MarginsIndirect}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.MarginsIndirect}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.MarginsIndirect}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_MarginsIndirectAbsolute}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.MarginsIndirectAbsolute}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.MarginsIndirectAbsolute}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_MarginsOther}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.MarginsOther}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.MarginsOther}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_MarginsOtherAbsolute}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.MarginsOtherAbsolute}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.MarginsOtherAbsolute}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_MarginsTotal}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.MarginsTotal}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.MarginsTotal}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_MarginsTotalAbsolute}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.MarginsTotalAbsolute}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.MarginsTotalAbsolute}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_EffortsDirect}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.EffortsDirect}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.EffortsDirect}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_EffortsIndirect}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.EffortsIndirect}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.EffortsIndirect}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_EffortsOther}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.EffortsOther}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.EffortsOther}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_EffortsTotal}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.EffortsTotal}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.EffortsTotal}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_EffortsActivity}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.EffortsActivity}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.EffortsActivity}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_EffortsEfficiency}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.EffortsEfficiency}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.EffortsEfficiency}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_NetworkCyclomaticComplexity}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.NetworkCyclomaticComplexity}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.NetworkCyclomaticComplexity}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_NetworkDuration}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.NetworkDuration}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.NetworkDuration}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_TrackedMetric_NetworkDurationManMonths}"
+									  IsChecked="{Binding Path=TrackedMetricYAxis, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:TrackedMetrics.NetworkDurationManMonths}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeTrackedMetricYAxisCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:TrackedMetrics.NetworkDurationManMonths}"
+									  ToggleType="Radio" />
+						</MenuItem>
+
+						<Separator />
+
+						<MenuItem Header="{x:Static resources:Labels.Label_CurveFittingType}">
+							<MenuItem Header="{x:Static resources:Enums.Enum_CurveFittingType_None}"
+									  IsChecked="{Binding Path=CurveFittingType, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:CurveFittingType.None}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeCurveFittingTypeCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:CurveFittingType.None}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_CurveFittingType_Linear}"
+									  IsChecked="{Binding Path=CurveFittingType, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:CurveFittingType.Linear}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeCurveFittingTypeCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:CurveFittingType.Linear}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_CurveFittingType_Exponential}"
+									  IsChecked="{Binding Path=CurveFittingType, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:CurveFittingType.Exponential}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeCurveFittingTypeCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:CurveFittingType.Exponential}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_CurveFittingType_Logarithmic}"
+									  IsChecked="{Binding Path=CurveFittingType, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:CurveFittingType.Logarithmic}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeCurveFittingTypeCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:CurveFittingType.Logarithmic}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_CurveFittingType_Power}"
+									  IsChecked="{Binding Path=CurveFittingType, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:CurveFittingType.Power}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeCurveFittingTypeCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:CurveFittingType.Power}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_CurveFittingType_PolynomialOrder2}"
+									  IsChecked="{Binding Path=CurveFittingType, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:CurveFittingType.PolynomialOrder2}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeCurveFittingTypeCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:CurveFittingType.PolynomialOrder2}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_CurveFittingType_PolynomialOrder3}"
+									  IsChecked="{Binding Path=CurveFittingType, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:CurveFittingType.PolynomialOrder3}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeCurveFittingTypeCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:CurveFittingType.PolynomialOrder3}"
+									  ToggleType="Radio" />
+
+							<MenuItem Header="{x:Static resources:Enums.Enum_CurveFittingType_PolynomialOrder4}"
+									  IsChecked="{Binding Path=CurveFittingType, Converter={StaticResource enumToBool}, ConverterParameter={x:Static common:CurveFittingType.PolynomialOrder4}, Mode=OneWay}"
+									  Command="{Binding Path=ChangeCurveFittingTypeCommand, Mode=OneWay}"
+									  CommandParameter="{x:Static common:CurveFittingType.PolynomialOrder4}"
+									  ToggleType="Radio" />
+						</MenuItem>
+
+						<Separator />
+
 						<MenuItem Header="{x:Static resources:Menus.Menu_SaveAs}"
 								  Command="{Binding Path=SaveScenarioChartImageFileCommand, Mode=OneWay}" />
 

--- a/src/Zametek.View.ProjectPlan/ScenarioChartManagement/ScenarioChartManagerView.axaml
+++ b/src/Zametek.View.ProjectPlan/ScenarioChartManagement/ScenarioChartManagerView.axaml
@@ -16,19 +16,24 @@
 	</UserControl.Resources>
 
 	<DockPanel Margin="7">
-		<ScrollViewer DockPanel.Dock="Right"
-					  VerticalScrollBarVisibility="Auto"
+		<Border DockPanel.Dock="Right"
+				BorderThickness="1,0,0,0"
+				BorderBrush="{DynamicResource SemiColorBorder}">
+		<ScrollViewer VerticalScrollBarVisibility="Auto"
 					  HorizontalScrollBarVisibility="Disabled">
 			<DockPanel Width="205"
-					   Margin="11,0,0,0">
+					   Margin="12,8,8,8">
 
 				<DockPanel DockPanel.Dock="Top">
 					<Label VerticalContentAlignment="Center"
 						   HorizontalContentAlignment="Left"
-						   Height="25"
+						   Height="22"
 						   DockPanel.Dock="Top"
 						   IsTabStop="False"
-						   Margin="0,0,0,3"
+						   FontSize="11"
+						   FontWeight="SemiBold"
+						   Opacity="0.65"
+						   Margin="0,0,0,2"
 						   Content="{x:Static resources:Labels.Label_TrackedMetricXAxis}"/>
 
 					<ComboBox ItemsSource="{Binding Source={local:EnumBindingSource {x:Type common:TrackedMetrics}}}"
@@ -37,7 +42,7 @@
 							  BorderThickness="1"
 							  DockPanel.Dock="Top"
 							  IsTabStop="False"
-							  Margin="0,0,0,11"
+							  Margin="0,0,0,12"
 							  Height="25">
 						<ComboBox.ItemTemplate>
 							<DataTemplate>
@@ -55,10 +60,13 @@
 				<DockPanel DockPanel.Dock="Top">
 					<Label VerticalContentAlignment="Center"
 						   HorizontalContentAlignment="Left"
-						   Height="25"
+						   Height="22"
 						   DockPanel.Dock="Top"
 						   IsTabStop="False"
-						   Margin="0,0,0,3"
+						   FontSize="11"
+						   FontWeight="SemiBold"
+						   Opacity="0.65"
+						   Margin="0,0,0,2"
 						   Content="{x:Static resources:Labels.Label_TrackedMetricYAxis}"/>
 
 					<ComboBox ItemsSource="{Binding Source={local:EnumBindingSource {x:Type common:TrackedMetrics}}}"
@@ -67,7 +75,7 @@
 							  BorderThickness="1"
 							  DockPanel.Dock="Top"
 							  IsTabStop="False"
-							  Margin="0,0,0,11"
+							  Margin="0,0,0,12"
 							  Height="25">
 						<ComboBox.ItemTemplate>
 							<DataTemplate>
@@ -84,10 +92,13 @@
 				<DockPanel DockPanel.Dock="Top">
 					<Label VerticalContentAlignment="Center"
 						   HorizontalContentAlignment="Left"
-						   Height="25"
+						   Height="22"
 						   DockPanel.Dock="Top"
 						   IsTabStop="False"
-						   Margin="0,0,0,3"
+						   FontSize="11"
+						   FontWeight="SemiBold"
+						   Opacity="0.65"
+						   Margin="0,0,0,2"
 						   Content="{x:Static resources:Labels.Label_CurveFittingType}"/>
 
 					<ComboBox ItemsSource="{Binding Source={local:EnumBindingSource {x:Type common:CurveFittingType}}}"
@@ -96,7 +107,7 @@
 							  BorderThickness="1"
 							  DockPanel.Dock="Top"
 							  IsTabStop="False"
-							  Margin="0,0,0,11"
+							  Margin="0,0,0,12"
 							  Height="25">
 						<ComboBox.ItemTemplate>
 							<DataTemplate>
@@ -113,19 +124,22 @@
 				<DockPanel DockPanel.Dock="Top">
 					<Label VerticalContentAlignment="Center"
 						   HorizontalContentAlignment="Left"
-						   Height="25"
+						   Height="22"
 						   DockPanel.Dock="Top"
 						   IsTabStop="False"
-						   Margin="0,0,0,3"
+						   FontSize="11"
+						   FontWeight="SemiBold"
+						   Opacity="0.65"
+						   Margin="0,0,0,2"
 						   Content="{x:Static resources:Labels.Label_ShowNames}"/>
 
 					<ToggleSwitch DockPanel.Dock="Top"
 								  IsTabStop="False"
-								  Margin="0,0,0,11"
+								  Margin="0,0,0,12"
 								  VerticalAlignment="Center"
 								  VerticalContentAlignment="Center"
-								  HorizontalAlignment="Center"
-								  HorizontalContentAlignment="Center"
+								  HorizontalAlignment="Left"
+								  HorizontalContentAlignment="Left"
 								  OffContent="{x:Static resources:Labels.Label_No}"
 								  OnContent="{x:Static resources:Labels.Label_Yes}"
 								  IsChecked="{Binding Path=ShowNames, Mode=TwoWay}"/>
@@ -136,8 +150,10 @@
 								  HorizontalScrollBarVisibility="Disabled">
 						<SelectableTextBlock Text="{Binding Path=CurveFittingFormula, Mode=OneWay}"
 											 TextWrapping="Wrap"
-											 FontWeight="Bold"
-											 Margin="0,0,0,11"
+											 FontWeight="SemiBold"
+											 FontSize="11"
+											 Opacity="0.8"
+											 Margin="0,0,0,12"
 											 VerticalAlignment="Stretch"/>
 					</ScrollViewer>
 				</DockPanel>
@@ -145,6 +161,7 @@
 				<Grid/>
 			</DockPanel>
 		</ScrollViewer>
+		</Border>
 
 		<DockPanel>
 			<!-- ScottPlot PlotView -->

--- a/src/Zametek.View.ProjectPlan/ScenarioChartManagement/ScenarioChartManagerView.axaml
+++ b/src/Zametek.View.ProjectPlan/ScenarioChartManagement/ScenarioChartManagerView.axaml
@@ -15,159 +15,114 @@
 		<converters:EnumToBoolConverter x:Key="enumToBool" />
 	</UserControl.Resources>
 
-	<DockPanel Margin="7">
+	<DockPanel>
 		<Border DockPanel.Dock="Right"
+				Background="{DynamicResource ZSurface}"
 				BorderThickness="1,0,0,0"
-				BorderBrush="{DynamicResource SemiColorBorder}">
+				BorderBrush="{DynamicResource ZBorder}">
 		<ScrollViewer VerticalScrollBarVisibility="Auto"
 					  HorizontalScrollBarVisibility="Disabled">
-			<DockPanel Width="205"
-					   Margin="12,8,8,8">
+			<StackPanel Width="205"
+						Margin="12,12,8,12"
+						Spacing="0">
 
-				<DockPanel DockPanel.Dock="Top">
-					<Label VerticalContentAlignment="Center"
-						   HorizontalContentAlignment="Left"
-						   Height="22"
-						   DockPanel.Dock="Top"
-						   IsTabStop="False"
-						   FontSize="11"
-						   FontWeight="SemiBold"
-						   Opacity="0.65"
-						   Margin="0,0,0,2"
-						   Content="{x:Static resources:Labels.Label_TrackedMetricXAxis}"/>
+				<!-- X Axis Metric -->
+				<Label VerticalContentAlignment="Center"
+					   HorizontalContentAlignment="Left"
+					   IsTabStop="False"
+					   Classes="section-header"
+					   Content="{x:Static resources:Labels.Label_TrackedMetricXAxis}"/>
+				<ComboBox ItemsSource="{Binding Source={local:EnumBindingSource {x:Type common:TrackedMetrics}}}"
+						  SelectedItem="{Binding Path=TrackedMetricXAxis, Mode=TwoWay}"
+						  IsTabStop="False"
+						  Margin="0,0,0,12">
+					<ComboBox.ItemTemplate>
+						<DataTemplate>
+							<TextBlock VerticalAlignment="Center"
+									   TextAlignment="Left"
+									   Margin="0"
+									   Padding="3"
+									   Classes="displayOnly"
+									   Text="{Binding Converter={x:Static local:StringConverters.TrackedMetricsValue}, Mode=OneWay}"/>
+						</DataTemplate>
+					</ComboBox.ItemTemplate>
+				</ComboBox>
 
-					<ComboBox ItemsSource="{Binding Source={local:EnumBindingSource {x:Type common:TrackedMetrics}}}"
-							  SelectedItem="{Binding Path=TrackedMetricXAxis, Mode=TwoWay}"
-							  BorderBrush="Gray"
-							  BorderThickness="1"
-							  DockPanel.Dock="Top"
-							  IsTabStop="False"
+				<!-- Y Axis Metric -->
+				<Label VerticalContentAlignment="Center"
+					   HorizontalContentAlignment="Left"
+					   IsTabStop="False"
+					   Classes="section-header"
+					   Content="{x:Static resources:Labels.Label_TrackedMetricYAxis}"/>
+				<ComboBox ItemsSource="{Binding Source={local:EnumBindingSource {x:Type common:TrackedMetrics}}}"
+						  SelectedItem="{Binding Path=TrackedMetricYAxis, Mode=TwoWay}"
+						  IsTabStop="False"
+						  Margin="0,0,0,12">
+					<ComboBox.ItemTemplate>
+						<DataTemplate>
+							<TextBlock VerticalAlignment="Center"
+									   TextAlignment="Left"
+									   Margin="0"
+									   Padding="3"
+									   Text="{Binding Converter={x:Static local:StringConverters.TrackedMetricsValue}, Mode=OneWay}"/>
+						</DataTemplate>
+					</ComboBox.ItemTemplate>
+				</ComboBox>
+
+				<!-- Curve Fitting -->
+				<Label VerticalContentAlignment="Center"
+					   HorizontalContentAlignment="Left"
+					   IsTabStop="False"
+					   Classes="section-header"
+					   Content="{x:Static resources:Labels.Label_CurveFittingType}"/>
+				<ComboBox ItemsSource="{Binding Source={local:EnumBindingSource {x:Type common:CurveFittingType}}}"
+						  SelectedItem="{Binding Path=CurveFittingType, Mode=TwoWay}"
+						  IsTabStop="False"
+						  Margin="0,0,0,12">
+					<ComboBox.ItemTemplate>
+						<DataTemplate>
+							<TextBlock VerticalAlignment="Center"
+									   TextAlignment="Left"
+									   Margin="0"
+									   Padding="3"
+									   Text="{Binding Converter={x:Static local:StringConverters.CurveFittingTypeValue}, Mode=OneWay}"/>
+						</DataTemplate>
+					</ComboBox.ItemTemplate>
+				</ComboBox>
+
+				<!-- Show Names -->
+				<Label VerticalContentAlignment="Center"
+					   HorizontalContentAlignment="Left"
+					   IsTabStop="False"
+					   Classes="section-header"
+					   Content="{x:Static resources:Labels.Label_ShowNames}"/>
+				<ToggleSwitch IsTabStop="False"
 							  Margin="0,0,0,12"
-							  Height="25">
-						<ComboBox.ItemTemplate>
-							<DataTemplate>
-								<TextBlock VerticalAlignment="Center"
-										   TextAlignment="Left"
-										   Margin="0"
-										   Padding="3"
-										   Classes="displayOnly"
-										   Text="{Binding Converter={x:Static local:StringConverters.TrackedMetricsValue}, Mode=OneWay}"/>
-							</DataTemplate>
-						</ComboBox.ItemTemplate>
-					</ComboBox>
-				</DockPanel>
+							  VerticalAlignment="Center"
+							  VerticalContentAlignment="Center"
+							  HorizontalAlignment="Left"
+							  HorizontalContentAlignment="Left"
+							  OffContent="{x:Static resources:Labels.Label_No}"
+							  OnContent="{x:Static resources:Labels.Label_Yes}"
+							  IsChecked="{Binding Path=ShowNames, Mode=TwoWay}"/>
 
-				<DockPanel DockPanel.Dock="Top">
-					<Label VerticalContentAlignment="Center"
-						   HorizontalContentAlignment="Left"
-						   Height="22"
-						   DockPanel.Dock="Top"
-						   IsTabStop="False"
-						   FontSize="11"
-						   FontWeight="SemiBold"
-						   Opacity="0.65"
-						   Margin="0,0,0,2"
-						   Content="{x:Static resources:Labels.Label_TrackedMetricYAxis}"/>
+				<!-- Formula display -->
+				<SelectableTextBlock Text="{Binding Path=CurveFittingFormula, Mode=OneWay}"
+									 TextWrapping="Wrap"
+									 FontWeight="SemiBold"
+									 FontSize="11"
+									 Foreground="{DynamicResource ZTextSecondary}"
+									 Margin="0,0,0,12"
+									 VerticalAlignment="Stretch"/>
 
-					<ComboBox ItemsSource="{Binding Source={local:EnumBindingSource {x:Type common:TrackedMetrics}}}"
-							  SelectedItem="{Binding Path=TrackedMetricYAxis, Mode=TwoWay}"
-							  BorderBrush="Gray"
-							  BorderThickness="1"
-							  DockPanel.Dock="Top"
-							  IsTabStop="False"
-							  Margin="0,0,0,12"
-							  Height="25">
-						<ComboBox.ItemTemplate>
-							<DataTemplate>
-								<TextBlock VerticalAlignment="Center"
-										   TextAlignment="Left"
-										   Margin="0"
-										   Padding="3"
-										   Text="{Binding Converter={x:Static local:StringConverters.TrackedMetricsValue}, Mode=OneWay}"/>
-							</DataTemplate>
-						</ComboBox.ItemTemplate>
-					</ComboBox>
-				</DockPanel>
-
-				<DockPanel DockPanel.Dock="Top">
-					<Label VerticalContentAlignment="Center"
-						   HorizontalContentAlignment="Left"
-						   Height="22"
-						   DockPanel.Dock="Top"
-						   IsTabStop="False"
-						   FontSize="11"
-						   FontWeight="SemiBold"
-						   Opacity="0.65"
-						   Margin="0,0,0,2"
-						   Content="{x:Static resources:Labels.Label_CurveFittingType}"/>
-
-					<ComboBox ItemsSource="{Binding Source={local:EnumBindingSource {x:Type common:CurveFittingType}}}"
-							  SelectedItem="{Binding Path=CurveFittingType, Mode=TwoWay}"
-							  BorderBrush="Gray"
-							  BorderThickness="1"
-							  DockPanel.Dock="Top"
-							  IsTabStop="False"
-							  Margin="0,0,0,12"
-							  Height="25">
-						<ComboBox.ItemTemplate>
-							<DataTemplate>
-								<TextBlock VerticalAlignment="Center"
-										   TextAlignment="Left"
-										   Margin="0"
-										   Padding="3"
-										   Text="{Binding Converter={x:Static local:StringConverters.CurveFittingTypeValue}, Mode=OneWay}"/>
-							</DataTemplate>
-						</ComboBox.ItemTemplate>
-					</ComboBox>
-				</DockPanel>
-
-				<DockPanel DockPanel.Dock="Top">
-					<Label VerticalContentAlignment="Center"
-						   HorizontalContentAlignment="Left"
-						   Height="22"
-						   DockPanel.Dock="Top"
-						   IsTabStop="False"
-						   FontSize="11"
-						   FontWeight="SemiBold"
-						   Opacity="0.65"
-						   Margin="0,0,0,2"
-						   Content="{x:Static resources:Labels.Label_ShowNames}"/>
-
-					<ToggleSwitch DockPanel.Dock="Top"
-								  IsTabStop="False"
-								  Margin="0,0,0,12"
-								  VerticalAlignment="Center"
-								  VerticalContentAlignment="Center"
-								  HorizontalAlignment="Left"
-								  HorizontalContentAlignment="Left"
-								  OffContent="{x:Static resources:Labels.Label_No}"
-								  OnContent="{x:Static resources:Labels.Label_Yes}"
-								  IsChecked="{Binding Path=ShowNames, Mode=TwoWay}"/>
-				</DockPanel>
-
-				<DockPanel DockPanel.Dock="Top">
-					<ScrollViewer VerticalScrollBarVisibility="Auto"
-								  HorizontalScrollBarVisibility="Disabled">
-						<SelectableTextBlock Text="{Binding Path=CurveFittingFormula, Mode=OneWay}"
-											 TextWrapping="Wrap"
-											 FontWeight="SemiBold"
-											 FontSize="11"
-											 Opacity="0.8"
-											 Margin="0,0,0,12"
-											 VerticalAlignment="Stretch"/>
-					</ScrollViewer>
-				</DockPanel>
-
-				<Grid/>
-			</DockPanel>
+			</StackPanel>
 		</ScrollViewer>
 		</Border>
 
-		<DockPanel>
-			<!-- ScottPlot PlotView -->
-			<ContentControl x:Name="scottplot"
-							Content="{Binding ScenarioChartPlotModel, Mode=OneWay}"
-							Bounds="{Binding Path=ImageBounds, Mode=OneWayToSource}">
+		<!-- ScottPlot PlotView -->
+		<ContentControl x:Name="scottplot"
+						Content="{Binding ScenarioChartPlotModel, Mode=OneWay}"
+						Bounds="{Binding Path=ImageBounds, Mode=OneWayToSource}">
 				<ContentControl.ContextMenu>
 					<ContextMenu>
 						<MenuItem Header="{x:Static resources:Labels.Label_ShowNames}"
@@ -639,7 +594,6 @@
 								  Command="{Binding Path=ResetScenarioChartCommand, Mode=OneWay}" />
 					</ContextMenu>
 				</ContentControl.ContextMenu>
-			</ContentControl>
-		</DockPanel>
+		</ContentControl>
 	</DockPanel>
 </UserControl>

--- a/src/Zametek.View.ProjectPlan/ScottPlotUserControl.cs
+++ b/src/Zametek.View.ProjectPlan/ScottPlotUserControl.cs
@@ -48,12 +48,17 @@ namespace Zametek.View.ProjectPlan
             m_IsCtrlLeftDragging = false;
             m_CtrlWasHeldOnPress = false;
 
-            m_PlotContainer.AddHandler(PointerPressedEvent, PlotContainer_PointerPressed, RoutingStrategies.Bubble, handledEventsToo: true);
-            m_PlotContainer.AddHandler(PointerReleasedEvent, PlotContainer_PointerReleased, RoutingStrategies.Bubble, handledEventsToo: true);
+            // Tunnel routing fires at ContentControl BEFORE AvaPlot's handlers, so we can mark
+            // events as handled before ScottPlot sees them — preventing ScottPlot from entering
+            // its own pan/zoom mode when we're handling the interaction ourselves.
+            m_PlotContainer.AddHandler(PointerPressedEvent, PlotContainer_PointerPressed, RoutingStrategies.Tunnel);
+            m_PlotContainer.AddHandler(PointerReleasedEvent, PlotContainer_PointerReleased, RoutingStrategies.Tunnel);
 
             m_PlotContainer.Loaded += PlotContainer_Loaded;
             m_PlotContainer.PointerExited += PlotContainer_PointerExited;
-            m_PlotContainer.PointerMoved += PlotContainer_PointerMoved;
+            // handledEventsToo: true so we still receive PointerMoved even if ScottPlot marks it
+            // handled (e.g. during hover feedback rendering inside AvaPlot).
+            m_PlotContainer.AddHandler(PointerMovedEvent, PlotContainer_PointerMoved, RoutingStrategies.Bubble, handledEventsToo: true);
         }
 
         private void PlotContainer_PointerPressed(

--- a/src/Zametek.View.ProjectPlan/ScottPlotUserControl.cs
+++ b/src/Zametek.View.ProjectPlan/ScottPlotUserControl.cs
@@ -21,6 +21,11 @@ namespace Zametek.View.ProjectPlan
         private Point? m_LeftDragStartPoint;
         private bool m_IsLeftDragging;
 
+        // Ctrl+left-button drag state (for subclasses).
+        private Point? m_CtrlLeftDragStartPoint;
+        private bool m_IsCtrlLeftDragging;
+        private bool m_CtrlWasHeldOnPress;
+
         protected ContentControl? m_PlotContainer;
 
         public ScottPlotUserControl()
@@ -38,6 +43,9 @@ namespace Zametek.View.ProjectPlan
             m_IsDragging = false;
             m_LeftDragStartPoint = null;
             m_IsLeftDragging = false;
+            m_CtrlLeftDragStartPoint = null;
+            m_IsCtrlLeftDragging = false;
+            m_CtrlWasHeldOnPress = false;
 
             m_PlotContainer.AddHandler(PointerPressedEvent, PlotContainer_PointerPressed, RoutingStrategies.Bubble, handledEventsToo: true);
             m_PlotContainer.AddHandler(PointerReleasedEvent, PlotContainer_PointerReleased, RoutingStrategies.Bubble, handledEventsToo: true);
@@ -56,13 +64,30 @@ namespace Zametek.View.ProjectPlan
 
             if (properties.PointerUpdateKind == PointerUpdateKind.LeftButtonPressed)
             {
-                m_LeftDragStartPoint = e.GetPosition(this);
-                m_IsLeftDragging = false;
+                bool ctrlHeld = e.KeyModifiers.HasFlag(KeyModifiers.Control);
+                m_CtrlWasHeldOnPress = ctrlHeld;
 
-                if (m_PlotContainer?.Content is AvaPlot plotModel)
+                if (ctrlHeld)
                 {
-                    Point pos = e.GetPosition(plotModel);
-                    OnLeftPointerPressed(plotModel, pos, e);
+                    m_CtrlLeftDragStartPoint = e.GetPosition(this);
+                    m_IsCtrlLeftDragging = false;
+
+                    if (m_PlotContainer?.Content is AvaPlot plotModelCtrl)
+                    {
+                        Point posCtrl = e.GetPosition(plotModelCtrl);
+                        OnCtrlLeftDragStart(plotModelCtrl, posCtrl, e);
+                    }
+                }
+                else
+                {
+                    m_LeftDragStartPoint = e.GetPosition(this);
+                    m_IsLeftDragging = false;
+
+                    if (m_PlotContainer?.Content is AvaPlot plotModel)
+                    {
+                        Point pos = e.GetPosition(plotModel);
+                        OnLeftPointerPressed(plotModel, pos, e);
+                    }
                 }
             }
 
@@ -84,21 +109,36 @@ namespace Zametek.View.ProjectPlan
 
             if (properties.PointerUpdateKind == PointerUpdateKind.LeftButtonReleased)
             {
-                if (m_PlotContainer?.Content is AvaPlot plotModel)
+                if (m_CtrlWasHeldOnPress)
                 {
-                    Point pos = e.GetPosition(plotModel);
-                    if (m_IsLeftDragging)
+                    if (m_PlotContainer?.Content is AvaPlot plotModelCtrl)
                     {
-                        OnLeftDragCompleted(plotModel, pos, e);
+                        Point posCtrl = e.GetPosition(plotModelCtrl);
+                        OnCtrlLeftDragCompleted(plotModelCtrl, posCtrl, e);
                     }
-                    else
-                    {
-                        OnLeftPointerReleased(plotModel, pos, e);
-                    }
-                }
 
-                m_LeftDragStartPoint = null;
-                m_IsLeftDragging = false;
+                    m_CtrlLeftDragStartPoint = null;
+                    m_IsCtrlLeftDragging = false;
+                    m_CtrlWasHeldOnPress = false;
+                }
+                else
+                {
+                    if (m_PlotContainer?.Content is AvaPlot plotModel)
+                    {
+                        Point pos = e.GetPosition(plotModel);
+                        if (m_IsLeftDragging)
+                        {
+                            OnLeftDragCompleted(plotModel, pos, e);
+                        }
+                        else
+                        {
+                            OnLeftPointerReleased(plotModel, pos, e);
+                        }
+                    }
+
+                    m_LeftDragStartPoint = null;
+                    m_IsLeftDragging = false;
+                }
             }
 
             // Ensure it is the right mouse button
@@ -117,6 +157,17 @@ namespace Zametek.View.ProjectPlan
 
         private void CheckPointerDrag(PointerEventArgs e)
         {
+            if (m_CtrlLeftDragStartPoint.HasValue)
+            {
+                Point currentPosition = e.GetPosition(this);
+                double distance = Vector.Distance(m_CtrlLeftDragStartPoint.Value, currentPosition);
+
+                if (distance > c_DragThreshold && !m_IsCtrlLeftDragging)
+                {
+                    m_IsCtrlLeftDragging = true;
+                }
+            }
+
             if (m_LeftDragStartPoint.HasValue)
             {
                 Point currentPosition = e.GetPosition(this);
@@ -168,6 +219,26 @@ namespace Zametek.View.ProjectPlan
         /// </summary>
         protected bool IsLeftDragging => m_IsLeftDragging;
 
+        /// <summary>
+        /// Called when Ctrl+left mouse button is pressed on the plot. Override to begin a dependency drag.
+        /// </summary>
+        protected virtual void OnCtrlLeftDragStart(AvaPlot plotModel, Point plotPosition, PointerPressedEventArgs e) { }
+
+        /// <summary>
+        /// Called on every PointerMoved event while a Ctrl+left drag is in progress.
+        /// </summary>
+        protected virtual void OnCtrlLeftDragging(AvaPlot plotModel, Point plotPosition, PointerEventArgs e) { }
+
+        /// <summary>
+        /// Called when Ctrl+left mouse button is released after a drag. Override to commit the dependency.
+        /// </summary>
+        protected virtual void OnCtrlLeftDragCompleted(AvaPlot plotModel, Point plotPosition, PointerReleasedEventArgs e) { }
+
+        /// <summary>
+        /// True while a Ctrl+left-button drag is active.
+        /// </summary>
+        protected bool IsCtrlLeftDragging => m_IsCtrlLeftDragging;
+
         private void OpenPlotContainerContextMenu(PointerReleasedEventArgs e)
         {
             // Manually open the ContextMenu assigned to this container
@@ -200,6 +271,13 @@ namespace Zametek.View.ProjectPlan
             }
 
             Point pos = e.GetPosition(plotModel);
+
+            // Notify subclass of active Ctrl+left drag.
+            if (m_IsCtrlLeftDragging)
+            {
+                OnCtrlLeftDragging(plotModel, pos, e);
+                return;
+            }
 
             // Notify subclass of active left drag.
             if (m_IsLeftDragging)

--- a/src/Zametek.View.ProjectPlan/ScottPlotUserControl.cs
+++ b/src/Zametek.View.ProjectPlan/ScottPlotUserControl.cs
@@ -17,12 +17,18 @@ namespace Zametek.View.ProjectPlan
         private Point? m_DragStartPoint;
         private bool m_IsDragging;
 
+        // Left-button drag state (for subclasses).
+        private Point? m_LeftDragStartPoint;
+        private bool m_IsLeftDragging;
+
         protected ContentControl? m_PlotContainer;
 
         public ScottPlotUserControl()
         {
             m_DragStartPoint = null;
             m_IsDragging = false;
+            m_LeftDragStartPoint = null;
+            m_IsLeftDragging = false;
         }
 
         public void InitializePlotContainer(ContentControl plotContainer)
@@ -30,6 +36,8 @@ namespace Zametek.View.ProjectPlan
             m_PlotContainer = plotContainer;
             m_DragStartPoint = null;
             m_IsDragging = false;
+            m_LeftDragStartPoint = null;
+            m_IsLeftDragging = false;
 
             m_PlotContainer.AddHandler(PointerPressedEvent, PlotContainer_PointerPressed, RoutingStrategies.Bubble, handledEventsToo: true);
             m_PlotContainer.AddHandler(PointerReleasedEvent, PlotContainer_PointerReleased, RoutingStrategies.Bubble, handledEventsToo: true);
@@ -45,6 +53,18 @@ namespace Zametek.View.ProjectPlan
         {
             // Check if the pointer action is a click or a drag.
             PointerPointProperties properties = e.GetCurrentPoint(this).Properties;
+
+            if (properties.PointerUpdateKind == PointerUpdateKind.LeftButtonPressed)
+            {
+                m_LeftDragStartPoint = e.GetPosition(this);
+                m_IsLeftDragging = false;
+
+                if (m_PlotContainer?.Content is AvaPlot plotModel)
+                {
+                    Point pos = e.GetPosition(plotModel);
+                    OnLeftPointerPressed(plotModel, pos, e);
+                }
+            }
 
             // Ensure it is the right mouse button
             if (properties.PointerUpdateKind == PointerUpdateKind.RightButtonPressed)
@@ -62,6 +82,25 @@ namespace Zametek.View.ProjectPlan
             // Check if the pointer action is a click or a drag.
             PointerPointProperties properties = e.GetCurrentPoint(this).Properties;
 
+            if (properties.PointerUpdateKind == PointerUpdateKind.LeftButtonReleased)
+            {
+                if (m_PlotContainer?.Content is AvaPlot plotModel)
+                {
+                    Point pos = e.GetPosition(plotModel);
+                    if (m_IsLeftDragging)
+                    {
+                        OnLeftDragCompleted(plotModel, pos, e);
+                    }
+                    else
+                    {
+                        OnLeftPointerReleased(plotModel, pos, e);
+                    }
+                }
+
+                m_LeftDragStartPoint = null;
+                m_IsLeftDragging = false;
+            }
+
             // Ensure it is the right mouse button
             if (properties.PointerUpdateKind == PointerUpdateKind.RightButtonReleased
                 && !m_IsDragging)
@@ -75,8 +114,20 @@ namespace Zametek.View.ProjectPlan
             m_IsDragging = false;
             e.Handled = true;
         }
+
         private void CheckPointerDrag(PointerEventArgs e)
         {
+            if (m_LeftDragStartPoint.HasValue)
+            {
+                Point currentPosition = e.GetPosition(this);
+                double distance = Vector.Distance(m_LeftDragStartPoint.Value, currentPosition);
+
+                if (distance > c_DragThreshold && !m_IsLeftDragging)
+                {
+                    m_IsLeftDragging = true;
+                }
+            }
+
             if (m_DragStartPoint.HasValue)
             {
                 Point currentPosition = e.GetPosition(this);
@@ -91,6 +142,31 @@ namespace Zametek.View.ProjectPlan
                 }
             }
         }
+
+        /// <summary>
+        /// Called when the left mouse button is pressed on the plot. Override to implement custom behaviour.
+        /// </summary>
+        protected virtual void OnLeftPointerPressed(AvaPlot plotModel, Point plotPosition, PointerPressedEventArgs e) { }
+
+        /// <summary>
+        /// Called when the left mouse button is released after a drag. Override to commit the drag action.
+        /// </summary>
+        protected virtual void OnLeftDragCompleted(AvaPlot plotModel, Point plotPosition, PointerReleasedEventArgs e) { }
+
+        /// <summary>
+        /// Called when the left mouse button is released without a drag (i.e. a simple click). Override to cancel any pending state.
+        /// </summary>
+        protected virtual void OnLeftPointerReleased(AvaPlot plotModel, Point plotPosition, PointerReleasedEventArgs e) { }
+
+        /// <summary>
+        /// Called on every PointerMoved event while a left drag is in progress. Override for live preview.
+        /// </summary>
+        protected virtual void OnLeftDragging(AvaPlot plotModel, Point plotPosition, PointerEventArgs e) { }
+
+        /// <summary>
+        /// True while a left-button drag is active.
+        /// </summary>
+        protected bool IsLeftDragging => m_IsLeftDragging;
 
         private void OpenPlotContainerContextMenu(PointerReleasedEventArgs e)
         {
@@ -124,6 +200,14 @@ namespace Zametek.View.ProjectPlan
             }
 
             Point pos = e.GetPosition(plotModel);
+
+            // Notify subclass of active left drag.
+            if (m_IsLeftDragging)
+            {
+                OnLeftDragging(plotModel, pos, e);
+                return;
+            }
+
             Pixel mousePixel = new(pos.X, pos.Y);
             Coordinates mouseLocation = plotModel.Plot.GetCoordinates(mousePixel);
 

--- a/src/Zametek.View.ProjectPlan/ScottPlotUserControl.cs
+++ b/src/Zametek.View.ProjectPlan/ScottPlotUserControl.cs
@@ -2,6 +2,7 @@
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using AvaloniaCursor = Avalonia.Input.Cursor;
 using ScottPlot;
 using ScottPlot.Avalonia;
 using ScottPlot.Plottables;
@@ -69,24 +70,36 @@ namespace Zametek.View.ProjectPlan
 
                 if (ctrlHeld)
                 {
-                    m_CtrlLeftDragStartPoint = e.GetPosition(this);
-                    m_IsCtrlLeftDragging = false;
-
                     if (m_PlotContainer?.Content is AvaPlot plotModelCtrl)
                     {
                         Point posCtrl = e.GetPosition(plotModelCtrl);
-                        OnCtrlLeftDragStart(plotModelCtrl, posCtrl, e);
+                        bool claimedCtrl = OnCtrlLeftDragStart(plotModelCtrl, posCtrl, e);
+                        if (claimedCtrl)
+                        {
+                            m_CtrlLeftDragStartPoint = e.GetPosition(this);
+                            m_IsCtrlLeftDragging = false;
+                        }
+                        else
+                        {
+                            // Not claimed — don't intercept the ctrl+click.
+                            m_CtrlWasHeldOnPress = false;
+                        }
                     }
                 }
                 else
                 {
-                    m_LeftDragStartPoint = e.GetPosition(this);
-                    m_IsLeftDragging = false;
-
                     if (m_PlotContainer?.Content is AvaPlot plotModel)
                     {
                         Point pos = e.GetPosition(plotModel);
-                        OnLeftPointerPressed(plotModel, pos, e);
+                        bool claimed = OnLeftPointerPressed(plotModel, pos, e);
+                        if (claimed)
+                        {
+                            // Only set up our drag tracking when the subclass actually wants this click.
+                            m_LeftDragStartPoint = e.GetPosition(this);
+                            m_IsLeftDragging = false;
+                        }
+                        // If not claimed, leave m_LeftDragStartPoint null so ScottPlot handles
+                        // the full press/release cycle (e.g. double-click auto-scale).
                     }
                 }
             }
@@ -120,9 +133,11 @@ namespace Zametek.View.ProjectPlan
                     m_CtrlLeftDragStartPoint = null;
                     m_IsCtrlLeftDragging = false;
                     m_CtrlWasHeldOnPress = false;
+                    e.Handled = true;
                 }
-                else
+                else if (m_LeftDragStartPoint.HasValue)
                 {
+                    // Only claim handling when WE started a left-drag session.
                     if (m_PlotContainer?.Content is AvaPlot plotModel)
                     {
                         Point pos = e.GetPosition(plotModel);
@@ -138,7 +153,10 @@ namespace Zametek.View.ProjectPlan
 
                     m_LeftDragStartPoint = null;
                     m_IsLeftDragging = false;
+                    e.Handled = true;
                 }
+                // If m_LeftDragStartPoint is null we didn't start the session —
+                // let ScottPlot process its own release (pan/zoom cleanup).
             }
 
             // Ensure it is the right mouse button
@@ -149,10 +167,9 @@ namespace Zametek.View.ProjectPlan
                 OpenPlotContainerContextMenu(e);
             }
 
-            // Reset the dragging state.
+            // Reset the right-button dragging state.
             m_DragStartPoint = null;
             m_IsDragging = false;
-            e.Handled = true;
         }
 
         private void CheckPointerDrag(PointerEventArgs e)
@@ -195,9 +212,11 @@ namespace Zametek.View.ProjectPlan
         }
 
         /// <summary>
-        /// Called when the left mouse button is pressed on the plot. Override to implement custom behaviour.
+        /// Called when the left mouse button is pressed on the plot.
+        /// Return true to claim this click (sets up drag tracking and marks the release as handled).
+        /// Return false to let ScottPlot handle the full press/release cycle (e.g. double-click auto-scale).
         /// </summary>
-        protected virtual void OnLeftPointerPressed(AvaPlot plotModel, Point plotPosition, PointerPressedEventArgs e) { }
+        protected virtual bool OnLeftPointerPressed(AvaPlot plotModel, Point plotPosition, PointerPressedEventArgs e) => false;
 
         /// <summary>
         /// Called when the left mouse button is released after a drag. Override to commit the drag action.
@@ -220,9 +239,11 @@ namespace Zametek.View.ProjectPlan
         protected bool IsLeftDragging => m_IsLeftDragging;
 
         /// <summary>
-        /// Called when Ctrl+left mouse button is pressed on the plot. Override to begin a dependency drag.
+        /// Called when Ctrl+left mouse button is pressed on the plot.
+        /// Return true to claim this click (sets up Ctrl+drag tracking).
+        /// Return false to let ScottPlot handle it.
         /// </summary>
-        protected virtual void OnCtrlLeftDragStart(AvaPlot plotModel, Point plotPosition, PointerPressedEventArgs e) { }
+        protected virtual bool OnCtrlLeftDragStart(AvaPlot plotModel, Point plotPosition, PointerPressedEventArgs e) => false;
 
         /// <summary>
         /// Called on every PointerMoved event while a Ctrl+left drag is in progress.
@@ -238,6 +259,12 @@ namespace Zametek.View.ProjectPlan
         /// True while a Ctrl+left-button drag is active.
         /// </summary>
         protected bool IsCtrlLeftDragging => m_IsCtrlLeftDragging;
+
+        /// <summary>
+        /// Called during PointerMoved when no drag is active. Override to set a context-sensitive cursor.
+        /// Return null to leave the cursor unchanged.
+        /// </summary>
+        protected virtual AvaloniaCursor? GetHoverCursor(AvaPlot plotModel, Point plotPosition) => null;
 
         private void OpenPlotContainerContextMenu(PointerReleasedEventArgs e)
         {
@@ -275,6 +302,7 @@ namespace Zametek.View.ProjectPlan
             // Notify subclass of active Ctrl+left drag.
             if (m_IsCtrlLeftDragging)
             {
+                m_PlotContainer.Cursor = new AvaloniaCursor(StandardCursorType.DragCopy);
                 OnCtrlLeftDragging(plotModel, pos, e);
                 return;
             }
@@ -282,9 +310,14 @@ namespace Zametek.View.ProjectPlan
             // Notify subclass of active left drag.
             if (m_IsLeftDragging)
             {
+                m_PlotContainer.Cursor = new AvaloniaCursor(StandardCursorType.SizeWestEast);
                 OnLeftDragging(plotModel, pos, e);
                 return;
             }
+
+            // Ask subclass for a context-sensitive hover cursor.
+            AvaloniaCursor? hoverCursor = GetHoverCursor(plotModel, pos);
+            m_PlotContainer.Cursor = hoverCursor ?? AvaloniaCursor.Default;
 
             Pixel mousePixel = new(pos.X, pos.Y);
             Coordinates mouseLocation = plotModel.Plot.GetCoordinates(mousePixel);

--- a/src/Zametek.View.ProjectPlan/Themes/ZametekTheme.axaml
+++ b/src/Zametek.View.ProjectPlan/Themes/ZametekTheme.axaml
@@ -1,0 +1,216 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:idc="clr-namespace:Dock.Avalonia.Controls;assembly=Dock.Avalonia">
+
+  <!-- =====================================================================
+       ZAMETEK DESIGN SYSTEM — ZametekTheme.axaml
+       Linear / Vercel / Modern SaaS desktop aesthetic
+       Color tokens live in App.axaml Application.Resources
+       ===================================================================== -->
+
+  <!-- ─────────────────────────────────────────────────────────────────────
+       1. TYPOGRAPHY — base font 13px, consistent line height
+       ───────────────────────────────────────────────────────────────────── -->
+
+  <Style Selector="TextBlock">
+    <Setter Property="FontSize" Value="13"/>
+    <Setter Property="LineHeight" Value="20"/>
+    <Setter Property="Foreground" Value="{DynamicResource ZTextPrimary}"/>
+  </Style>
+
+  <Style Selector="SelectableTextBlock">
+    <Setter Property="FontSize" Value="13"/>
+    <Setter Property="LineHeight" Value="20"/>
+    <Setter Property="Foreground" Value="{DynamicResource ZTextPrimary}"/>
+  </Style>
+
+  <Style Selector="Label">
+    <Setter Property="FontSize" Value="13"/>
+    <Setter Property="Padding" Value="4,0"/>
+    <Setter Property="Foreground" Value="{DynamicResource ZTextPrimary}"/>
+  </Style>
+
+  <Style Selector="TextBox">
+    <Setter Property="FontSize" Value="13"/>
+    <Setter Property="MinHeight" Value="28"/>
+    <Setter Property="CornerRadius" Value="4"/>
+  </Style>
+
+  <!-- ─────────────────────────────────────────────────────────────────────
+       2. BUTTONS — clean, 28px height, consistent padding
+       ───────────────────────────────────────────────────────────────────── -->
+
+  <Style Selector="Button">
+    <Setter Property="Height" Value="28"/>
+    <Setter Property="Padding" Value="12,0"/>
+    <Setter Property="FontSize" Value="13"/>
+    <Setter Property="CornerRadius" Value="4"/>
+    <Setter Property="VerticalContentAlignment" Value="Center"/>
+  </Style>
+
+  <!-- ─────────────────────────────────────────────────────────────────────
+       3. COMBOBOX — uniform 28px height
+       ───────────────────────────────────────────────────────────────────── -->
+
+  <Style Selector="ComboBox">
+    <Setter Property="MinHeight" Value="28"/>
+    <Setter Property="FontSize" Value="13"/>
+    <Setter Property="CornerRadius" Value="4"/>
+    <Setter Property="VerticalAlignment" Value="Center"/>
+    <Setter Property="VerticalContentAlignment" Value="Center"/>
+    <Setter Property="HorizontalAlignment" Value="Stretch"/>
+    <Setter Property="HorizontalContentAlignment" Value="Left"/>
+    <Setter Property="Padding" Value="8,3"/>
+  </Style>
+
+  <!-- ─────────────────────────────────────────────────────────────────────
+       4. TOGGLE SWITCH — consistent font
+       ───────────────────────────────────────────────────────────────────── -->
+
+  <Style Selector="ToggleSwitch">
+    <Setter Property="FontSize" Value="13"/>
+  </Style>
+
+  <!-- ─────────────────────────────────────────────────────────────────────
+       5. MENU / CONTEXT MENU — 13px, proper spacing
+       ───────────────────────────────────────────────────────────────────── -->
+
+  <Style Selector="Menu">
+    <Setter Property="Background" Value="{DynamicResource ZToolbarBg}"/>
+    <Setter Property="FontSize" Value="13"/>
+  </Style>
+
+  <Style Selector="MenuItem">
+    <Setter Property="FontSize" Value="13"/>
+    <Setter Property="Padding" Value="8,5"/>
+    <Setter Property="Height" Value="32"/>
+  </Style>
+
+  <Style Selector="MenuItem > MenuItem">
+    <Setter Property="Padding" Value="8,4"/>
+    <Setter Property="Height" Value="32"/>
+  </Style>
+
+  <Style Selector="Separator">
+    <Setter Property="Margin" Value="4,2"/>
+  </Style>
+
+  <!-- ─────────────────────────────────────────────────────────────────────
+       6. DATAGRID — professional grid with clean headers
+       ───────────────────────────────────────────────────────────────────── -->
+
+  <Style Selector="DataGrid">
+    <Setter Property="FontSize" Value="13"/>
+    <Setter Property="GridLinesVisibility" Value="Horizontal"/>
+    <Setter Property="BorderThickness" Value="1"/>
+    <Setter Property="BorderBrush" Value="{DynamicResource ZBorder}"/>
+    <Setter Property="CornerRadius" Value="4"/>
+    <Setter Property="Background" Value="{DynamicResource ZSurface}"/>
+  </Style>
+
+  <Style Selector="DataGridColumnHeader">
+    <Setter Property="FontSize" Value="12"/>
+    <Setter Property="FontWeight" Value="SemiBold"/>
+    <Setter Property="Height" Value="32"/>
+    <Setter Property="MinHeight" Value="32"/>
+    <Setter Property="Background" Value="{DynamicResource ZSurface2}"/>
+    <Setter Property="Foreground" Value="{DynamicResource ZTextSecondary}"/>
+    <Setter Property="Padding" Value="8,0"/>
+    <Setter Property="BorderBrush" Value="{DynamicResource ZBorder}"/>
+    <Setter Property="BorderThickness" Value="0,0,0,1"/>
+  </Style>
+
+  <Style Selector="DataGridCell">
+    <Setter Property="FontSize" Value="13"/>
+    <Setter Property="Padding" Value="8,4"/>
+  </Style>
+
+  <Style Selector="DataGridRow">
+    <Setter Property="MinHeight" Value="30"/>
+  </Style>
+
+  <!-- ─────────────────────────────────────────────────────────────────────
+       7. DATE PICKER — vertically centered, compact
+       ───────────────────────────────────────────────────────────────────── -->
+
+  <Style Selector="DatePicker">
+    <Setter Property="VerticalAlignment" Value="Center"/>
+    <Setter Property="FontSize" Value="12"/>
+  </Style>
+
+  <Style Selector="CalendarDatePicker">
+    <Setter Property="FontSize" Value="12"/>
+  </Style>
+
+  <!-- ─────────────────────────────────────────────────────────────────────
+       8. STATUS BAR LABEL — 11px muted, consistent
+       ───────────────────────────────────────────────────────────────────── -->
+
+  <Style Selector="DockPanel Label.status-label">
+    <Setter Property="FontSize" Value="11"/>
+    <Setter Property="Foreground" Value="{DynamicResource ZTextMuted}"/>
+    <Setter Property="VerticalContentAlignment" Value="Center"/>
+  </Style>
+
+  <!-- ─────────────────────────────────────────────────────────────────────
+       9. DOCK.AVALONIA TAB OVERRIDES
+          Clean underline style: muted inactive, primary active
+       ───────────────────────────────────────────────────────────────────── -->
+
+  <Style Selector="TabItem">
+    <Setter Property="FontSize" Value="13"/>
+    <Setter Property="Padding" Value="12,6"/>
+    <Setter Property="Foreground" Value="{DynamicResource ZTextSecondary}"/>
+    <Setter Property="Background" Value="Transparent"/>
+    <Setter Property="BorderThickness" Value="0"/>
+  </Style>
+
+  <Style Selector="TabItem:selected">
+    <Setter Property="Foreground" Value="{DynamicResource ZTextPrimary}"/>
+    <Setter Property="FontWeight" Value="Medium"/>
+  </Style>
+
+  <Style Selector="TabItem:pointerover">
+    <Setter Property="Foreground" Value="{DynamicResource ZTextPrimary}"/>
+  </Style>
+
+  <!-- Dock root control — remove bottom gap -->
+  <Style Selector="idc|RootDockControl">
+    <Setter Property="Margin" Value="0"/>
+  </Style>
+
+  <!-- ─────────────────────────────────────────────────────────────────────
+       10. PANEL SECTION HEADERS — the 11px SemiBold label style
+           Used in chart side panels for section grouping
+       ───────────────────────────────────────────────────────────────────── -->
+
+  <Style Selector="Label.section-header">
+    <Setter Property="FontSize" Value="11"/>
+    <Setter Property="FontWeight" Value="SemiBold"/>
+    <Setter Property="Foreground" Value="{DynamicResource ZTextSecondary}"/>
+    <Setter Property="Opacity" Value="1"/>
+    <Setter Property="Padding" Value="0"/>
+    <Setter Property="Margin" Value="0,0,0,4"/>
+  </Style>
+
+  <!-- ─────────────────────────────────────────────────────────────────────
+       11. SCROLLVIEWER — clean, thin scrollbars
+       ───────────────────────────────────────────────────────────────────── -->
+
+  <Style Selector="ScrollViewer">
+    <Setter Property="AllowAutoHide" Value="True"/>
+  </Style>
+
+  <!-- ─────────────────────────────────────────────────────────────────────
+       12. WINDOW ERROR INDICATOR — Border classes for compile state
+       ───────────────────────────────────────────────────────────────────── -->
+
+  <Style Selector="Border.compile-ok">
+    <Setter Property="Background" Value="Transparent"/>
+  </Style>
+
+  <Style Selector="Border.compile-error">
+    <Setter Property="Background" Value="{DynamicResource ZError}"/>
+  </Style>
+
+</Styles>

--- a/src/Zametek.View.ProjectPlan/Themes/ZametekTheme.axaml
+++ b/src/Zametek.View.ProjectPlan/Themes/ZametekTheme.axaml
@@ -15,19 +15,16 @@
   <Style Selector="TextBlock">
     <Setter Property="FontSize" Value="13"/>
     <Setter Property="LineHeight" Value="20"/>
-    <Setter Property="Foreground" Value="{DynamicResource ZTextPrimary}"/>
   </Style>
 
   <Style Selector="SelectableTextBlock">
     <Setter Property="FontSize" Value="13"/>
     <Setter Property="LineHeight" Value="20"/>
-    <Setter Property="Foreground" Value="{DynamicResource ZTextPrimary}"/>
   </Style>
 
   <Style Selector="Label">
     <Setter Property="FontSize" Value="13"/>
     <Setter Property="Padding" Value="4,0"/>
-    <Setter Property="Foreground" Value="{DynamicResource ZTextPrimary}"/>
   </Style>
 
   <Style Selector="TextBox">
@@ -105,7 +102,6 @@
     <Setter Property="BorderThickness" Value="1"/>
     <Setter Property="BorderBrush" Value="{DynamicResource ZBorder}"/>
     <Setter Property="CornerRadius" Value="4"/>
-    <Setter Property="Background" Value="{DynamicResource ZSurface}"/>
   </Style>
 
   <Style Selector="DataGridColumnHeader">
@@ -113,8 +109,6 @@
     <Setter Property="FontWeight" Value="SemiBold"/>
     <Setter Property="Height" Value="32"/>
     <Setter Property="MinHeight" Value="32"/>
-    <Setter Property="Background" Value="{DynamicResource ZSurface2}"/>
-    <Setter Property="Foreground" Value="{DynamicResource ZTextSecondary}"/>
     <Setter Property="Padding" Value="8,0"/>
     <Setter Property="BorderBrush" Value="{DynamicResource ZBorder}"/>
     <Setter Property="BorderThickness" Value="0,0,0,1"/>

--- a/src/Zametek.View.ProjectPlan/TrackingManagement/TrackingManagerView.axaml
+++ b/src/Zametek.View.ProjectPlan/TrackingManagement/TrackingManagerView.axaml
@@ -190,7 +190,7 @@
 				</DataGrid.Columns>
 			</DataGrid>
 
-			<GridSplitter Grid.Row="1" Background="Black" ResizeDirection="Rows"/>
+			<GridSplitter Grid.Row="1" Background="{DynamicResource SemiColorBorder}" ResizeDirection="Rows"/>
 
 			<DataGrid Name="TrackerActivitiesGrid"
 					  IsEnabled="{Binding Path=HasActivities, Mode=OneWay}"

--- a/src/Zametek.ViewModel.ProjectPlan/ActivityManagement/ActivitiesManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ActivityManagement/ActivitiesManagerViewModel.cs
@@ -457,6 +457,29 @@ namespace Zametek.ViewModel.ProjectPlan
 
         public ObservableCollection<IManagedActivityViewModel> OrderableActivities => m_CoreViewModel.OrderableActivities;
 
+        private int m_ScrollToActivityId;
+        public int ScrollToActivityId
+        {
+            get => m_ScrollToActivityId;
+            private set => this.RaiseAndSetIfChanged(ref m_ScrollToActivityId, value);
+        }
+
+        public void SelectActivityById(int activityId)
+        {
+            lock (m_Lock)
+            {
+                IManagedActivityViewModel? activity = RawActivities.FirstOrDefault(a => a.Id == activityId);
+                if (activity is not null)
+                {
+                    SelectedActivities.Clear();
+                    SelectedActivities[activityId] = activity;
+                    HasSelectedActivities = true;
+                    HasSelectedActivity = true;
+                    ScrollToActivityId = activityId;
+                }
+            }
+        }
+
         public ICommand SetSelectedManagedActivitiesCommand { get; }
 
         public ICommand AddManagedActivityCommand { get; }

--- a/src/Zametek.ViewModel.ProjectPlan/GanttChartManagement/GanttChartManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/GanttChartManagement/GanttChartManagerViewModel.cs
@@ -89,7 +89,7 @@ namespace Zametek.ViewModel.ProjectPlan
         private const double c_BarSize = 0.5;
         private const double c_TrackerCorrection = c_BarSize / 2.0;
 
-        private const double c_ArrowHeadDelta = 0.03;
+        private const double c_ArrowHeadDelta = 0.5;
         private const float c_ArrowHeadWidth = 6.0f;
         private const float c_ArrowHeadLength = 14.0f;
         private const float c_ArrowHeadHeight = 8.0f;
@@ -1214,8 +1214,10 @@ namespace Zametek.ViewModel.ProjectPlan
             Dictionary<int, (double Start, double End)> activityBarPositions,
             Dictionary<int, double> activityBarYPosition)
         {
-            // Draw a thin grey arrow from the end of each predecessor bar to the start of each successor bar.
+            // Draw elbow connectors (3 segments) from predecessor bar end to successor bar start.
+            // Routing: right from predecessor end → vertical to successor row → to successor start.
             Color connectionColor = Colors.Grey.WithAlpha(180);
+            const double c_ElbowBuffer = 0.5; // time units to extend right before turning
 
             foreach (IDependentActivity activity in graphCompilation.DependentActivities)
             {
@@ -1239,14 +1241,29 @@ namespace Zametek.ViewModel.ProjectPlan
                         continue;
                     }
 
-                    // Draw arrow from end of predecessor to start of successor.
-                    var basePoint = new Coordinates(fromPos.End, fromY);
-                    var tipPoint = new Coordinates(toPos.Start, toY);
+                    // viaX: the x-coordinate of the elbow turn.
+                    // Always buffer right of the predecessor end so the connector exits cleanly.
+                    double viaX = fromPos.End + c_ElbowBuffer;
 
+                    // Segment 1: horizontal right from predecessor bar end to the elbow.
+                    ScottPlot.Plottables.LinePlot seg1 = plotModel.Plot.Add.Line(fromPos.End, fromY, viaX, fromY);
+                    seg1.Color = connectionColor;
+                    seg1.LineWidth = c_ConnectionArrowLineWidth;
+
+                    // Segment 2: vertical from predecessor row to successor row (only if rows differ).
+                    if (Math.Abs(fromY - toY) > 0.01)
+                    {
+                        ScottPlot.Plottables.LinePlot seg2 = plotModel.Plot.Add.Line(viaX, fromY, viaX, toY);
+                        seg2.Color = connectionColor;
+                        seg2.LineWidth = c_ConnectionArrowLineWidth;
+                    }
+
+                    // Segment 3: horizontal arrow from elbow to successor bar start, arrowhead at start.
+                    // Arrow.Base = elbow point, Arrow.Tip = successor start (arrowhead lands here).
                     var arrow = new Arrow
                     {
-                        Base = basePoint,
-                        Tip = tipPoint,
+                        Base = new Coordinates(viaX, toY),
+                        Tip = new Coordinates(toPos.Start, toY),
                         ArrowLineColor = connectionColor,
                         ArrowFillColor = connectionColor,
                         ArrowShape = ArrowShape.Arrowhead.GetShape(),
@@ -1254,7 +1271,6 @@ namespace Zametek.ViewModel.ProjectPlan
                         ArrowheadLength = c_ConnectionArrowHeadLength,
                         ArrowLineWidth = c_ConnectionArrowLineWidth,
                     };
-
                     plotModel.Plot.PlottableList.Add(arrow);
                 }
             }

--- a/src/Zametek.ViewModel.ProjectPlan/GanttChartManagement/GanttChartManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/GanttChartManagement/GanttChartManagerViewModel.cs
@@ -95,6 +95,9 @@ namespace Zametek.ViewModel.ProjectPlan
         private const float c_ArrowHeadHeight = 8.0f;
 
         private const float c_VerticalLineWidth = 2.0f;
+        private const float c_ConnectionArrowLineWidth = 1.0f;
+        private const float c_ConnectionArrowHeadWidth = 5.0f;
+        private const float c_ConnectionArrowHeadLength = 10.0f;
 
         #endregion
 
@@ -211,6 +214,9 @@ namespace Zametek.ViewModel.ProjectPlan
                     })
                 .ToProperty(this, rcm => rcm.BoolAccumulator);
 
+            this.WhenAnyValue(rcm => rcm.ShowAllConnections)
+                .Subscribe(_ => BuildGanttChartPlotModel());
+
             m_BuildGanttChartPlotModelSub = this
                 .WhenAnyValue(
                     rcm => rcm.m_CoreViewModel.ResourceSeriesSet,
@@ -264,6 +270,19 @@ namespace Zametek.ViewModel.ProjectPlan
 
         public object? ImageBounds { get; set; }
 
+        private bool m_ShowAllConnections;
+        public bool ShowAllConnections
+        {
+            get => m_ShowAllConnections;
+            set
+            {
+                lock (m_Lock)
+                {
+                    this.RaiseAndSetIfChanged(ref m_ShowAllConnections, value);
+                }
+            }
+        }
+
         #endregion
 
         #region Private Methods
@@ -310,6 +329,7 @@ namespace Zametek.ViewModel.ProjectPlan
             bool showProjectFinish,
             bool showTracking,
             IEnumerable<int> highlightActivityConnections,
+            bool showAllConnections,
             BaseTheme baseTheme)
         {
             ArgumentNullException.ThrowIfNull(dateTimeCalculator);
@@ -355,6 +375,7 @@ namespace Zametek.ViewModel.ProjectPlan
             var bars = new List<Bar>();
             var highlights = new List<IPlottable>();
             var labels = new List<string>();
+            var activityBarPositions = new Dictionary<int, (double Start, double End)>();
 
             switch (groupByMode)
             {
@@ -395,7 +416,8 @@ namespace Zametek.ViewModel.ProjectPlan
                                 labels,
                                 highlights,
                                 activity,
-                                highlightActivityConnections);
+                                highlightActivityConnections,
+                                activityBarPositions);
 
                             switch (annotationStyle)
                             {
@@ -540,7 +562,8 @@ namespace Zametek.ViewModel.ProjectPlan
                                         labels,
                                         highlights,
                                         activity,
-                                        highlightActivityConnections);
+                                        highlightActivityConnections,
+                                        activityBarPositions);
                                 }
                             }
 
@@ -746,7 +769,8 @@ namespace Zametek.ViewModel.ProjectPlan
                                         labels,
                                         highlights,
                                         activity,
-                                        highlightActivityConnections);
+                                        highlightActivityConnections,
+                                        activityBarPositions);
                                 }
                             }
 
@@ -845,14 +869,30 @@ namespace Zametek.ViewModel.ProjectPlan
             }
 
             // Enumerate the bar series and set the position of each bar.
+            // Also build a position lookup for connection arrow drawing.
+            var activityBarYPosition = new Dictionary<int, double>();
             for (int i = 0; i < bars.Count; i++)
             {
                 var bar = bars[i];
                 bar.Position = i + 1;
+                if (bar is AnnotatedBar ab && ab.ActivityId != 0)
+                {
+                    activityBarYPosition[ab.ActivityId] = i + 1;
+                }
             }
 
             BarPlot barPlot = plotModel.Plot.Add.Bars(bars);
             barPlot.Horizontal = true;
+
+            // Draw "show all connections" arrows between dependent activity bars.
+            if (showAllConnections)
+            {
+                AddAllConnectionArrows(
+                    plotModel,
+                    graphCompilation,
+                    activityBarPositions,
+                    activityBarYPosition);
+            }
 
             // Highlights (above the bar plot).
             plotModel.Plot.PlottableList.AddRange(highlights);
@@ -1043,7 +1083,8 @@ namespace Zametek.ViewModel.ProjectPlan
             List<string> labels,
             List<IPlottable> highlights,
             IDependentActivity activity,
-            IEnumerable<int> highlightActivityConnections)
+            IEnumerable<int> highlightActivityConnections,
+            Dictionary<int, (double Start, double End)>? activityBarPositions = null)
         {
             if (activity.EarliestStartTime.HasValue
                 && activity.EarliestFinishTime.HasValue
@@ -1126,6 +1167,11 @@ namespace Zametek.ViewModel.ProjectPlan
                 series.Add(item);
                 labels.Add(label);
 
+                if (activityBarPositions is not null)
+                {
+                    activityBarPositions[activity.Id] = (start, end);
+                }
+
                 int labelCount = labels.Count;
 
                 if (highlightAsDependency)
@@ -1158,6 +1204,58 @@ namespace Zametek.ViewModel.ProjectPlan
                     {
                         highlights.Add(rectangle);
                     }
+                }
+            }
+        }
+
+        private static void AddAllConnectionArrows(
+            AvaPlot plotModel,
+            IGraphCompilation<int, int, int, IDependentActivity> graphCompilation,
+            Dictionary<int, (double Start, double End)> activityBarPositions,
+            Dictionary<int, double> activityBarYPosition)
+        {
+            // Draw a thin grey arrow from the end of each predecessor bar to the start of each successor bar.
+            Color connectionColor = Colors.Grey.WithAlpha(180);
+
+            foreach (IDependentActivity activity in graphCompilation.DependentActivities)
+            {
+                // activity.Successors = list of successor IDs
+                foreach (int successorId in activity.Successors)
+                {
+                    if (!activityBarPositions.TryGetValue(activity.Id, out (double Start, double End) fromPos))
+                    {
+                        continue;
+                    }
+                    if (!activityBarPositions.TryGetValue(successorId, out (double Start, double End) toPos))
+                    {
+                        continue;
+                    }
+                    if (!activityBarYPosition.TryGetValue(activity.Id, out double fromY))
+                    {
+                        continue;
+                    }
+                    if (!activityBarYPosition.TryGetValue(successorId, out double toY))
+                    {
+                        continue;
+                    }
+
+                    // Draw arrow from end of predecessor to start of successor.
+                    var basePoint = new Coordinates(fromPos.End, fromY);
+                    var tipPoint = new Coordinates(toPos.Start, toY);
+
+                    var arrow = new Arrow
+                    {
+                        Base = basePoint,
+                        Tip = tipPoint,
+                        ArrowLineColor = connectionColor,
+                        ArrowFillColor = connectionColor,
+                        ArrowShape = ArrowShape.Arrowhead.GetShape(),
+                        ArrowheadWidth = c_ConnectionArrowHeadWidth,
+                        ArrowheadLength = c_ConnectionArrowHeadLength,
+                        ArrowLineWidth = c_ConnectionArrowLineWidth,
+                    };
+
+                    plotModel.Plot.PlottableList.Add(arrow);
                 }
             }
         }
@@ -1596,6 +1694,7 @@ namespace Zametek.ViewModel.ProjectPlan
                     ShowProjectFinish,
                     ShowTracking,
                     ActivitySelector.SelectedActivityIds,
+                    ShowAllConnections,
                     m_CoreViewModel.BaseTheme);
             }
 
@@ -1633,6 +1732,34 @@ namespace Zametek.ViewModel.ProjectPlan
             }
 
             activity.Duration = newDuration;
+            m_CoreViewModel.IsProjectScenarioUpdated = true;
+            m_CoreViewModel.RunAutoCompile();
+        }
+
+        public void AddActivityDependency(int fromActivityId, int toActivityId)
+        {
+            if (fromActivityId == toActivityId)
+            {
+                return;
+            }
+
+            IManagedActivityViewModel? fromActivity = m_CoreViewModel.RawActivities
+                .FirstOrDefault(a => a.Id == fromActivityId);
+
+            if (fromActivity is null)
+            {
+                return;
+            }
+
+            // Parse existing dependencies and add the new one if not already present.
+            HashSet<int> deps = [.. fromActivity.Dependencies];
+            if (deps.Contains(toActivityId))
+            {
+                return;
+            }
+
+            deps.Add(toActivityId);
+            fromActivity.DependenciesString = string.Join(",", deps.OrderBy(x => x));
             m_CoreViewModel.IsProjectScenarioUpdated = true;
             m_CoreViewModel.RunAutoCompile();
         }

--- a/src/Zametek.ViewModel.ProjectPlan/GanttChartManagement/GanttChartManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/GanttChartManagement/GanttChartManagerViewModel.cs
@@ -1118,6 +1118,9 @@ namespace Zametek.ViewModel.ProjectPlan
                     Value = end,
                     FillColor = backgroundColor,
                     Size = c_BarSize,
+                    ActivityId = activity.Id,
+                    ActivityStartTime = activity.EarliestStartTime.GetValueOrDefault(),
+                    ActivityDuration = activity.Duration,
                 };
 
                 series.Add(item);
@@ -1612,6 +1615,26 @@ namespace Zametek.ViewModel.ProjectPlan
             //});
 
             GanttChartPlotModel = plotModel;
+        }
+
+        public void SetActivityDuration(int activityId, int newDuration)
+        {
+            if (newDuration < 1)
+            {
+                newDuration = 1;
+            }
+
+            IManagedActivityViewModel? activity = m_CoreViewModel.RawActivities
+                .FirstOrDefault(a => a.Id == activityId);
+
+            if (activity is null)
+            {
+                return;
+            }
+
+            activity.Duration = newDuration;
+            m_CoreViewModel.IsProjectScenarioUpdated = true;
+            m_CoreViewModel.RunAutoCompile();
         }
 
         #endregion

--- a/src/Zametek.ViewModel.ProjectPlan/GraphManagement/ArrowGraphManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/GraphManagement/ArrowGraphManagerViewModel.cs
@@ -76,9 +76,12 @@ namespace Zametek.ViewModel.ProjectPlan
         private readonly IDialogService m_DialogService;
         private readonly IArrowGraphSerializer m_ArrowGraphExport;
         private readonly IGraphImageExporter m_GraphImageExporter;
+        private readonly Lazy<IMainViewModel> m_MainViewModel;
 
         private readonly IDisposable? m_BuildArrowGraphDataSub;
         private readonly IDisposable? m_BuildArrowGraphImageSub;
+
+        private IReadOnlyList<GraphEdgeHitRect> m_EdgeHitRects = [];
 
         #endregion
 
@@ -89,19 +92,22 @@ namespace Zametek.ViewModel.ProjectPlan
             ISettingService settingService,
             IDialogService dialogService,
             IArrowGraphSerializer arrowGraphExport,
-            IGraphImageExporter graphImageExporter)
+            IGraphImageExporter graphImageExporter,
+            Lazy<IMainViewModel> mainViewModel)
         {
             ArgumentNullException.ThrowIfNull(coreViewModel);
             ArgumentNullException.ThrowIfNull(settingService);
             ArgumentNullException.ThrowIfNull(dialogService);
             ArgumentNullException.ThrowIfNull(arrowGraphExport);
             ArgumentNullException.ThrowIfNull(graphImageExporter);
+            ArgumentNullException.ThrowIfNull(mainViewModel);
             m_Lock = new();
             m_CoreViewModel = coreViewModel;
             m_SettingService = settingService;
             m_DialogService = dialogService;
             m_ArrowGraphExport = arrowGraphExport;
             m_GraphImageExporter = graphImageExporter;
+            m_MainViewModel = mainViewModel;
 
             m_ArrowGraphData = string.Empty;
             m_ArrowGraphImage = new SvgImage();
@@ -266,6 +272,17 @@ namespace Zametek.ViewModel.ProjectPlan
         private readonly ObservableAsPropertyHelper<BaseTheme> m_BaseTheme;
         public BaseTheme BaseTheme => m_BaseTheme.Value;
 
+        public IReadOnlyList<GraphEdgeHitRect> EdgeHitRects
+        {
+            get
+            {
+                lock (m_Lock)
+                {
+                    return m_EdgeHitRects;
+                }
+            }
+        }
+
         public ICommand SaveArrowGraphImageFileCommand { get; }
 
         public async Task SaveArrowGraphImageFileAsync(string? filename)
@@ -324,20 +341,33 @@ namespace Zametek.ViewModel.ProjectPlan
         public void BuildArrowGraphDiagramData()
         {
             byte[]? data = null;
+            IReadOnlyList<GraphEdgeHitRect> hitRects = [];
 
             lock (m_Lock)
             {
                 if (!HasCompilationErrors)
                 {
-                    data = m_ArrowGraphExport.BuildArrowGraphSvgData(
+                    (byte[] svgData, IReadOnlyList<GraphEdgeHitRect> rects) = m_ArrowGraphExport.BuildArrowGraphSvgData(
                         m_CoreViewModel.ArrowGraph,
                         m_CoreViewModel.GraphSettings,
                         m_CoreViewModel.BaseTheme,
                         m_CoreViewModel.DisplaySettingsViewModel.ArrowGraphShowNames);
+                    data = svgData;
+                    hitRects = rects;
                 }
             }
 
+            lock (m_Lock)
+            {
+                m_EdgeHitRects = hitRects;
+            }
+
             ArrowGraphData = data?.ByteArrayToString() ?? string.Empty;
+        }
+
+        public void NavigateToActivity(int activityId)
+        {
+            m_MainViewModel.Value.SelectActivity(activityId);
         }
 
         public void BuildArrowGraphDiagramImage()

--- a/src/Zametek.ViewModel.ProjectPlan/GraphManagement/GraphSerializer/ArrowGraphSerializer.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/GraphManagement/GraphSerializer/ArrowGraphSerializer.cs
@@ -25,8 +25,8 @@ namespace Zametek.ViewModel.ProjectPlan
                 {NodeBorderDashStyle.Dashed, Microsoft.Msagl.Drawing.Style.Dashed}
              };
 
-        private static readonly double s_SvgNodeWidth = 40.0;
-        private static readonly double s_SvgNodeHeight = 34.0;
+        private static readonly double s_SvgNodeWidth = 48.0;
+        private static readonly double s_SvgNodeHeight = 38.0;
         private static readonly double s_SvgNodeLabelWidth = 34.0;
         private static readonly double s_SvgNodeLabelLines = 1.0;
         private static readonly double s_SvgRadiusInXDirection = 3.0;
@@ -45,12 +45,13 @@ namespace Zametek.ViewModel.ProjectPlan
         private static readonly double s_SvgConsolasLabelWidthCorrectionFactor = s_SvgNodeLabelLines * s_SvgNodeLabelWidth / 14;
         private static readonly double s_SvgConsolasLabelHeightCorrectionFactor = 0.7;
 
-        private static readonly Color s_NodeFillColor = Colors.LightGray;
-        private static readonly Color s_NodeBorderColor = Colors.Black;
+        private static readonly Color s_NodeFillColor = Color.FromRgb(0x1E, 0x29, 0x3B);   // dark slate
+        private static readonly Color s_NodeBorderColor = Color.FromRgb(0x3B, 0x82, 0xF6); // blue
+        private static readonly Microsoft.Msagl.Drawing.Color s_NodeLabelColor = new(0xF1, 0xF5, 0xF9); // near-white
 
         private const double c_PxPerInch = 96;
         private const double c_PtPerInch = 72;
-        private const string c_FontName = @"Consolas";
+        private const string c_FontName = @"Inter";
 
         private readonly IMsaglSvgRenderer m_MsaglSvgRenderer;
 
@@ -339,20 +340,58 @@ namespace Zametek.ViewModel.ProjectPlan
 
         private static Microsoft.Msagl.Drawing.Color EdgeFontColor(BaseTheme baseTheme)
         {
-            if (baseTheme == BaseTheme.Light)
-            {
-                return Microsoft.Msagl.Drawing.Color.Black;
-            }
-            if (baseTheme == BaseTheme.Dark)
-            {
-                return Microsoft.Msagl.Drawing.Color.White;
-            }
-            return Microsoft.Msagl.Drawing.Color.Black;
+            // Muted slate — readable on both light and dark SVG backgrounds.
+            return new Microsoft.Msagl.Drawing.Color(0x94, 0xA3, 0xB8);
         }
 
         #endregion
 
-        public byte[] BuildArrowGraphSvgData(
+        // Margin used by SvgGraphWriter when computing positions in SVG space.
+        private const double c_SvgMargin = 1.0;
+
+        private static IReadOnlyList<GraphEdgeHitRect> ComputeEdgeHitRects(
+            Microsoft.Msagl.Drawing.Graph drawingGraph,
+            Dictionary<Microsoft.Msagl.Drawing.Edge, int> edgeToActivityId)
+        {
+            var hitRects = new List<GraphEdgeHitRect>();
+
+            Microsoft.Msagl.Core.Geometry.Rectangle bb = drawingGraph.GeometryGraph.BoundingBox;
+
+            foreach (Microsoft.Msagl.Drawing.Edge drawingEdge in drawingGraph.Edges)
+            {
+                if (!edgeToActivityId.TryGetValue(drawingEdge, out int activityId))
+                {
+                    continue;
+                }
+
+                if (drawingEdge.Label is null || !drawingEdge.Label.IsVisible)
+                {
+                    continue;
+                }
+
+                Microsoft.Msagl.Core.Layout.Label? geomLabel = drawingEdge.Label.GeometryLabel;
+                if (geomLabel is null)
+                {
+                    continue;
+                }
+
+                double w = geomLabel.Width;
+                double h = geomLabel.Height;
+                double cx = geomLabel.Center.X - bb.Left + c_SvgMargin;
+                double cy = bb.Top - geomLabel.Center.Y + c_SvgMargin;
+
+                hitRects.Add(new GraphEdgeHitRect(
+                    activityId,
+                    LabelX: cx - w / 2.0,
+                    LabelY: cy - h / 2.0,
+                    LabelWidth: w,
+                    LabelHeight: h));
+            }
+
+            return hitRects.AsReadOnly();
+        }
+
+        public (byte[] SvgData, IReadOnlyList<GraphEdgeHitRect> EdgeHitRects) BuildArrowGraphSvgData(
             ArrowGraphModel arrowGraph,
             GraphSettingsModel graphSettings,
             BaseTheme baseTheme,
@@ -373,6 +412,9 @@ namespace Zametek.ViewModel.ProjectPlan
 
             Dictionary<string, Microsoft.Msagl.Drawing.Node> drawingNodeLookup = drawingGraph.Nodes.ToDictionary(x => x.Id);
 
+            // Track edge -> activity ID for hit-rect computation.
+            var edgeToActivityId = new Dictionary<Microsoft.Msagl.Drawing.Edge, int>();
+
             foreach (DiagramEdgeModel diagramEdge in diagramGraph.Edges)
             {
                 var edge = new Microsoft.Msagl.Drawing.Edge(
@@ -389,6 +431,7 @@ namespace Zametek.ViewModel.ProjectPlan
                 edge.Label.FontColor = EdgeFontColor(baseTheme);
 
                 drawingGraph.AddPrecalculatedEdge(edge);
+                edgeToActivityId[edge] = diagramEdge.Id;
             }
 
             drawingGraph.LayoutAlgorithmSettings = drawingGraph.CreateLayoutSettings();
@@ -431,6 +474,7 @@ namespace Zametek.ViewModel.ProjectPlan
                 drawingGraphNode.Label.FontStyle = s_SvgNodeFontStyle;
 
                 drawingGraphNode.Label.FontName = c_FontName;
+                drawingGraphNode.Label.FontColor = s_NodeLabelColor;
                 drawingGraphNode.Attr.AddStyle(s_NodeBorderDashMsaglLookup[diagramNode.BorderDashStyle]);
                 drawingGraphNode.Attr.FillColor = HtmlHexCodeToMsaglColor(diagramNode.FillColorHexCode) ?? Microsoft.Msagl.Drawing.Color.LightGray;
                 drawingGraphNode.Attr.Color = HtmlHexCodeToMsaglColor(diagramNode.BorderColorHexCode) ?? Microsoft.Msagl.Drawing.Color.Black;
@@ -452,7 +496,10 @@ namespace Zametek.ViewModel.ProjectPlan
 
             Microsoft.Msagl.Miscellaneous.LayoutHelpers.CalculateLayout(drawingGraph.GeometryGraph, drawingGraph.LayoutAlgorithmSettings, null);
 
-            return m_MsaglSvgRenderer.RenderToSvg(drawingGraph, baseTheme);
+            byte[] svgData = m_MsaglSvgRenderer.RenderToSvg(drawingGraph, baseTheme);
+            IReadOnlyList<GraphEdgeHitRect> edgeHitRects = ComputeEdgeHitRects(drawingGraph, edgeToActivityId);
+
+            return (svgData, edgeHitRects);
         }
 
         public byte[] BuildArrowGraphMLData(

--- a/src/Zametek.ViewModel.ProjectPlan/GraphManagement/GraphSerializer/GraphEdgeFormatLookup.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/GraphManagement/GraphSerializer/GraphEdgeFormatLookup.cs
@@ -12,8 +12,8 @@ namespace Zametek.ViewModel.ProjectPlan
                 {EdgeWeightStyle.Normal, c_NormalStrokeWeight},
                 {EdgeWeightStyle.Bold, c_BoldStrokeWeight}
             };
-        private const double c_NormalStrokeWeight = 1.0;
-        private const double c_BoldStrokeWeight = 2.0;
+        private const double c_NormalStrokeWeight = 1.5;
+        private const double c_BoldStrokeWeight = 2.5;
 
         private readonly Dictionary<EdgeType, EdgeDashStyle> m_EdgeTypeDashLookup;
         private readonly Dictionary<EdgeType, double> m_EdgeTypeWeightLookup;

--- a/src/Zametek.ViewModel.ProjectPlan/GraphManagement/GraphSerializer/VertexGraphSerializer.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/GraphManagement/GraphSerializer/VertexGraphSerializer.cs
@@ -25,8 +25,8 @@ namespace Zametek.ViewModel.ProjectPlan
                 {NodeBorderDashStyle.Dashed, Microsoft.Msagl.Drawing.Style.Dashed}
              };
 
-        private static readonly double s_SvgNodeWidth = 38.0;
-        private static readonly double s_SvgNodeHeight = 30.0;
+        private static readonly double s_SvgNodeWidth = 52.0;
+        private static readonly double s_SvgNodeHeight = 44.0;
         private static readonly double s_SvgNodeLabelWidth = 30.0;
         private static readonly double s_SvgNodeLabelLines = 3.0;
         private static readonly double s_SvgRadiusInXDirection = 3.0;
@@ -45,12 +45,14 @@ namespace Zametek.ViewModel.ProjectPlan
         private static readonly double s_SvgConsolasLabelWidthCorrectionFactor = s_SvgNodeLabelLines * s_SvgNodeLabelWidth / 11.5;
         private static readonly double s_SvgConsolasLabelHeightCorrectionFactor = 3;
 
-        private static readonly Color s_NodeFillColor = Colors.LightGray;
-        private static readonly Color s_NodeBorderColor = Colors.Black;
+        private static readonly Color s_NodeFillColor = Color.FromRgb(0x1E, 0x29, 0x3B);   // dark slate
+        private static readonly Color s_NodeBorderColor = Color.FromRgb(0x3B, 0x82, 0xF6); // blue (fallback only)
+        private static readonly Microsoft.Msagl.Drawing.Color s_NodeLabelColor = new(0xF1, 0xF5, 0xF9); // near-white
+        private static readonly Microsoft.Msagl.Drawing.Color s_EdgeDefaultColor = new(0x64, 0x74, 0x8B); // muted slate
 
         private const double c_PxPerInch = 96;
         private const double c_PtPerInch = 72;
-        private const string c_FontName = @"Consolas";
+        private const string c_FontName = @"Inter";
 
         private readonly IMsaglSvgRenderer m_MsaglSvgRenderer;
 
@@ -243,20 +245,49 @@ namespace Zametek.ViewModel.ProjectPlan
 
         private static Microsoft.Msagl.Drawing.Color EdgeFontColor(BaseTheme baseTheme)
         {
-            if (baseTheme == BaseTheme.Light)
-            {
-                return Microsoft.Msagl.Drawing.Color.Black;
-            }
-            if (baseTheme == BaseTheme.Dark)
-            {
-                return Microsoft.Msagl.Drawing.Color.White;
-            }
-            return Microsoft.Msagl.Drawing.Color.Black;
+            // Muted slate — readable on both light and dark SVG backgrounds.
+            return new Microsoft.Msagl.Drawing.Color(0x94, 0xA3, 0xB8);
         }
 
         #endregion
 
-        public byte[] BuildVertexGraphSvgData(
+        // Margin used by SvgGraphWriter when computing node positions in SVG space.
+        private const double c_SvgMargin = 1.0;
+
+        private static IReadOnlyList<GraphNodeHitRect> ComputeHitRects(
+            Microsoft.Msagl.Drawing.Graph drawingGraph,
+            Dictionary<string, int> nodeIdToActivityId)
+        {
+            var hitRects = new List<GraphNodeHitRect>();
+
+            Microsoft.Msagl.Core.Geometry.Rectangle bb = drawingGraph.GeometryGraph.BoundingBox;
+            double svgHeight = bb.Height + 2.0 * c_SvgMargin;
+
+            foreach (Microsoft.Msagl.Drawing.Node drawingNode in drawingGraph.Nodes)
+            {
+                if (!nodeIdToActivityId.TryGetValue(drawingNode.Id, out int activityId))
+                {
+                    continue;
+                }
+
+                Microsoft.Msagl.Core.Geometry.Rectangle nodeBb = drawingNode.GeometryNode.BoundingBox;
+                double cx = nodeBb.Center.X - bb.Left + c_SvgMargin;
+                double cy = bb.Top - nodeBb.Center.Y + c_SvgMargin;
+                double w = nodeBb.Width;
+                double h = nodeBb.Height;
+
+                hitRects.Add(new GraphNodeHitRect(
+                    activityId,
+                    X: cx - w / 2.0,
+                    Y: cy - h / 2.0,
+                    Width: w,
+                    Height: h));
+            }
+
+            return hitRects.AsReadOnly();
+        }
+
+        public (byte[] SvgData, IReadOnlyList<GraphNodeHitRect> NodeHitRects) BuildVertexGraphSvgData(
             VertexGraphModel vertexGraph,
             GraphSettingsModel graphSettings,
             BaseTheme baseTheme,
@@ -269,10 +300,15 @@ namespace Zametek.ViewModel.ProjectPlan
             // Fill the graph.
             var drawingGraph = new Microsoft.Msagl.Drawing.Graph();
 
+            // Build a mapping from MSAGL node string ID -> activity int ID for hit-rect computation.
+            var nodeIdToActivityId = new Dictionary<string, int>();
+
             foreach (DiagramNodeModel diagramNode in diagramGraph.Nodes)
             {
-                var drawingGraphNode = new Microsoft.Msagl.Drawing.Node($@"{diagramNode.Id}");
+                string nodeKey = $@"{diagramNode.Id}";
+                var drawingGraphNode = new Microsoft.Msagl.Drawing.Node(nodeKey);
                 drawingGraph.AddNode(drawingGraphNode);
+                nodeIdToActivityId[nodeKey] = diagramNode.Id;
             }
 
             Dictionary<string, Microsoft.Msagl.Drawing.Node> drawingNodeLookup = drawingGraph.Nodes.ToDictionary(x => x.Id);
@@ -286,7 +322,7 @@ namespace Zametek.ViewModel.ProjectPlan
 
                 edge.Attr.ClearStyles();
                 edge.Attr.AddStyle(s_EdgeDashMsaglLookup[diagramEdge.DashStyle]);
-                edge.Attr.Color = HtmlHexCodeToMsaglColor(diagramEdge.ForegroundColorHexCode) ?? Microsoft.Msagl.Drawing.Color.Black;
+                edge.Attr.Color = HtmlHexCodeToMsaglColor(diagramEdge.ForegroundColorHexCode) ?? s_EdgeDefaultColor;
                 edge.Attr.LineWidth = diagramEdge.StrokeThickness;
                 edge.LabelText = diagramEdge.Label;
                 edge.Label.IsVisible = diagramEdge.ShowLabel;
@@ -335,6 +371,7 @@ namespace Zametek.ViewModel.ProjectPlan
                 drawingGraphNode.Label.FontStyle = s_SvgNodeFontStyle;
 
                 drawingGraphNode.Label.FontName = c_FontName;
+                drawingGraphNode.Label.FontColor = s_NodeLabelColor;
                 drawingGraphNode.Attr.AddStyle(s_NodeBorderDashMsaglLookup[diagramNode.BorderDashStyle]);
                 drawingGraphNode.Attr.FillColor = HtmlHexCodeToMsaglColor(diagramNode.FillColorHexCode) ?? Microsoft.Msagl.Drawing.Color.LightGray;
                 drawingGraphNode.Attr.Color = HtmlHexCodeToMsaglColor(diagramNode.BorderColorHexCode) ?? Microsoft.Msagl.Drawing.Color.Black;
@@ -356,7 +393,10 @@ namespace Zametek.ViewModel.ProjectPlan
 
             Microsoft.Msagl.Miscellaneous.LayoutHelpers.CalculateLayout(drawingGraph.GeometryGraph, drawingGraph.LayoutAlgorithmSettings, null);
 
-            return m_MsaglSvgRenderer.RenderToSvg(drawingGraph, baseTheme);
+            byte[] svgData = m_MsaglSvgRenderer.RenderToSvg(drawingGraph, baseTheme);
+            IReadOnlyList<GraphNodeHitRect> nodeHitRects = ComputeHitRects(drawingGraph, nodeIdToActivityId);
+
+            return (svgData, nodeHitRects);
         }
 
         public byte[] BuildVertexGraphMLData(

--- a/src/Zametek.ViewModel.ProjectPlan/GraphManagement/VertexGraphManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/GraphManagement/VertexGraphManagerViewModel.cs
@@ -76,9 +76,12 @@ namespace Zametek.ViewModel.ProjectPlan
         private readonly IDialogService m_DialogService;
         private readonly IVertexGraphSerializer m_VertexGraphExport;
         private readonly IGraphImageExporter m_GraphImageExporter;
+        private readonly Lazy<IMainViewModel> m_MainViewModel;
 
         private readonly IDisposable? m_BuildVertexGraphDataSub;
         private readonly IDisposable? m_BuildVertexGraphImageSub;
+
+        private IReadOnlyList<GraphNodeHitRect> m_NodeHitRects = [];
 
         #endregion
 
@@ -89,19 +92,22 @@ namespace Zametek.ViewModel.ProjectPlan
             ISettingService settingService,
             IDialogService dialogService,
             IVertexGraphSerializer vertexGraphExport,
-            IGraphImageExporter graphImageExporter)
+            IGraphImageExporter graphImageExporter,
+            Lazy<IMainViewModel> mainViewModel)
         {
             ArgumentNullException.ThrowIfNull(coreViewModel);
             ArgumentNullException.ThrowIfNull(settingService);
             ArgumentNullException.ThrowIfNull(dialogService);
             ArgumentNullException.ThrowIfNull(vertexGraphExport);
             ArgumentNullException.ThrowIfNull(graphImageExporter);
+            ArgumentNullException.ThrowIfNull(mainViewModel);
             m_Lock = new();
             m_CoreViewModel = coreViewModel;
             m_SettingService = settingService;
             m_DialogService = dialogService;
             m_VertexGraphExport = vertexGraphExport;
             m_GraphImageExporter = graphImageExporter;
+            m_MainViewModel = mainViewModel;
 
             m_VertexGraphData = string.Empty;
             m_VertexGraphImage = new SvgImage();
@@ -269,6 +275,17 @@ namespace Zametek.ViewModel.ProjectPlan
         private readonly ObservableAsPropertyHelper<BaseTheme> m_BaseTheme;
         public BaseTheme BaseTheme => m_BaseTheme.Value;
 
+        public IReadOnlyList<GraphNodeHitRect> NodeHitRects
+        {
+            get
+            {
+                lock (m_Lock)
+                {
+                    return m_NodeHitRects;
+                }
+            }
+        }
+
         public ICommand SaveVertexGraphImageFileCommand { get; }
 
         public async Task SaveVertexGraphImageFileAsync(string? filename)
@@ -327,20 +344,33 @@ namespace Zametek.ViewModel.ProjectPlan
         public void BuildVertexGraphDiagramData()
         {
             byte[]? data = null;
+            IReadOnlyList<GraphNodeHitRect> hitRects = [];
 
             lock (m_Lock)
             {
                 if (!HasCompilationErrors)
                 {
-                    data = m_VertexGraphExport.BuildVertexGraphSvgData(
+                    (byte[] svgData, IReadOnlyList<GraphNodeHitRect> rects) = m_VertexGraphExport.BuildVertexGraphSvgData(
                         m_CoreViewModel.VertexGraph,
                         m_CoreViewModel.GraphSettings,
                         m_CoreViewModel.BaseTheme,
                         m_CoreViewModel.DisplaySettingsViewModel.VertexGraphShowNames);
+                    data = svgData;
+                    hitRects = rects;
                 }
             }
 
+            lock (m_Lock)
+            {
+                m_NodeHitRects = hitRects;
+            }
+
             VertexGraphData = data?.ByteArrayToString() ?? string.Empty;
+        }
+
+        public void NavigateToActivity(int activityId)
+        {
+            m_MainViewModel.Value.SelectActivity(activityId);
         }
 
         public void BuildVertexGraphDiagramImage()

--- a/src/Zametek.ViewModel.ProjectPlan/MainViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/MainViewModel.cs
@@ -83,6 +83,14 @@ namespace Zametek.ViewModel.ProjectPlan
         private readonly IDialogService m_DialogService;
         private readonly IServiceProvider m_ServiceProvider;
 
+        private readonly IActivitiesManagerViewModel m_ActivitiesManagerViewModel;
+        private readonly IGanttChartManagerViewModel m_GanttChartManagerViewModel;
+        private readonly IResourceChartManagerViewModel m_ResourceChartManagerViewModel;
+        private readonly IScenarioChartManagerViewModel m_ScenarioChartManagerViewModel;
+        private readonly IArrowGraphManagerViewModel m_ArrowGraphManagerViewModel;
+        private readonly IVertexGraphManagerViewModel m_VertexGraphManagerViewModel;
+        private readonly ITrackingManagerViewModel m_TrackingManagerViewModel;
+
         private readonly IDisposable? m_ProjectTitleUpdateSub;
 
         #endregion
@@ -98,7 +106,14 @@ namespace Zametek.ViewModel.ProjectPlan
             IProjectFileSave projectFileSave,
             ISettingService settingService,
             IDialogService dialogService,
-            IServiceProvider serviceProvider)
+            IServiceProvider serviceProvider,
+            IActivitiesManagerViewModel activitiesManagerViewModel,
+            IGanttChartManagerViewModel ganttChartManagerViewModel,
+            IResourceChartManagerViewModel resourceChartManagerViewModel,
+            IScenarioChartManagerViewModel scenarioChartManagerViewModel,
+            IArrowGraphManagerViewModel arrowGraphManagerViewModel,
+            IVertexGraphManagerViewModel vertexGraphManagerViewModel,
+            ITrackingManagerViewModel trackingManagerViewModel)
         {
             ArgumentNullException.ThrowIfNull(dockFactory);
             ArgumentNullException.ThrowIfNull(dataGridManager);
@@ -109,6 +124,13 @@ namespace Zametek.ViewModel.ProjectPlan
             ArgumentNullException.ThrowIfNull(settingService);
             ArgumentNullException.ThrowIfNull(dialogService);
             ArgumentNullException.ThrowIfNull(serviceProvider);
+            ArgumentNullException.ThrowIfNull(activitiesManagerViewModel);
+            ArgumentNullException.ThrowIfNull(ganttChartManagerViewModel);
+            ArgumentNullException.ThrowIfNull(resourceChartManagerViewModel);
+            ArgumentNullException.ThrowIfNull(scenarioChartManagerViewModel);
+            ArgumentNullException.ThrowIfNull(arrowGraphManagerViewModel);
+            ArgumentNullException.ThrowIfNull(vertexGraphManagerViewModel);
+            ArgumentNullException.ThrowIfNull(trackingManagerViewModel);
             m_Lock = new();
             m_DockFactory = dockFactory;
             m_DataGridManager = dataGridManager;
@@ -119,6 +141,13 @@ namespace Zametek.ViewModel.ProjectPlan
             m_SettingService = settingService;
             m_DialogService = dialogService;
             m_ServiceProvider = serviceProvider;
+            m_ActivitiesManagerViewModel = activitiesManagerViewModel;
+            m_GanttChartManagerViewModel = ganttChartManagerViewModel;
+            m_ResourceChartManagerViewModel = resourceChartManagerViewModel;
+            m_ScenarioChartManagerViewModel = scenarioChartManagerViewModel;
+            m_ArrowGraphManagerViewModel = arrowGraphManagerViewModel;
+            m_VertexGraphManagerViewModel = vertexGraphManagerViewModel;
+            m_TrackingManagerViewModel = trackingManagerViewModel;
             m_ProjectTitle = string.Empty;
             m_IsMainBusy = false;
 
@@ -334,6 +363,34 @@ namespace Zametek.ViewModel.ProjectPlan
             get => m_IsMainBusy;
             set => this.RaiseAndSetIfChanged(ref m_IsMainBusy, value);
         }
+
+        private ShellView m_ActiveShellView;
+        public ShellView ActiveShellView
+        {
+            get => m_ActiveShellView;
+            set => this.RaiseAndSetIfChanged(ref m_ActiveShellView, value);
+        }
+
+        private bool m_IsCommandPaletteOpen;
+        public bool IsCommandPaletteOpen
+        {
+            get => m_IsCommandPaletteOpen;
+            set => this.RaiseAndSetIfChanged(ref m_IsCommandPaletteOpen, value);
+        }
+
+        public IActivitiesManagerViewModel ActivitiesManagerViewModel => m_ActivitiesManagerViewModel;
+
+        public IGanttChartManagerViewModel GanttChartManagerViewModel => m_GanttChartManagerViewModel;
+
+        public IResourceChartManagerViewModel ResourceChartManagerViewModel => m_ResourceChartManagerViewModel;
+
+        public IScenarioChartManagerViewModel ScenarioChartManagerViewModel => m_ScenarioChartManagerViewModel;
+
+        public IArrowGraphManagerViewModel ArrowGraphManagerViewModel => m_ArrowGraphManagerViewModel;
+
+        public IVertexGraphManagerViewModel VertexGraphManagerViewModel => m_VertexGraphManagerViewModel;
+
+        public ITrackingManagerViewModel TrackingManagerViewModel => m_TrackingManagerViewModel;
 
         #endregion
 

--- a/src/Zametek.ViewModel.ProjectPlan/MainViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/MainViewModel.cs
@@ -1393,6 +1393,12 @@ namespace Zametek.ViewModel.ProjectPlan
             }
         }
 
+        public void SelectActivity(int activityId)
+        {
+            ActiveShellView = ShellView.ActivitiesGantt;
+            m_ActivitiesManagerViewModel.SelectActivityById(activityId);
+        }
+
         #endregion
 
         #region IKillSubscriptions Members

--- a/src/Zametek.ViewModel.ProjectPlan/MainViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/MainViewModel.cs
@@ -90,6 +90,13 @@ namespace Zametek.ViewModel.ProjectPlan
         private readonly IArrowGraphManagerViewModel m_ArrowGraphManagerViewModel;
         private readonly IVertexGraphManagerViewModel m_VertexGraphManagerViewModel;
         private readonly ITrackingManagerViewModel m_TrackingManagerViewModel;
+        private readonly IResourceSettingsManagerViewModel m_ResourceSettingsManagerViewModel;
+        private readonly IWorkStreamSettingsManagerViewModel m_WorkStreamSettingsManagerViewModel;
+        private readonly IGraphSettingsManagerViewModel m_GraphSettingsManagerViewModel;
+        private readonly IHolidaySettingsManagerViewModel m_HolidaySettingsManagerViewModel;
+        private readonly IMetricManagerViewModel m_MetricManagerViewModel;
+        private readonly IEarnedValueChartManagerViewModel m_EarnedValueChartManagerViewModel;
+        private readonly IOutputManagerViewModel m_OutputManagerViewModel;
 
         private readonly IDisposable? m_ProjectTitleUpdateSub;
 
@@ -113,7 +120,14 @@ namespace Zametek.ViewModel.ProjectPlan
             IScenarioChartManagerViewModel scenarioChartManagerViewModel,
             IArrowGraphManagerViewModel arrowGraphManagerViewModel,
             IVertexGraphManagerViewModel vertexGraphManagerViewModel,
-            ITrackingManagerViewModel trackingManagerViewModel)
+            ITrackingManagerViewModel trackingManagerViewModel,
+            IResourceSettingsManagerViewModel resourceSettingsManagerViewModel,
+            IWorkStreamSettingsManagerViewModel workStreamSettingsManagerViewModel,
+            IGraphSettingsManagerViewModel graphSettingsManagerViewModel,
+            IHolidaySettingsManagerViewModel holidaySettingsManagerViewModel,
+            IMetricManagerViewModel metricManagerViewModel,
+            IEarnedValueChartManagerViewModel earnedValueChartManagerViewModel,
+            IOutputManagerViewModel outputManagerViewModel)
         {
             ArgumentNullException.ThrowIfNull(dockFactory);
             ArgumentNullException.ThrowIfNull(dataGridManager);
@@ -131,6 +145,13 @@ namespace Zametek.ViewModel.ProjectPlan
             ArgumentNullException.ThrowIfNull(arrowGraphManagerViewModel);
             ArgumentNullException.ThrowIfNull(vertexGraphManagerViewModel);
             ArgumentNullException.ThrowIfNull(trackingManagerViewModel);
+            ArgumentNullException.ThrowIfNull(resourceSettingsManagerViewModel);
+            ArgumentNullException.ThrowIfNull(workStreamSettingsManagerViewModel);
+            ArgumentNullException.ThrowIfNull(graphSettingsManagerViewModel);
+            ArgumentNullException.ThrowIfNull(holidaySettingsManagerViewModel);
+            ArgumentNullException.ThrowIfNull(metricManagerViewModel);
+            ArgumentNullException.ThrowIfNull(earnedValueChartManagerViewModel);
+            ArgumentNullException.ThrowIfNull(outputManagerViewModel);
             m_Lock = new();
             m_DockFactory = dockFactory;
             m_DataGridManager = dataGridManager;
@@ -148,6 +169,13 @@ namespace Zametek.ViewModel.ProjectPlan
             m_ArrowGraphManagerViewModel = arrowGraphManagerViewModel;
             m_VertexGraphManagerViewModel = vertexGraphManagerViewModel;
             m_TrackingManagerViewModel = trackingManagerViewModel;
+            m_ResourceSettingsManagerViewModel = resourceSettingsManagerViewModel;
+            m_WorkStreamSettingsManagerViewModel = workStreamSettingsManagerViewModel;
+            m_GraphSettingsManagerViewModel = graphSettingsManagerViewModel;
+            m_HolidaySettingsManagerViewModel = holidaySettingsManagerViewModel;
+            m_MetricManagerViewModel = metricManagerViewModel;
+            m_EarnedValueChartManagerViewModel = earnedValueChartManagerViewModel;
+            m_OutputManagerViewModel = outputManagerViewModel;
             m_ProjectTitle = string.Empty;
             m_IsMainBusy = false;
 
@@ -391,6 +419,22 @@ namespace Zametek.ViewModel.ProjectPlan
         public IVertexGraphManagerViewModel VertexGraphManagerViewModel => m_VertexGraphManagerViewModel;
 
         public ITrackingManagerViewModel TrackingManagerViewModel => m_TrackingManagerViewModel;
+
+        public IResourceSettingsManagerViewModel ResourceSettingsManagerViewModel => m_ResourceSettingsManagerViewModel;
+
+        public IWorkStreamSettingsManagerViewModel WorkStreamSettingsManagerViewModel => m_WorkStreamSettingsManagerViewModel;
+
+        public IGraphSettingsManagerViewModel GraphSettingsManagerViewModel => m_GraphSettingsManagerViewModel;
+
+        public IHolidaySettingsManagerViewModel HolidaySettingsManagerViewModel => m_HolidaySettingsManagerViewModel;
+
+        public IMetricManagerViewModel MetricManagerViewModel => m_MetricManagerViewModel;
+
+        public IEarnedValueChartManagerViewModel EarnedValueChartManagerViewModel => m_EarnedValueChartManagerViewModel;
+
+        public IProjectScenarioManagerViewModel ProjectScenarioManagerViewModel => m_ProjectScenarioManagerViewModel;
+
+        public IOutputManagerViewModel OutputManagerViewModel => m_OutputManagerViewModel;
 
         #endregion
 

--- a/src/Zametek.ViewModel.ProjectPlan/Plottables/AnnotatedBar.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/Plottables/AnnotatedBar.cs
@@ -6,5 +6,20 @@ namespace Zametek.ViewModel.ProjectPlan
         : Bar
     {
         public string Annotation { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The ID of the activity this bar represents. Zero means no activity (e.g. padding bars).
+        /// </summary>
+        public int ActivityId { get; set; } = 0;
+
+        /// <summary>
+        /// The start time (in project days) of the activity, used to compute duration from drag.
+        /// </summary>
+        public int ActivityStartTime { get; set; } = 0;
+
+        /// <summary>
+        /// The original duration (in project days) of the activity.
+        /// </summary>
+        public int ActivityDuration { get; set; } = 0;
     }
 }

--- a/src/Zametek.ViewModel.ProjectPlan/ResourceChartManagement/ResourceChartManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ResourceChartManagement/ResourceChartManagerViewModel.cs
@@ -119,6 +119,10 @@ namespace Zametek.ViewModel.ProjectPlan
                 SaveResourceChartImageFileCommand = saveResourceChartImageFileCommand;
             }
 
+            ChangeAllocationModeCommand = ReactiveCommand.CreateFromTask<AllocationMode>(ChangeAllocationModeAsync);
+            ChangeScheduleModeCommand = ReactiveCommand.CreateFromTask<ScheduleMode>(ChangeScheduleModeAsync);
+            ChangeDisplayStyleCommand = ReactiveCommand.CreateFromTask<DisplayStyle>(ChangeDisplayStyleAsync);
+
             m_IsBusy = this
                 .WhenAnyValue(rcm => rcm.m_CoreViewModel.IsBusy)
                 .ToProperty(this, rcm => rcm.IsBusy);
@@ -529,6 +533,51 @@ namespace Zametek.ViewModel.ProjectPlan
             ResourceChartPlotModel.Plot.Axes.AutoScale();
         }
 
+        private async Task ChangeAllocationModeAsync(AllocationMode allocationMode)
+        {
+            try
+            {
+                AllocationMode = allocationMode;
+            }
+            catch (Exception ex)
+            {
+                await m_DialogService.ShowErrorAsync(
+                    Resource.ProjectPlan.Titles.Title_Error,
+                    string.Empty,
+                    ex.Message);
+            }
+        }
+
+        private async Task ChangeScheduleModeAsync(ScheduleMode scheduleMode)
+        {
+            try
+            {
+                ScheduleMode = scheduleMode;
+            }
+            catch (Exception ex)
+            {
+                await m_DialogService.ShowErrorAsync(
+                    Resource.ProjectPlan.Titles.Title_Error,
+                    string.Empty,
+                    ex.Message);
+            }
+        }
+
+        private async Task ChangeDisplayStyleAsync(DisplayStyle displayStyle)
+        {
+            try
+            {
+                DisplayStyle = displayStyle;
+            }
+            catch (Exception ex)
+            {
+                await m_DialogService.ShowErrorAsync(
+                    Resource.ProjectPlan.Titles.Title_Error,
+                    string.Empty,
+                    ex.Message);
+            }
+        }
+
         private async Task SaveResourceChartImageFileAsync()
         {
             try
@@ -623,6 +672,12 @@ namespace Zametek.ViewModel.ProjectPlan
         public ICommand ResetResourceChartCommand { get; }
 
         public ICommand SaveResourceChartImageFileCommand { get; }
+
+        public ICommand ChangeAllocationModeCommand { get; }
+
+        public ICommand ChangeScheduleModeCommand { get; }
+
+        public ICommand ChangeDisplayStyleCommand { get; }
 
         public async Task SaveResourceChartImageFileAsync(
             string? filename,

--- a/src/Zametek.ViewModel.ProjectPlan/ResourceChartManagement/ResourceChartManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ResourceChartManagement/ResourceChartManagerViewModel.cs
@@ -733,18 +733,10 @@ namespace Zametek.ViewModel.ProjectPlan
 
             plotModel ??= new AvaPlot();
 
-            // Clear existing menu items.
+            // Clear ScottPlot's built-in menu entirely — Save As and Reset are
+            // exposed through the Avalonia ContextMenu on the ContentControl instead,
+            // preventing the double-menu that occurs when both menus are open simultaneously.
             plotModel.Menu?.Clear();
-
-            // Add menu items with custom actions.
-            plotModel.Menu?.Add(Resource.ProjectPlan.Menus.Menu_SaveAs, (plot) =>
-            {
-                SaveResourceChartImageFileCommand.Execute(null);
-            });
-            plotModel.Menu?.Add(Resource.ProjectPlan.Menus.Menu_Reset, (plot) =>
-            {
-                plot.Axes.AutoScale();
-            });
 
             //plotModel.Plot.Axes.AutoScale();
             ResourceChartPlotModel = plotModel;

--- a/src/Zametek.ViewModel.ProjectPlan/ScenarioChartManagement/ScenarioChartManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ScenarioChartManagement/ScenarioChartManagerViewModel.cs
@@ -116,6 +116,10 @@ namespace Zametek.ViewModel.ProjectPlan
 
             ResetScenarioChartCommand = ReactiveCommand.Create(ResetScenarioChart);
 
+            ChangeTrackedMetricXAxisCommand = ReactiveCommand.CreateFromTask<TrackedMetrics>(ChangeTrackedMetricXAxisAsync);
+            ChangeTrackedMetricYAxisCommand = ReactiveCommand.CreateFromTask<TrackedMetrics>(ChangeTrackedMetricYAxisAsync);
+            ChangeCurveFittingTypeCommand = ReactiveCommand.CreateFromTask<CurveFittingType>(ChangeCurveFittingTypeAsync);
+
             m_IsBusy = this
                 .WhenAnyValue(
                     rcm => rcm.m_CoreViewModel.IsBusy,
@@ -500,6 +504,51 @@ namespace Zametek.ViewModel.ProjectPlan
             ScenarioChartPlotModel.Plot.Axes.AutoScale();
         }
 
+        private async Task ChangeTrackedMetricXAxisAsync(TrackedMetrics trackedMetric)
+        {
+            try
+            {
+                TrackedMetricXAxis = trackedMetric;
+            }
+            catch (Exception ex)
+            {
+                await m_DialogService.ShowErrorAsync(
+                    Resource.ProjectPlan.Titles.Title_Error,
+                    string.Empty,
+                    ex.Message);
+            }
+        }
+
+        private async Task ChangeTrackedMetricYAxisAsync(TrackedMetrics trackedMetric)
+        {
+            try
+            {
+                TrackedMetricYAxis = trackedMetric;
+            }
+            catch (Exception ex)
+            {
+                await m_DialogService.ShowErrorAsync(
+                    Resource.ProjectPlan.Titles.Title_Error,
+                    string.Empty,
+                    ex.Message);
+            }
+        }
+
+        private async Task ChangeCurveFittingTypeAsync(CurveFittingType curveFittingType)
+        {
+            try
+            {
+                CurveFittingType = curveFittingType;
+            }
+            catch (Exception ex)
+            {
+                await m_DialogService.ShowErrorAsync(
+                    Resource.ProjectPlan.Titles.Title_Error,
+                    string.Empty,
+                    ex.Message);
+            }
+        }
+
         private async Task SaveScenarioChartImageFileAsync()
         {
             try
@@ -584,6 +633,12 @@ namespace Zametek.ViewModel.ProjectPlan
         public ICommand SaveScenarioChartImageFileCommand { get; }
 
         public ICommand ResetScenarioChartCommand { get; }
+
+        public ICommand ChangeTrackedMetricXAxisCommand { get; }
+
+        public ICommand ChangeTrackedMetricYAxisCommand { get; }
+
+        public ICommand ChangeCurveFittingTypeCommand { get; }
 
         public async Task SaveScenarioChartImageFileAsync(
             string? filename,

--- a/src/Zametek.ViewModel.ProjectPlan/ScenarioChartManagement/ScenarioChartManagerViewModel.cs
+++ b/src/Zametek.ViewModel.ProjectPlan/ScenarioChartManagement/ScenarioChartManagerViewModel.cs
@@ -734,18 +734,10 @@ namespace Zametek.ViewModel.ProjectPlan
 
             plotModel ??= new AvaPlot();
 
-            // Clear existing menu items.
+            // Clear ScottPlot's built-in menu entirely — Save As and Reset are
+            // exposed through the Avalonia ContextMenu on the ContentControl instead,
+            // preventing the double-menu that occurs when both menus are open simultaneously.
             plotModel.Menu?.Clear();
-
-            // Add menu items with custom actions.
-            plotModel.Menu?.Add(Resource.ProjectPlan.Menus.Menu_SaveAs, (plot) =>
-            {
-                SaveScenarioChartImageFileCommand.Execute(null);
-            });
-            plotModel.Menu?.Add(Resource.ProjectPlan.Menus.Menu_Reset, (plot) =>
-            {
-                plot.Axes.AutoScale();
-            });
 
             //plotModel.Plot.Axes.AutoScale();
             ScenarioChartPlotModel = plotModel;


### PR DESCRIPTION
## Summary

This branch delivers a substantial set of improvements across the UI, UX, Gantt chart, graph management, file handling, and dialog layers. Changes are layered on top of the context menu work already open in #116.

### Context Menus on Resource and Scenario Charts
- Fixed double context menu appearing on Resource and Scenario chart controls
- Context menu is now correctly scoped to the chart surface without propagation to the host control

### Full UX Architectural Overhaul
- Fixed shell layout replacing the previous floating-panel approach
- Split-view pane for activities and Gantt chart side-by-side
- Toolbar with primary actions surfaced (Add Activity, Insert, Milestone buttons now visible in the activities panel)
- Command palette for keyboard-first navigation

### Management Panels
- Added all missing panels to the shell: Resource Settings, Work Streams, Graph Settings, Holidays, Metrics, Earned Value, Project Scenario, Output

### Gantt Chart Interactivity
- Drag right edge of a Gantt bar to resize the activity's duration directly on the chart
- Ctrl+drag bar-to-bar to create a dependency between activities
- Context-sensitive cursors: SizeWestEast on bar right edge, Hand on bar body
- Pointer capture fixed: capture is now taken on the AvaPlot (ScottPlot) element rather than the ContentControl wrapper, so ScottPlot still receives release events via bubbling and does not get stuck in a "button held" / sticky-pan state after a Gantt drag
- Show-all-connections toggle

### Graph Visual Improvements (Vertex/Arrow Graph)
- Attractive MSAGL-based node and edge styling replacing the default plain rendering
- Click-to-navigate: clicking a vertex or arrow in the graph selects and scrolls to the corresponding activity in the activities table

### Gantt Dependency Connectors
- Replace diamond-shaped dependency indicators with proper elbow connectors
- Fix arrowhead indicator size for clarity and readability

### macOS File Picker Fix
- Added `AppleUniformTypeIdentifiers` metadata to `.zpp` file type registrations so the native macOS file picker correctly filters for project files

### Custom Confirmation Dialog
- Replaced MsBox-based confirmation dialogs with a custom confirmation dialog for consistent styling and behaviour across platforms

## Test plan
- [ ] Open a project and verify context menus work correctly on Resource and Scenario charts (no double menu)
- [ ] Verify all management panels are accessible from the shell navigation (Resource Settings, Work Streams, Graph Settings, Holidays, Metrics, Earned Value, Project Scenario, Output)
- [ ] Confirm Add Activity, Insert, and Milestone buttons are visible in the activities panel toolbar
- [ ] Drag a Gantt bar right edge to resize an activity's duration; confirm the model updates correctly
- [ ] Ctrl+drag from one Gantt bar to another to create a dependency; confirm the dependency is recorded
- [ ] Drag a Gantt bar and release — confirm ScottPlot does not enter sticky pan mode after the drag
- [ ] Verify context-sensitive cursors: SizeWestEast when hovering the right edge of a bar, Hand when hovering the bar body
- [ ] Click a vertex in the arrow/vertex graph; confirm the activities table navigates to that activity
- [ ] Confirm dependency arrows on the Gantt render as elbow connectors (not diamonds)
- [ ] On macOS, open the file picker and confirm it correctly filters for .zpp files
- [ ] Trigger a confirmation dialog and verify it uses the custom dialog (not MsBox)
- [ ] Check dark and light themes render correctly throughout the shell